### PR TITLE
Fix excessive loop unrolling

### DIFF
--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -243,7 +243,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<UniformBSplines<Tag, D>> UniformBSpl
     // 3. Compute values of aforementioned B-splines
     double xx, temp, saved;
     values[0] = 1.0;
-    for (std::size_t j = 1; j < deg + 1; ++j) {
+    for (std::size_t j = 1; j < Size; ++j) {
         xx = -offset;
         saved = 0.0;
         for (std::size_t r = 0; r < j; ++r) {


### PR DESCRIPTION
In the uniform bsplines there is a function with the following prototype:
```cpp
template <class Tag, std::size_t D>
template <class MemorySpace>
template <std::size_t Size>
KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<UniformBSplines<Tag, D>> UniformBSplines<Tag, D>::
        Impl<MemorySpace>::eval_basis(
                std::array<double, Size>& values,
                ddc::Coordinate<Tag> const& x,
                std::size_t const deg) const
```
There is an assertion about the size:
```cpp
assert(values.size() == deg + 1);
```
followed by a loop which modifies `values`:
```cpp
for (std::size_t j = 1; j < deg + 1; ++j) {
```
When optimisations are turned on the compiler may try to unroll this loop. As `deg + 1` is not a `constexpr` the loop is unrolled beyond what is necessary leading to warnings such as:
```
/builds/gysela-developpers/gyselalibxx/vendor/ddc/include/ddc/kernels/splines/bsplines_uniform.hpp:255:19: warning: array subscript '_Type {aka const double [5]}[0]' is partly outside array bounds of 'std::array<double, 4> [1]' [-Warray-bounds]
  255 |         values[j] = saved;
```

The simple fix for this is to use the value which is known at compile time for the loop bound