### PR TITLE
Update Ginkgo dependency to version 1.7.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,7 @@ endif()
 
 if("${BUILD_SPLINES_KERNEL}")
   # Ginkgo
-  find_package(Ginkgo 1.6.0 EXACT REQUIRED)
+  find_package(Ginkgo 1.7.0 EXACT REQUIRED)
   target_link_libraries(DDC INTERFACE Ginkgo::ginkgo)
   target_compile_definitions(DDC INTERFACE ginkgo_AVAIL)
 endif()

--- a/docker/doxygen/Dockerfile
+++ b/docker/doxygen/Dockerfile
@@ -34,7 +34,7 @@ RUN chmod +x /bin/bash_run \
     git \
     graphviz \
     texlive \
- && git clone -b v1.6.0 https://github.com/ginkgo-project/ginkgo.git \
+ && git clone -b v1.7.0 https://github.com/ginkgo-project/ginkgo.git \
  && cd ginkgo \
  && cmake -S . -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGINKGO_BUILD_OMP=OFF -DGINKGO_BUILD_TESTS=OFF -DGINKGO_BUILD_EXAMPLES=OFF -DGINKGO_BUILD_BENCHMARKS=OFF \
  && cmake --build build \

--- a/docker/latest/Dockerfile
+++ b/docker/latest/Dockerfile
@@ -57,7 +57,7 @@ RUN chmod +x /bin/bash_run \
       apt-get install -y --no-install-recommends \
       rocm-hip-sdk \
  ;; esac \
- && git clone -b v1.6.0 https://github.com/ginkgo-project/ginkgo.git \
+ && git clone -b v1.7.0 https://github.com/ginkgo-project/ginkgo.git \
  && cd ginkgo \
  && case "${BACKEND}" in \
     "cpu") \

--- a/docker/oldest/Dockerfile
+++ b/docker/oldest/Dockerfile
@@ -52,7 +52,7 @@ RUN chmod +x /bin/bash_run \
       apt-get install -y --no-install-recommends \
       rocm-hip-sdk \
  ;; esac \
- && git clone -b v1.6.0 https://github.com/ginkgo-project/ginkgo.git \
+ && git clone -b v1.7.0 https://github.com/ginkgo-project/ginkgo.git \
  && cd ginkgo \
  && case "${BACKEND}" in \
     "cpu") \

--- a/include/ddc/misc/ginkgo_executors.hpp
+++ b/include/ddc/misc/ginkgo_executors.hpp
@@ -38,8 +38,7 @@ inline std::shared_ptr<gko::Executor> create_gko_exec()
         return gko::CudaExecutor::
                 create(exec_space.cuda_device(),
                        create_default_host_executor(),
-                       false,
-                       gko::default_cuda_alloc_mode,
+                       std::make_shared<gko::CudaAllocator>(),
                        exec_space.cuda_stream());
     }
 #endif
@@ -49,8 +48,7 @@ inline std::shared_ptr<gko::Executor> create_gko_exec()
         return gko::HipExecutor::
                 create(exec_space.hip_device(),
                        create_default_host_executor(),
-                       false,
-                       gko::default_hip_alloc_mode,
+                       std::make_shared<gko::HipAllocator>(),
                        exec_space.hip_stream());
     }
 #endif


### PR DESCRIPTION
Changes:
- remove deprecated calls of Ginkgo 1.7.0