### PR TITLE
Decouple SplineEvaluator from domain

### DIFF
--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -115,6 +115,7 @@ static void characteristics_advection(benchmark::State& state)
             DDimX,
             DDimY>
             spline_builder(x_mesh, state.range(2), state.range(3));
+    ddc::PeriodicExtrapolationRule<X> periodic_extrapolation;
     ddc::SplineEvaluator<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
@@ -124,10 +125,7 @@ static void characteristics_advection(benchmark::State& state)
             ddc::PeriodicExtrapolationRule<X>,
             DDimX,
             DDimY>
-            spline_evaluator(
-                    spline_builder.spline_domain(),
-                    ddc::PeriodicExtrapolationRule<X>(),
-                    ddc::PeriodicExtrapolationRule<X>());
+            spline_evaluator(periodic_extrapolation, periodic_extrapolation);
     ddc::Chunk coef_alloc(
             spline_builder.spline_domain(),
             ddc::KokkosAllocator<double, Kokkos::DefaultExecutionSpace::memory_space>());

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -214,6 +214,7 @@ int main(int argc, char** argv)
             DDimX,
             DDimY>
             spline_builder(x_mesh);
+    ddc::PeriodicExtrapolationRule<DimX> periodic_extrapolation;
     ddc::SplineEvaluator<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
@@ -224,9 +225,8 @@ int main(int argc, char** argv)
             DDimX,
             DDimY>
             spline_evaluator(
-                    spline_builder.spline_domain(),
-                    ddc::PeriodicExtrapolationRule<X>(),
-                    ddc::PeriodicExtrapolationRule<X>());
+                    periodic_extrapolation,
+                    periodic_extrapolation);
     //! [instantiate solver]
 
     //! [instantiate intermediate chunks]

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -214,7 +214,7 @@ int main(int argc, char** argv)
             DDimX,
             DDimY>
             spline_builder(x_mesh);
-    ddc::PeriodicExtrapolationRule<DimX> periodic_extrapolation;
+    ddc::PeriodicExtrapolationRule<X> periodic_extrapolation;
     ddc::SplineEvaluator<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -125,6 +125,16 @@ public:
 
     SplineEvaluator& operator=(SplineEvaluator&& x) = default;
 
+    left_extrapolation_rule_type left_extrapolation_rule() const
+    {
+        return m_left_extrap_rule;
+    }
+
+    right_extrapolation_rule_type right_extrapolation_rule() const
+    {
+        return m_right_extrap_rule;
+    }
+
 
 
     template <class Layout, class... CoordsDims>

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -110,7 +110,7 @@ public:
     explicit SplineEvaluator(
             LeftExtrapolationRule const& left_extrap_rule,
             RightExtrapolationRule const& right_extrap_rule)
-        , m_left_extrap_rule(left_extrap_rule)
+        : m_left_extrap_rule(left_extrap_rule)
         , m_right_extrap_rule(right_extrap_rule)
     {
     }

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -135,8 +135,6 @@ public:
         return m_right_extrap_rule;
     }
 
-
-
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION double operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -127,7 +127,6 @@ public:
 
 
 
-
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION double operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -182,8 +182,6 @@ public:
 
 
 
-  
-
     left_extrapolation_rule_1_type left_extrapolation_rule_dim_1() const
     {
         return m_left_extrap_rule_1;

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -550,8 +550,7 @@ static void Batched2dSplineTest()
             ddc::NullExtrapolationRule,
 #endif
             IDim<X, I1, I2>...>
-            spline_evaluator(
-                    coef.domain(),
+            spline_evaluator{
 #if defined(BC_PERIODIC)
                     ddc::PeriodicExtrapolationRule<I1>(),
                     ddc::PeriodicExtrapolationRule<I1>(),
@@ -563,7 +562,7 @@ static void Batched2dSplineTest()
                     ddc::NullExtrapolationRule(),
                     ddc::NullExtrapolationRule()
 #endif
-            );
+            };
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X...>, MemorySpace>());

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -550,19 +550,16 @@ static void Batched2dSplineTest()
             ddc::NullExtrapolationRule,
 #endif
             IDim<X, I1, I2>...>
-            spline_evaluator{
+            spline_evaluator
+    {
 #if defined(BC_PERIODIC)
-                    ddc::PeriodicExtrapolationRule<I1>(),
-                    ddc::PeriodicExtrapolationRule<I1>(),
-                    ddc::PeriodicExtrapolationRule<I2>(),
-                    ddc::PeriodicExtrapolationRule<I2>()
+        ddc::PeriodicExtrapolationRule<I1>(), ddc::PeriodicExtrapolationRule<I1>(),
+                ddc::PeriodicExtrapolationRule<I2>(), ddc::PeriodicExtrapolationRule<I2>()
 #else
-                    ddc::NullExtrapolationRule(),
-                    ddc::NullExtrapolationRule(),
-                    ddc::NullExtrapolationRule(),
-                    ddc::NullExtrapolationRule()
+        ddc::NullExtrapolationRule(), ddc::NullExtrapolationRule(), ddc::NullExtrapolationRule(),
+                ddc::NullExtrapolationRule()
 #endif
-            };
+    };
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X...>, MemorySpace>());

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -557,7 +557,11 @@ static void Batched2dSplineTest()
             ddc::NullExtrapolationRule,
 #endif
             IDim<X, I1, I2>...>
-            spline_evaluator(extrapolation_rule_1, extrapolation_rule_2);
+            spline_evaluator(
+                    extrapolation_rule_1,
+                    extrapolation_rule_1,
+                    extrapolation_rule_2,
+                    extrapolation_rule_2);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X...>, MemorySpace>());

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -531,6 +531,13 @@ static void Batched2dSplineTest()
     spline_builder(coef, vals.span_cview());
 #endif
     // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
+#if defined(BC_PERIODIC)
+    ddc::PeriodicExtrapolationRule<I1> extrapolation_rule_1;
+    ddc::PeriodicExtrapolationRule<I2> extrapolation_rule_2;
+#else
+    ddc::NullExtrapolationRule extrapolation_rule_1;
+    ddc::NullExtrapolationRule extrapolation_rule_2;
+#endif
     ddc::SplineEvaluator2D<
             ExecSpace,
             MemorySpace,
@@ -550,16 +557,7 @@ static void Batched2dSplineTest()
             ddc::NullExtrapolationRule,
 #endif
             IDim<X, I1, I2>...>
-            spline_evaluator
-    {
-#if defined(BC_PERIODIC)
-        ddc::PeriodicExtrapolationRule<I1>(), ddc::PeriodicExtrapolationRule<I1>(),
-                ddc::PeriodicExtrapolationRule<I2>(), ddc::PeriodicExtrapolationRule<I2>()
-#else
-        ddc::NullExtrapolationRule(), ddc::NullExtrapolationRule(), ddc::NullExtrapolationRule(),
-                ddc::NullExtrapolationRule()
-#endif
-    };
+            spline_evaluator(extrapolation_rule_1, extrapolation_rule_2);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X...>, MemorySpace>());

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -322,15 +322,14 @@ static void BatchedSplineTest()
             ddc::NullExtrapolationRule,
 #endif
             IDim<X, I>...>
-            spline_evaluator_batched{
+            spline_evaluator_batched
+    {
 #if defined(BC_PERIODIC)
-                    ddc::PeriodicExtrapolationRule<I>(),
-                    ddc::PeriodicExtrapolationRule<I>()
+        ddc::PeriodicExtrapolationRule<I>(), ddc::PeriodicExtrapolationRule<I>()
 #else
-                    ddc::NullExtrapolationRule(),
-                    ddc::NullExtrapolationRule()
+        ddc::NullExtrapolationRule(), ddc::NullExtrapolationRule()
 #endif
-            };
+    };
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X...>, MemorySpace>());

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -309,6 +309,11 @@ static void BatchedSplineTest()
 #endif
 
     // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
+#if defined(BC_PERIODIC)
+    ddc::PeriodicExtrapolationRule<I> extrapolation_rule;
+#else
+    ddc::NullExtrapolationRule extrapolation_rule;
+#endif
     ddc::SplineEvaluator<
             ExecSpace,
             MemorySpace,
@@ -322,14 +327,7 @@ static void BatchedSplineTest()
             ddc::NullExtrapolationRule,
 #endif
             IDim<X, I>...>
-            spline_evaluator_batched
-    {
-#if defined(BC_PERIODIC)
-        ddc::PeriodicExtrapolationRule<I>(), ddc::PeriodicExtrapolationRule<I>()
-#else
-        ddc::NullExtrapolationRule(), ddc::NullExtrapolationRule()
-#endif
-    };
+            spline_evaluator_batched(extrapolation_rule, extrapolation_rule);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X...>, MemorySpace>());

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -322,8 +322,7 @@ static void BatchedSplineTest()
             ddc::NullExtrapolationRule,
 #endif
             IDim<X, I>...>
-            spline_evaluator_batched(
-                    coef.domain(),
+            spline_evaluator_batched{
 #if defined(BC_PERIODIC)
                     ddc::PeriodicExtrapolationRule<I>(),
                     ddc::PeriodicExtrapolationRule<I>()
@@ -331,7 +330,7 @@ static void BatchedSplineTest()
                     ddc::NullExtrapolationRule(),
                     ddc::NullExtrapolationRule()
 #endif
-            );
+            };
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X...>, MemorySpace>());

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -268,8 +268,8 @@ static void ExtrapolationRuleSplineTest()
     ddc::NullExtrapolationRule extrapolation_rule_left_dim_1;
     ddc::NullExtrapolationRule extrapolation_rule_right_dim_1;
 #if defined(BC_PERIODIC)
-    ddc::PeriodicExtrapolationRule<I2> extrapolation_rule_left_dim_1;
-    ddc::PeriodicExtrapolationRule<I2> extrapolation_rule_right_dim_1;
+    ddc::PeriodicExtrapolationRule<I2> extrapolation_rule_left_dim_2;
+    ddc::PeriodicExtrapolationRule<I2> extrapolation_rule_right_dim_2;
 #else
     ddc::NullExtrapolationRule extrapolation_rule_left_dim_2;
     ddc::NullExtrapolationRule extrapolation_rule_right_dim_2;
@@ -320,7 +320,6 @@ static void ExtrapolationRuleSplineTest()
 
             IDim<X, I1, I2>...>
             spline_evaluator_batched(
-                    coef.domain(),
                     extrapolation_rule_left_dim_1,
                     extrapolation_rule_right_dim_1,
                     extrapolation_rule_left_dim_2,

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -264,6 +264,33 @@ static void ExtrapolationRuleSplineTest()
     spline_builder(coef, vals.span_cview());
 
     // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
+#if defined(ER_NULL)
+    ddc::NullExtrapolationRule extrapolation_rule_left_dim_1;
+    ddc::NullExtrapolationRule extrapolation_rule_right_dim_1;
+#if defined(BC_PERIODIC)
+    ddc::PeriodicExtrapolationRule<I2> extrapolation_rule_left_dim_1;
+    ddc::PeriodicExtrapolationRule<I2> extrapolation_rule_right_dim_1;
+#else
+    ddc::NullExtrapolationRule extrapolation_rule_left_dim_2;
+    ddc::NullExtrapolationRule extrapolation_rule_right_dim_2;
+#endif
+#elif defined(ER_CONSTANT)
+#if defined(BC_PERIODIC)
+    ddc::ConstantExtrapolationRule<I1, I2> extrapolation_rule_left_dim_1(x0<I1>());
+    ddc::ConstantExtrapolationRule<I1, I2> extrapolation_rule_right_dim_1(xN<I1>());
+    ddc::PeriodicExtrapolationRule<I2> extrapolation_rule_left_dim_2;
+    ddc::PeriodicExtrapolationRule<I2> extrapolation_rule_right_dim_2;
+#else
+    ddc::ConstantExtrapolationRule<I1, I2>
+            extrapolation_rule_left_dim_1(x0<I1>(), x0<I2>(), xN<I2>());
+    ddc::ConstantExtrapolationRule<I1, I2>
+            extrapolation_rule_right_dim_1(xN<I1>(), x0<I2>(), xN<I2>());
+    ddc::ConstantExtrapolationRule<I2, I1>
+            extrapolation_rule_left_dim_2(x0<I2>(), x0<I1>(), xN<I1>());
+    ddc::ConstantExtrapolationRule<I2, I1>
+            extrapolation_rule_right_dim_2(xN<I2>(), x0<I1>(), xN<I1>());
+#endif
+#endif
     ddc::SplineEvaluator2D<
             ExecSpace,
             MemorySpace,
@@ -294,30 +321,10 @@ static void ExtrapolationRuleSplineTest()
             IDim<X, I1, I2>...>
             spline_evaluator_batched(
                     coef.domain(),
-#if defined(ER_NULL)
-                    ddc::NullExtrapolationRule(),
-                    ddc::NullExtrapolationRule(),
-#if defined(BC_PERIODIC)
-                    ddc::PeriodicExtrapolationRule<I2>(),
-                    ddc::PeriodicExtrapolationRule<I2>()
-#else
-                    ddc::NullExtrapolationRule(),
-                    ddc::NullExtrapolationRule()
-#endif
-#elif defined(ER_CONSTANT)
-#if defined(BC_PERIODIC)
-                    ddc::ConstantExtrapolationRule<I1, I2>(x0<I1>()),
-                    ddc::ConstantExtrapolationRule<I1, I2>(xN<I1>()),
-                    ddc::PeriodicExtrapolationRule<I2>(),
-                    ddc::PeriodicExtrapolationRule<I2>()
-#else
-                    ddc::ConstantExtrapolationRule<I1, I2>(x0<I1>(), x0<I2>(), xN<I2>()),
-                    ddc::ConstantExtrapolationRule<I1, I2>(xN<I1>(), x0<I2>(), xN<I2>()),
-                    ddc::ConstantExtrapolationRule<I2, I1>(x0<I2>(), x0<I1>(), xN<I1>()),
-                    ddc::ConstantExtrapolationRule<I2, I1>(xN<I2>(), x0<I1>(), xN<I1>())
-#endif
-#endif
-            );
+                    extrapolation_rule_left_dim_1,
+                    extrapolation_rule_right_dim_1,
+                    extrapolation_rule_left_dim_2,
+                    extrapolation_rule_right_dim_2);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X...>, MemorySpace>());

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -157,7 +157,7 @@ TEST(NonPeriodicSplineBuilderTest, Identity)
             ddc::NullExtrapolationRule,
             ddc::NullExtrapolationRule,
             IDimX>
-            spline_evaluator(coef.domain(), extrapolation_rule, extrapolation_rule);
+            spline_evaluator(extrapolation_rule, extrapolation_rule);
 
     ddc::Chunk<ddc::Coordinate<DimX>, ddc::DiscreteDomain<IDimX>> coords_eval(interpolation_domain);
     for (IndexX const ix : interpolation_domain) {

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -148,6 +148,7 @@ TEST(NonPeriodicSplineBuilderTest, Identity)
     spline_builder(coef.span_view(), yvals.span_cview(), deriv_l, deriv_r);
 
     // 7. Create a SplineEvaluator to evaluate the spline at any point in the domain of the BSplines
+    ddc::NullExtrapolationRule extrapolation_rule;
     ddc::SplineEvaluator<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::HostSpace,
@@ -156,10 +157,7 @@ TEST(NonPeriodicSplineBuilderTest, Identity)
             ddc::NullExtrapolationRule,
             ddc::NullExtrapolationRule,
             IDimX>
-            spline_evaluator(
-                    coef.domain(),
-                    ddc::NullExtrapolationRule(),
-                    ddc::NullExtrapolationRule());
+            spline_evaluator(coef.domain(), extrapolation_rule, extrapolation_rule);
 
     ddc::Chunk<ddc::Coordinate<DimX>, ddc::DiscreteDomain<IDimX>> coords_eval(interpolation_domain);
     for (IndexX const ix : interpolation_domain) {

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -98,6 +98,7 @@ TEST(PeriodicSplineBuilderTest, Identity)
     spline_builder(coef.span_view(), yvals.span_cview());
 
     // 7. Create a SplineEvaluator to evaluate the spline at any point in the domain of the BSplines
+    ddc::PeriodicExtrapolationRule<DimX> periodic_extrapolation;
     ddc::SplineEvaluator<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::HostSpace,
@@ -106,10 +107,7 @@ TEST(PeriodicSplineBuilderTest, Identity)
             ddc::PeriodicExtrapolationRule<DimX>,
             ddc::PeriodicExtrapolationRule<DimX>,
             IDimX>
-            spline_evaluator(
-                    coef.domain(),
-                    ddc::PeriodicExtrapolationRule<DimX>(),
-                    ddc::PeriodicExtrapolationRule<DimX>());
+            spline_evaluator(periodic_extrapolation, periodic_extrapolation);
 
     ddc::Chunk<CoordX, ddc::DiscreteDomain<IDimX>> coords_eval(interpolation_domain);
     for (IndexX const ix : interpolation_domain) {

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -169,7 +169,7 @@ static void PeriodicitySplineBuilderTest()
             ddc::PeriodicExtrapolationRule<X>,
             ddc::PeriodicExtrapolationRule<X>,
             IDim<X>>
-            spline_evaluator(coef.domain(), extrapolation_rule, extrapolation_rule);
+            spline_evaluator(extrapolation_rule, extrapolation_rule);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X>, MemorySpace>());

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -160,6 +160,7 @@ static void PeriodicitySplineBuilderTest()
     spline_builder(coef, vals.span_cview());
 
     // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
+    ddc::PeriodicExtrapolationRule<X> extrapolation_rule;
     ddc::SplineEvaluator<
             ExecSpace,
             MemorySpace,
@@ -168,10 +169,7 @@ static void PeriodicitySplineBuilderTest()
             ddc::PeriodicExtrapolationRule<X>,
             ddc::PeriodicExtrapolationRule<X>,
             IDim<X>>
-            spline_evaluator(
-                    coef.domain(),
-                    ddc::PeriodicExtrapolationRule<X>(),
-                    ddc::PeriodicExtrapolationRule<X>());
+            spline_evaluator(coef.domain(), extrapolation_rule, extrapolation_rule);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X>, MemorySpace>());


### PR DESCRIPTION
Decouple `SplineEvaluator` from spline domain to prevent potential segmentation faults when using a smaller batch domain or unexpectedly non-updated values when using a larger batch domain. Fixes #344 