### PR TITLE
Splines minor fixes

### DIFF
--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -30,7 +30,7 @@ template <
         class InterpolationMesh,
         ddc::BoundCond BcXmin,
         ddc::BoundCond BcXmax,
-        SplineSolver Solver = ddc::SplineSolver::GINKGO,
+        SplineSolver Solver,
         class... IDimX>
 class SplineBuilder
 {
@@ -616,7 +616,7 @@ operator()(
             ddc::policies::policy(exec_space()),
             batch_domain(),
             KOKKOS_LAMBDA(typename batch_domain_type::discrete_element_type const j) {
-                for (int i = 0; i < nbasis_proxy; i++) {
+                for (std::size_t i = 0; i < nbasis_proxy; i++) {
                     spline_tr(ddc::DiscreteElement<bsplines_type>(i), j)
                             = spline(ddc::DiscreteElement<bsplines_type>(i + offset_proxy), j);
                 }
@@ -633,7 +633,7 @@ operator()(
             ddc::policies::policy(exec_space()),
             batch_domain(),
             KOKKOS_LAMBDA(typename batch_domain_type::discrete_element_type const j) {
-                for (int i = 0; i < nbasis_proxy; i++) {
+                for (std::size_t i = 0; i < nbasis_proxy; i++) {
                     spline(ddc::DiscreteElement<bsplines_type>(i + offset_proxy), j)
                             = spline_tr(ddc::DiscreteElement<bsplines_type>(i), j);
                 }

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -15,7 +15,7 @@ template <
         ddc::BoundCond BcXmax1,
         ddc::BoundCond BcXmin2,
         ddc::BoundCond BcXmax2,
-		ddc::SplineSolver Solver,
+        ddc::SplineSolver Solver,
         class... IDimX>
 class SplineBuilder2D
 {
@@ -40,7 +40,7 @@ public:
             IDimI2,
             BcXmin2,
             BcXmax2,
-			Solver,
+            Solver,
             std::conditional_t<std::is_same_v<IDimX, IDimI1>, BSpline1, IDimX>...>;
     using builder_deriv_type1 = ddc::SplineBuilder<
             ExecSpace,
@@ -49,7 +49,7 @@ public:
             IDimI1,
             BcXmin1,
             BcXmax1,
-			Solver,
+            Solver,
             std::conditional_t<
                     std::is_same_v<IDimX, IDimI2>,
                     typename builder_type2::deriv_type,
@@ -216,7 +216,7 @@ template <
         ddc::BoundCond BcXmax1,
         ddc::BoundCond BcXmin2,
         ddc::BoundCond BcXmax2,
-		ddc::SplineSolver Solver,
+        ddc::SplineSolver Solver,
         class... IDimX>
 template <class Layout>
 void SplineBuilder2D<
@@ -230,7 +230,7 @@ void SplineBuilder2D<
         BcXmax1,
         BcXmin2,
         BcXmax2,
-		Solver,
+        Solver,
         IDimX...>::
 operator()(
         ddc::ChunkSpan<double, spline_domain_type, Layout, memory_space> spline,

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -15,6 +15,7 @@ template <
         ddc::BoundCond BcXmax1,
         ddc::BoundCond BcXmin2,
         ddc::BoundCond BcXmax2,
+		ddc::SplineSolver Solver,
         class... IDimX>
 class SplineBuilder2D
 {
@@ -30,7 +31,7 @@ public:
             IDimI1,
             BcXmin1,
             BcXmax1,
-            ddc::SplineSolver::GINKGO,
+            Solver,
             IDimX...>;
     using builder_type2 = ddc::SplineBuilder<
             ExecSpace,
@@ -39,7 +40,7 @@ public:
             IDimI2,
             BcXmin2,
             BcXmax2,
-            ddc::SplineSolver::GINKGO,
+			Solver,
             std::conditional_t<std::is_same_v<IDimX, IDimI1>, BSpline1, IDimX>...>;
     using builder_deriv_type1 = ddc::SplineBuilder<
             ExecSpace,
@@ -48,7 +49,7 @@ public:
             IDimI1,
             BcXmin1,
             BcXmax1,
-            ddc::SplineSolver::GINKGO,
+			Solver,
             std::conditional_t<
                     std::is_same_v<IDimX, IDimI2>,
                     typename builder_type2::deriv_type,
@@ -215,6 +216,7 @@ template <
         ddc::BoundCond BcXmax1,
         ddc::BoundCond BcXmin2,
         ddc::BoundCond BcXmax2,
+		ddc::SplineSolver Solver,
         class... IDimX>
 template <class Layout>
 void SplineBuilder2D<
@@ -228,6 +230,7 @@ void SplineBuilder2D<
         BcXmax1,
         BcXmin2,
         BcXmax2,
+		Solver,
         IDimX...>::
 operator()(
         ddc::ChunkSpan<double, spline_domain_type, Layout, memory_space> spline,

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -142,7 +142,7 @@ public:
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION double operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<double const, bsplines_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         return eval(coord_eval, spline_coef);

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -197,7 +197,7 @@ public:
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION double operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<double const, bsplines_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         return eval(coord_eval, spline_coef);

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -264,7 +264,7 @@ static void Batched2dSplineTest()
             s_bcr,
             s_bcl,
             s_bcr,
-			ddc::SplineSolver::GINKGO,
+            ddc::SplineSolver::GINKGO,
             IDim<X, I1, I2>...>
             spline_builder(dom_vals);
 
@@ -449,8 +449,11 @@ static void Batched2dSplineTest()
         ddc::Chunk Sderiv_mixed_rhs_rhs1_cpu_alloc(derivs_domain, ddc::HostAllocator<double>());
         ddc::ChunkSpan Sderiv_mixed_rhs_rhs1_cpu = Sderiv_mixed_rhs_rhs1_cpu_alloc.span_view();
 
-        for (int ii = 1; ii < derivs_domain.template extent<ddc::Deriv<I1>>() + 1; ++ii) {
-            for (std::size_t jj = 1; jj < derivs_domain.template extent<ddc::Deriv<I2>>() + 1;
+        for (std::size_t ii = 1;
+             ii < (std::size_t)derivs_domain.template extent<ddc::Deriv<I1>>() + 1;
+             ++ii) {
+            for (std::size_t jj = 1;
+                 jj < (std::size_t)derivs_domain.template extent<ddc::Deriv<I2>>() + 1;
                  ++jj) {
                 Sderiv_mixed_lhs_lhs1_cpu(
                         typename decltype(derivs_domain)::discrete_element_type(ii, jj))

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -151,7 +151,7 @@ template <typename X>
 static std::vector<Coord<X>> breaks(std::size_t ncells)
 {
     std::vector<Coord<X>> out(ncells + 1);
-    for (int i(0); i < ncells + 1; ++i) {
+    for (std::size_t i(0); i < ncells + 1; ++i) {
         out[i] = x0<X>() + i * dx<X>(ncells);
     }
     return out;
@@ -264,6 +264,7 @@ static void Batched2dSplineTest()
             s_bcr,
             s_bcl,
             s_bcr,
+			ddc::SplineSolver::GINKGO,
             IDim<X, I1, I2>...>
             spline_builder(dom_vals);
 

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -139,7 +139,7 @@ template <typename X>
 static std::vector<Coord<X>> breaks(std::size_t ncells)
 {
     std::vector<Coord<X>> out(ncells + 1);
-    for (int i(0); i < ncells + 1; ++i) {
+    for (std::size_t i(0); i < ncells + 1; ++i) {
         out[i] = x0<X>() + i * dx<X>(ncells);
     }
     return out;

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -223,7 +223,7 @@ static void ExtrapolationRuleSplineTest()
             s_bcr1,
             s_bcl2,
             s_bcr2,
-			ddc::SplineSolver::GINKGO,
+            ddc::SplineSolver::GINKGO,
             IDim<X, I1, I2>...>
             spline_builder(dom_vals);
 

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -133,7 +133,7 @@ template <typename X>
 static std::vector<Coord<X>> breaks(std::size_t ncells)
 {
     std::vector<Coord<X>> out(ncells + 1);
-    for (int i(0); i < ncells + 1; ++i) {
+    for (std::size_t i(0); i < ncells + 1; ++i) {
         out[i] = x0<X>() + i * dx<X>(ncells);
     }
     return out;
@@ -223,6 +223,7 @@ static void ExtrapolationRuleSplineTest()
             s_bcr1,
             s_bcl2,
             s_bcr2,
+			ddc::SplineSolver::GINKGO,
             IDim<X, I1, I2>...>
             spline_builder(dom_vals);
 

--- a/tests/splines/matrix.cpp
+++ b/tests/splines/matrix.cpp
@@ -86,12 +86,12 @@ TEST_P(MatrixSizesFixture, Sparse)
 
     std::vector<double> val_ptr(N * N);
     ddc::DSpan2D val(val_ptr.data(), N, N);
-    for (int i(0); i < N; ++i) {
-        for (int j(0); j < N; ++j) {
+    for (std::size_t i(0); i < N; ++i) {
+        for (std::size_t j(0); j < N; ++j) {
             if (i == j) {
                 matrix->set_element(i, j, 3. / 4);
                 val(i, j) = 3. / 4;
-            } else if (std::abs(j - i) <= k) {
+            } else if (std::abs((std::ptrdiff_t)(j - i)) <= (std::ptrdiff_t)k) {
                 matrix->set_element(i, j, -(1. / 4) / k);
                 val(i, j) = -(1. / 4) / k;
             } else {

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -78,7 +78,7 @@ template <typename X>
 static std::vector<Coord<X>> breaks(std::size_t ncells)
 {
     std::vector<Coord<X>> out(ncells + 1);
-    for (int i(0); i < ncells + 1; ++i) {
+    for (std::size_t i(0); i < ncells + 1; ++i) {
         out[i] = x0<X>() + i * dx<X>(ncells);
     }
     return out;


### PR DESCRIPTION
- Template spline_builder_2d with solver
- Single-coordinate SplineEvaluator::operator() are based on 1d spline coefs (like evals)
- Change types in loops to avoid warnings