### PR TITLE
Update spline kernels with improvements from SLL

### DIFF
--- a/include/ddc/kernels/splines/constant_extrapolation_rule.hpp
+++ b/include/ddc/kernels/splines/constant_extrapolation_rule.hpp
@@ -44,7 +44,7 @@ public:
      * @param[in] spline_coef
      *			The coefficients of the function on B-splines.
      *
-     *@return A double with the value of the function on B-splines evaluated at the coordinate.
+     * @return A double with the value of the function on B-splines evaluated at the coordinate.
      */
     template <class CoordType, class BSplines, class Layout, class MemorySpace>
     KOKKOS_FUNCTION double operator()(

--- a/include/ddc/kernels/splines/constant_extrapolation_rule.hpp
+++ b/include/ddc/kernels/splines/constant_extrapolation_rule.hpp
@@ -134,15 +134,13 @@ public:
      *
      * In the dimension defined in the constructor Dim1 (or Dim2), it sets the coordinate pos_1 (or pos_2)
      * given at the m_eval_pos coordinate if it is outside the domain.
-     * If the coordinate on the complementary dimension of the boundary condition dimension pos_2 (or pos_1) is
+     * If the coordinate on the complementary dimension of the boundary condition dimension ddc::select<DimNI>(coord_extrap) is
      * outside the domain, then it also sets the coordinate at eval_pos_not_interest_min
-     * (if pos_2 (or pos_1) @f$ < @f$ eval_pos_not_interest_min) or
-     * at eval_pos_not_interest_max (if pos_2 (or pos_1) @f$ > @f$ eval_pos_not_interest_max).
+     * (if ddc::select<DimNI>(coord_extrap) @f$ < @f$ eval_pos_not_interest_min) or
+     * at eval_pos_not_interest_max (if ddc::select<DimNI>(coord_extrap) @f$ > @f$ eval_pos_not_interest_max).
      *
-     * @param[in] pos_1
-     * 			The coordinate in the first dimension where we want to evaluate the function on B-splines
-     * @param[in] pos_2
-     * 			The coordinate in the second dimension where we want to evaluate the function on B-splines.
+     * @param[in] coord_extrap
+     * 			The coordinates where we want to evaluate the function on B-splines
      * @param[in] spline_coef
      *			The coefficients of the function on B-splines.
      *

--- a/include/ddc/kernels/splines/constant_extrapolation_rule.hpp
+++ b/include/ddc/kernels/splines/constant_extrapolation_rule.hpp
@@ -68,7 +68,7 @@ public:
 };
 
 /**
- * @brief A class for describing a spline boundary value by a constant extrapolation for 2D evaluator.
+ * @brief A functor for describing a spline boundary value by a constant extrapolation for 2D evaluator.
  *
  * To define the value of a function on B-splines out of the domain, we here use a constant
  * extrapolation on the edge.

--- a/include/ddc/kernels/splines/constant_extrapolation_rule.hpp
+++ b/include/ddc/kernels/splines/constant_extrapolation_rule.hpp
@@ -13,6 +13,12 @@ struct ConstantExtrapolationRule
 {
 };
 
+/**
+ * @brief A functor for describing a spline boundary value by a constant extrapolation for 1D evaluator.
+ *
+ * To define the value of a function on B-splines out of the domain, we here use a constant
+ * extrapolation on the edge.
+ */
 template <class DimI>
 struct ConstantExtrapolationRule<DimI>
 {
@@ -20,8 +26,26 @@ private:
     ddc::Coordinate<DimI> m_eval_pos;
 
 public:
+    /**
+     * @brief Instantiate a ConstantExtrapolationRule.
+     *
+     * The boundary value will be the same as at the coordinate eval_pos given.
+     *
+     * @param[in] eval_pos
+     * 			Coordinate inside the domain where we will evaluate each points outside the domain.
+     */
     explicit ConstantExtrapolationRule(ddc::Coordinate<DimI> eval_pos) : m_eval_pos(eval_pos) {}
 
+    /**
+     * @brief Get the value of the function on B-splines at a coordinate outside the domain.
+     *
+     * @param[in] pos
+     * 			The coordinate where we want to evaluate the function on B-splines.
+     * @param[in] spline_coef
+     *			The coefficients of the function on B-splines.
+     *
+     *@return A double with the value of the function on B-splines evaluated at the coordinate.
+     */
     template <class CoordType, class BSplines, class Layout, class MemorySpace>
     KOKKOS_FUNCTION double operator()(
             CoordType,
@@ -43,6 +67,12 @@ public:
     }
 };
 
+/**
+ * @brief A class for describing a spline boundary value by a constant extrapolation for 2D evaluator.
+ *
+ * To define the value of a function on B-splines out of the domain, we here use a constant
+ * extrapolation on the edge.
+ */
 template <class DimI, class DimNI>
 struct ConstantExtrapolationRule<DimI, DimNI>
 {
@@ -52,6 +82,23 @@ private:
     ddc::Coordinate<DimNI> m_eval_pos_not_interest_max;
 
 public:
+    /**
+     * @brief Instantiate a ConstantExtrapolationRule.
+     *
+     * The boundary value will be the same as at the coordinate given in a dimension given.
+     * The dimension of the input defines the dimension of the boundary condition.
+     * The second and the third parameters are needed in case of non-periodic splines on the
+     * dimension off-interest (the complementary dimension of the boundary condition),
+     * because the evaluator can receive coordinates outside the domain in both dimension.
+     *
+     * @param[in] eval_pos_bc
+     * 			Coordinate in the dimension given inside the domain where we will evaluate
+     * 			each points outside the domain.
+     * @param[in] eval_pos_not_interest_min
+     * 			The minimum coordinate inside the domain on the complementary dimension of the boundary condition.
+     * @param[in] eval_pos_not_interest_max
+     * 			The maximum coordinate inside the domain on the complementary dimension of the boundary condition.
+     */
     explicit ConstantExtrapolationRule(
             ddc::Coordinate<DimI> eval_pos,
             ddc::Coordinate<DimNI> eval_pos_not_interest_min,
@@ -62,6 +109,18 @@ public:
     {
     }
 
+    /**
+     * @brief Instantiate a ConstantExtrapolationRule.
+     *
+     * The boundary value will be the same as at the coordinate given in a dimension given.
+     * The dimension of the input defines the dimension of the boundary condition.
+     * No second and third parameters are needed in case of periodic splines on the
+     * dimension off-interest (the complementary dimension of the boundary condition).
+     *
+     * @param[in] eval_pos_bc
+     * 			Coordinate in the dimension given inside the domain where we will evaluate
+     * 			each points outside the domain.
+     */
     template <class DimNI_sfinae = DimNI, std::enable_if_t<DimNI_sfinae::PERIODIC, int> = 0>
     explicit ConstantExtrapolationRule(ddc::Coordinate<DimI> eval_pos)
         : m_eval_pos(eval_pos)
@@ -70,6 +129,25 @@ public:
     {
     }
 
+    /**
+     * @brief Get the value of the function on B-splines at a coordinate outside the domain.
+     *
+     * In the dimension defined in the constructor Dim1 (or Dim2), it sets the coordinate pos_1 (or pos_2)
+     * given at the m_eval_pos coordinate if it is outside the domain.
+     * If the coordinate on the complementary dimension of the boundary condition dimension pos_2 (or pos_1) is
+     * outside the domain, then it also sets the coordinate at eval_pos_not_interest_min
+     * (if pos_2 (or pos_1) @f$ < @f$ eval_pos_not_interest_min) or
+     * at eval_pos_not_interest_max (if pos_2 (or pos_1) @f$ > @f$ eval_pos_not_interest_max).
+     *
+     * @param[in] pos_1
+     * 			The coordinate in the first dimension where we want to evaluate the function on B-splines
+     * @param[in] pos_2
+     * 			The coordinate in the second dimension where we want to evaluate the function on B-splines.
+     * @param[in] spline_coef
+     *			The coefficients of the function on B-splines.
+     *
+     *@return A double with the value of the function on B-splines evaluated at the coordinate.
+     */
     template <class CoordType, class BSplines1, class BSplines2, class Layout, class MemorySpace>
     KOKKOS_FUNCTION double operator()(
             CoordType coord_extrap,

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -13,6 +13,9 @@
 
 namespace ddc {
 
+/**
+ * @brief Define an evaluator 2D on B-splines.
+ */
 template <
         class ExecSpace,
         class MemorySpace,
@@ -28,11 +31,16 @@ template <
 class SplineEvaluator2D
 {
 private:
-    // Tags to determine what to evaluate
+    /**
+     * @brief Tag to indicate that the value of the spline should be evaluated.
+     */
     struct eval_type
     {
     };
 
+    /**
+     * @brief Tag to indicate that derivative of the spline should be evaluated.
+     */
     struct eval_deriv_type
     {
     };
@@ -158,6 +166,24 @@ public:
             "RightExtrapolationRule2::operator() has to be callable "
             "with usual arguments.");
 
+    /**
+     * @brief Instantiate an evaluator operator.
+     *
+     * @param[in] left_extrap_rule1
+     * 			A SplineBoundaryValue2D object giving the value on the "left side" of the domain
+     * 			in the first dimension.
+     * @param[in] right_extrap_rule1
+     * 			A SplineBoundaryValue2D object giving the value on the "right side" of the domain
+     * 			in the first dimension.
+     * @param[in] left_extrap_rule2
+     * 			A SplineBoundaryValue2D object giving the value on the "left side" of the domain
+     * 			in the second dimension.
+     * @param[in] right_extrap_rule2
+     * 			A SplineBoundaryValue2D object giving the value on the "right side" of the domain
+     * 			in the second dimension.
+     *
+     * @see SplineBoundaryValue2D
+     */
     explicit SplineEvaluator2D(
             LeftExtrapolationRule1 const& left_extrap_rule1,
             RightExtrapolationRule1 const& right_extrap_rule1,
@@ -170,14 +196,44 @@ public:
     {
     }
 
+    /**
+     * @brief Instantiate a SplineEvaluator2D from another
+     * SplineEvaluator2D (lvalue).
+     *
+     * @param[in] x
+     * 		SplineEvaluator2D evaluator used to instantiate the new one.
+     */
     SplineEvaluator2D(SplineEvaluator2D const& x) = default;
 
+    /**
+     * @brief Instantiate a SplineEvaluator2D from another temporary
+     * SplineEvaluator2D (rvalue).
+     *
+     * @param[in] x
+     * 		SplineEvaluator2D evaluator used to instantiate the new one.
+     */
     SplineEvaluator2D(SplineEvaluator2D&& x) = default;
 
     ~SplineEvaluator2D() = default;
 
+    /**
+     * @brief Assign a SplineEvaluator2D from another SplineEvaluator2D (lvalue).
+     *
+     * @param[in] x
+     * 		SplineEvaluator2D mapping used to assign.
+     *
+     * @return The SplineEvaluator2D assigned.
+     */
     SplineEvaluator2D& operator=(SplineEvaluator2D const& x) = default;
 
+    /**
+     * @brief Assign a SplineEvaluator2D from another temporary SplineEvaluator2D (rvalue).
+     *
+     * @param[in] x
+     * 		SplineEvaluator2D mapping used to assign.
+     *
+     * @return The SplineEvaluator2D assigned.
+     */
     SplineEvaluator2D& operator=(SplineEvaluator2D&& x) = default;
 
 
@@ -202,6 +258,16 @@ public:
         return m_right_extrap_rule_2;
     }
 
+    /**
+     * @brief Get the value of the function on B-splines at the coordinate given.
+     *
+     * @param[in] coord_eval
+     * 			The 2D coordinate where we want to evaluate the function.
+     * @param[in] spline_coef
+     * 			The B-splines coefficients of the function we want to evaluate.
+     *
+     * @return A double containing the value of the function at the coordinate given.
+     */
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION double operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
@@ -240,6 +306,16 @@ public:
                 });
     }
 
+    /**
+     * @brief Get the value of the derivative of the first dimension of the function on B-splines at the coordinate given.
+     *
+     * @param[in] coord_eval
+     * 			The 2D coordinate where we want to evaluate the derivative of the first dimension of the function.
+     * @param[in] spline_coef
+     * 			The B-splines coefficients of the function we want to evaluate.
+     *
+     * @return A double containing the value of the derivative of the first dimension of the function at the coordinate given.
+     */
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION double deriv_dim_1(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
@@ -249,6 +325,16 @@ public:
         return eval_no_bc<eval_deriv_type, eval_type>(coord_eval, spline_coef);
     }
 
+    /**
+     * @brief Get the value of the derivative of the second dimension of the function on B-splines at the coordinate given.
+     *
+     * @param[in] coord_eval
+     * 			The 2D coordinate where we want to evaluate the derivative of the second dimension of the function.
+     * @param[in] spline_coef
+     * 			The B-splines coefficients of the function we want to evaluate.
+     *
+     * @return A double containing the value of the derivative of the second dimension of the function at the coordinate given.
+     */
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION double deriv_dim_2(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
@@ -258,6 +344,16 @@ public:
         return eval_no_bc<eval_type, eval_deriv_type>(coord_eval, spline_coef);
     }
 
+    /**
+     * @brief Get the value of the cross derivative of the function on B-splines at the coordinate given.
+     *
+     * @param[in] coord_eval
+     * 			The 2D coordinate where we want to evaluate the cross derivative of the function.
+     * @param[in] spline_coef
+     * 			The B-splines coefficients of the function we want to evaluate.
+     *
+     * @return A double containing the value of the cross derivative of the function at the coordinate given.
+     */
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION double deriv_1_and_2(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
@@ -308,6 +404,16 @@ public:
         return deriv_1_and_2(coord_eval, spline_coef);
     }
 
+    /**
+     * @brief Get the values of the derivative of the first dimension of the function on B-splines at the coordinates given.
+     *
+     * @param[out] spline_eval
+     * 			A ChunkSpan with the values of the derivative of the first dimension of the function at the coordinates given.
+     * @param[in] coords_eval
+     * 			A ChunkSpan with the 2D coordinates where we want to evaluate the derivative of the first dimension of the function.
+     * @param[in] spline_coef
+     * 			The B-splines coefficients of the function we want to evaluate.
+     */
     template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
     void deriv_dim_1(
             ddc::ChunkSpan<double, vals_domain_type, Layout1, memory_space> const spline_eval,
@@ -339,6 +445,16 @@ public:
                 });
     }
 
+    /**
+     * @brief Get the values of the derivative of the second dimension of the function on B-splines at the coordinates given.
+     *
+     * @param[out] spline_eval
+     * 			A ChunkSpan with the values of the derivative of the second dimension of the function at the coordinates given.
+     * @param[in] coords_eval
+     * 			A ChunkSpan with the 2D coordinates where we want to evaluate the derivative of the second dimension of the function.
+     * @param[in] spline_coef
+     * 			The B-splines coefficients of the function we want to evaluate.
+     */
     template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
     void deriv_dim_2(
             ddc::ChunkSpan<double, vals_domain_type, Layout1, memory_space> const spline_eval,
@@ -370,6 +486,16 @@ public:
                 });
     }
 
+    /**
+     * @brief Get the values of the cross derivative of the function on B-splines at the coordinates given.
+     *
+     * @param[out] spline_eval
+     * 			A ChunkSpan with the values of the cross derivative of the function at the coordinates given.
+     * @param[in] coords_eval
+     * 			A ChunkSpan with the 2D coordinates where we want to evaluate the cross derivative of the function.
+     * @param[in] spline_coef
+     * 			The B-splines coefficients of the function we want to evaluate.
+     */
     template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
     void deriv_1_and_2(
             ddc::ChunkSpan<double, vals_domain_type, Layout1, memory_space> const spline_eval,
@@ -458,6 +584,14 @@ public:
         return deriv_1_and_2(spline_eval, coords_eval, spline_coef);
     }
 
+    /**
+     * @brief Get the the integral of the function on B-splines on the domain.
+     *
+     * @param[in] spline_coef
+     * 			The B-splines coefficients of the function we want to integrate.
+     *
+     * @return A double with the value of the integral of the function.
+     */
     template <class Layout1, class Layout2>
     void integrate(
             ddc::ChunkSpan<double, batch_domain_type, Layout1, memory_space> const integrals,
@@ -496,6 +630,25 @@ public:
     }
 
 private:
+    /**
+     * @brief Evaluate the function on B-splines at the coordinate given.
+     *
+     * This function firstly deals with the boundary conditions and calls the SplineEvaluator2D::eval_no_bc function
+     * to evaluate.
+     *
+     * @param[in] coord_eval
+     * 			The 2D coordinate where we want to evaluate.
+     * @param[in] spline_coef
+     * 			The B-splines coefficients of the function we want to evaluate.
+     * @param[out] vals1
+     * 			A ChunkSpan with the not-null values of each function of the spline in the first dimension.
+     * @param[out] vals2
+     * 			A ChunkSpan with the not-null values of each function of the spline in the second dimension.
+     *
+     * @return A double with the value of the function at the coordinate given.
+     *
+     * @see SplineBoundaryValue
+     */
     template <class Layout, class... CoordsDims>
     KOKKOS_INLINE_FUNCTION double eval(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
@@ -551,6 +704,26 @@ private:
                 spline_coef);
     }
 
+    /**
+     * @brief Evaluate the function or its derivative at the coordinate given.
+     *
+     * @param[in] coord_eval1
+     * 			The coordinate on the first dimension where we want to evaluate.
+     * @param[in] coord_eval2
+     * 			The coordinate on the second dimension where we want to evaluate.
+     * @param[in] splne_coef
+     * 			The B-splines coefficients of the function we want to evaluate.
+     * @param[out] vals1
+     * 			A ChunkSpan with the not-null values of each function of the spline in the first dimension.
+     * @param[out] vals2
+     * 			A ChunkSpan with the not-null values of each function of the spline in the second dimension.
+     * @param[in] eval_type_1
+     * 			A flag indicating if we evaluate the function or its derivative in the first dimension.
+     * 			The type of this object is either `eval_type` or `eval_deriv_type`.
+     * @param[in] eval_type_2
+     * 			A flag indicating if we evaluate the function or its derivative in the second dimension.
+     *          The type of this object is either `eval_type` or `eval_deriv_type`.
+     */
     template <class EvalType1, class EvalType2, class Layout, class... CoordsDims>
     KOKKOS_INLINE_FUNCTION double eval_no_bc(
             ddc::Coordinate<CoordsDims...> const& coord_eval,


### PR DESCRIPTION
Update spline kernels with improvements from SLL. For most files this only concerns documentation. However for `include/ddc/kernels/splines/greville_interpolation_points.hpp` there is a bug fix. The periodic point *must* be calcucated in the helper class in order to be able to evaluate the length of the domain.