### PR TITLE
Expose ExtrapolationRules from SplineEvaluator

### DIFF
--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -42,6 +42,9 @@ public:
 
     using bsplines_type = BSplinesType;
 
+    using left_extrapolation_rule = LeftExtrapolationRule;
+    using right_extrapolation_rule = RightExtrapolationRule;
+
     using interpolation_mesh_type = InterpolationMesh;
 
     using interpolation_domain_type = ddc::DiscreteDomain<interpolation_mesh_type>;
@@ -71,7 +74,7 @@ private:
 
     LeftExtrapolationRule m_left_extrap_rule;
 
-    RightExtrapolationRule m_right_bc;
+    RightExtrapolationRule m_right_extrap_rule;
 
 public:
     static_assert(
@@ -112,7 +115,7 @@ public:
             RightExtrapolationRule const& right_extrap_rule)
         : m_spline_domain(spline_domain)
         , m_left_extrap_rule(left_extrap_rule)
-        , m_right_bc(right_extrap_rule)
+        , m_right_extrap_rule(right_extrap_rule)
     {
     }
 
@@ -141,6 +144,14 @@ public:
     KOKKOS_FUNCTION batch_domain_type batch_domain() const noexcept
     {
         return ddc::remove_dims_of(spline_domain(), bsplines_domain());
+    }
+
+    left_extrapolation_rule left_extrapolation_rule() const {
+        return m_left_extrap_rule;
+    }
+
+    right_extrapolation_rule right_extrapolation_rule() const {
+        return m_right_extrap_rule;
     }
 
     template <class Layout, class... CoordsDims>
@@ -263,7 +274,7 @@ private:
                 return m_left_extrap_rule(coord_eval_interpolation, spline_coef);
             }
             if (coord_eval_interpolation > ddc::discrete_space<bsplines_type>().rmax()) {
-                return m_right_bc(coord_eval_interpolation, spline_coef);
+                return m_right_extrap_rule(coord_eval_interpolation, spline_coef);
             }
         }
         return eval_no_bc<eval_type>(coord_eval_interpolation, spline_coef);

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -42,8 +42,8 @@ public:
 
     using bsplines_type = BSplinesType;
 
-    using left_extrapolation_rule = LeftExtrapolationRule;
-    using right_extrapolation_rule = RightExtrapolationRule;
+    using left_extrapolation_rule_type = LeftExtrapolationRule;
+    using right_extrapolation_rule_type = RightExtrapolationRule;
 
     using interpolation_mesh_type = InterpolationMesh;
 
@@ -146,12 +146,12 @@ public:
         return ddc::remove_dims_of(spline_domain(), bsplines_domain());
     }
 
-    left_extrapolation_rule left_extrapolation_rule() const
+    left_extrapolation_rule_type left_extrapolation_rule() const
     {
         return m_left_extrap_rule;
     }
 
-    right_extrapolation_rule right_extrapolation_rule() const
+    right_extrapolation_rule_type right_extrapolation_rule() const
     {
         return m_right_extrap_rule;
     }

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -146,11 +146,13 @@ public:
         return ddc::remove_dims_of(spline_domain(), bsplines_domain());
     }
 
-    left_extrapolation_rule left_extrapolation_rule() const {
+    left_extrapolation_rule left_extrapolation_rule() const
+    {
         return m_left_extrap_rule;
     }
 
-    right_extrapolation_rule right_extrapolation_rule() const {
+    right_extrapolation_rule right_extrapolation_rule() const
+    {
         return m_right_extrap_rule;
     }
 

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -48,6 +48,11 @@ public:
     using bsplines_type1 = BSplinesType1;
     using bsplines_type2 = BSplinesType2;
 
+    using left_extrapolation_rule_1 = LeftExtrapolationRule1;
+    using right_extrapolation_rule_1 = RightExtrapolationRule1;
+    using left_extrapolation_rule_2 = LeftExtrapolationRule2;
+    using right_extrapolation_rule_2 = RightExtrapolationRule2;
+
     using interpolation_domain_type1 = ddc::DiscreteDomain<interpolation_mesh_type1>;
     using interpolation_domain_type2 = ddc::DiscreteDomain<interpolation_mesh_type2>;
     using interpolation_domain_type
@@ -196,6 +201,22 @@ public:
     KOKKOS_FUNCTION batch_domain_type batch_domain() const noexcept
     {
         return ddc::remove_dims_of(spline_domain(), bsplines_domain());
+    }
+
+    left_extrapolation_rule_1 left_extrapolation_rule_dim_1() const {
+        return m_left1_bc;
+    }
+
+    right_extrapolation_rule_1 right_extrapolation_rule_dim_1() const {
+        return m_right1_bc;
+    }
+
+    left_extrapolation_rule_2 left_extrapolation_rule_dim_2() const {
+        return m_left2_bc;
+    }
+
+    right_extrapolation_rule_2 right_extrapolation_rule_dim_2() const {
+        return m_right2_bc;
     }
 
     template <class Layout, class... CoordsDims>

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -48,10 +48,10 @@ public:
     using bsplines_type1 = BSplinesType1;
     using bsplines_type2 = BSplinesType2;
 
-    using left_extrapolation_rule_1 = LeftExtrapolationRule1;
-    using right_extrapolation_rule_1 = RightExtrapolationRule1;
-    using left_extrapolation_rule_2 = LeftExtrapolationRule2;
-    using right_extrapolation_rule_2 = RightExtrapolationRule2;
+    using left_extrapolation_rule_1_type = LeftExtrapolationRule1;
+    using right_extrapolation_rule_1_type = RightExtrapolationRule1;
+    using left_extrapolation_rule_2_type = LeftExtrapolationRule2;
+    using right_extrapolation_rule_2_type = RightExtrapolationRule2;
 
     using interpolation_domain_type1 = ddc::DiscreteDomain<interpolation_mesh_type1>;
     using interpolation_domain_type2 = ddc::DiscreteDomain<interpolation_mesh_type2>;
@@ -203,22 +203,22 @@ public:
         return ddc::remove_dims_of(spline_domain(), bsplines_domain());
     }
 
-    left_extrapolation_rule_1 left_extrapolation_rule_dim_1() const
+    left_extrapolation_rule_1_type left_extrapolation_rule_dim_1() const
     {
         return m_left_extrap_rule_1;
     }
 
-    right_extrapolation_rule_1 right_extrapolation_rule_dim_1() const
+    right_extrapolation_rule_1_type right_extrapolation_rule_dim_1() const
     {
         return m_right_extrap_rule_1;
     }
 
-    left_extrapolation_rule_2 left_extrapolation_rule_dim_2() const
+    left_extrapolation_rule_2_type left_extrapolation_rule_dim_2() const
     {
         return m_left_extrap_rule_2;
     }
 
-    right_extrapolation_rule_2 right_extrapolation_rule_dim_2() const
+    right_extrapolation_rule_2_type right_extrapolation_rule_dim_2() const
     {
         return m_right_extrap_rule_2;
     }

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -85,13 +85,13 @@ public:
 private:
     spline_domain_type m_spline_domain;
 
-    LeftExtrapolationRule1 m_left1_bc;
+    LeftExtrapolationRule1 m_left_extrap_rule_1;
 
     RightExtrapolationRule1 m_right1_bc;
 
-    LeftExtrapolationRule2 m_left2_bc;
+    LeftExtrapolationRule2 m_left_extrap_rule_2;
 
-    RightExtrapolationRule2 m_right2_bc;
+    RightExtrapolationRule2 m_right_extrap_rule_2;
 
 public:
     static_assert(
@@ -167,10 +167,10 @@ public:
             LeftExtrapolationRule2 const& left_extrap_rule2,
             RightExtrapolationRule2 const& right_extrap_rule2)
         : m_spline_domain(spline_domain)
-        , m_left1_bc(left_extrap_rule1)
+        , m_left_extrap_rule_1(left_extrap_rule1)
         , m_right1_bc(right_extrap_rule1)
-        , m_left2_bc(left_extrap_rule2)
-        , m_right2_bc(right_extrap_rule2)
+        , m_left_extrap_rule_2(left_extrap_rule2)
+        , m_right_extrap_rule_2(right_extrap_rule2)
     {
     }
 
@@ -204,7 +204,7 @@ public:
     }
 
     left_extrapolation_rule_1 left_extrapolation_rule_dim_1() const {
-        return m_left1_bc;
+        return m_left_extrap_rule_1;
     }
 
     right_extrapolation_rule_1 right_extrapolation_rule_dim_1() const {
@@ -212,11 +212,11 @@ public:
     }
 
     left_extrapolation_rule_2 left_extrapolation_rule_dim_2() const {
-        return m_left2_bc;
+        return m_left_extrap_rule_2;
     }
 
     right_extrapolation_rule_2 right_extrapolation_rule_dim_2() const {
-        return m_right2_bc;
+        return m_right_extrap_rule_2;
     }
 
     template <class Layout, class... CoordsDims>
@@ -530,7 +530,7 @@ private:
             }
         } else {
             if (coord_eval_interpolation1 < ddc::discrete_space<bsplines_type1>().rmin()) {
-                return m_left1_bc(coord_eval, spline_coef);
+                return m_left_extrap_rule_1(coord_eval, spline_coef);
             }
             if (coord_eval_interpolation1 > ddc::discrete_space<bsplines_type1>().rmax()) {
                 return m_right1_bc(coord_eval, spline_coef);
@@ -548,10 +548,10 @@ private:
             }
         } else {
             if (coord_eval_interpolation2 < ddc::discrete_space<bsplines_type2>().rmin()) {
-                return m_left2_bc(coord_eval, spline_coef);
+                return m_left_extrap_rule_2(coord_eval, spline_coef);
             }
             if (coord_eval_interpolation2 > ddc::discrete_space<bsplines_type2>().rmax()) {
-                return m_right2_bc(coord_eval, spline_coef);
+                return m_right_extrap_rule_2(coord_eval, spline_coef);
             }
         }
         return eval_no_bc<eval_type, eval_type>(

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -87,7 +87,7 @@ private:
 
     LeftExtrapolationRule1 m_left_extrap_rule_1;
 
-    RightExtrapolationRule1 m_right1_bc;
+    RightExtrapolationRule1 m_right_extrap_rule_1;
 
     LeftExtrapolationRule2 m_left_extrap_rule_2;
 
@@ -168,7 +168,7 @@ public:
             RightExtrapolationRule2 const& right_extrap_rule2)
         : m_spline_domain(spline_domain)
         , m_left_extrap_rule_1(left_extrap_rule1)
-        , m_right1_bc(right_extrap_rule1)
+        , m_right_extrap_rule_1(right_extrap_rule1)
         , m_left_extrap_rule_2(left_extrap_rule2)
         , m_right_extrap_rule_2(right_extrap_rule2)
     {
@@ -208,7 +208,7 @@ public:
     }
 
     right_extrapolation_rule_1 right_extrapolation_rule_dim_1() const {
-        return m_right1_bc;
+        return m_right_extrap_rule_1;
     }
 
     left_extrapolation_rule_2 left_extrapolation_rule_dim_2() const {
@@ -533,7 +533,7 @@ private:
                 return m_left_extrap_rule_1(coord_eval, spline_coef);
             }
             if (coord_eval_interpolation1 > ddc::discrete_space<bsplines_type1>().rmax()) {
-                return m_right1_bc(coord_eval, spline_coef);
+                return m_right_extrap_rule_1(coord_eval, spline_coef);
             }
         }
         if constexpr (bsplines_type2::is_periodic()) {

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -203,19 +203,23 @@ public:
         return ddc::remove_dims_of(spline_domain(), bsplines_domain());
     }
 
-    left_extrapolation_rule_1 left_extrapolation_rule_dim_1() const {
+    left_extrapolation_rule_1 left_extrapolation_rule_dim_1() const
+    {
         return m_left_extrap_rule_1;
     }
 
-    right_extrapolation_rule_1 right_extrapolation_rule_dim_1() const {
+    right_extrapolation_rule_1 right_extrapolation_rule_dim_1() const
+    {
         return m_right_extrap_rule_1;
     }
 
-    left_extrapolation_rule_2 left_extrapolation_rule_dim_2() const {
+    left_extrapolation_rule_2 left_extrapolation_rule_dim_2() const
+    {
         return m_left_extrap_rule_2;
     }
 
-    right_extrapolation_rule_2 right_extrapolation_rule_dim_2() const {
+    right_extrapolation_rule_2 right_extrapolation_rule_dim_2() const
+    {
         return m_right_extrap_rule_2;
     }
 


### PR DESCRIPTION
Homogenise names of extrapolation rules in `SplineEvaluator` and `SplineEvaluator2D`. Add public type identifiers for the extrapolation rule types and getters for the operators. Fixes #345