### PR TITLE
Fix out of bounds periodic evaluation

### DIFF
--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -339,7 +339,7 @@ static void ExtrapolationRuleSplineTest()
                 // Set coords_eval outside of the domain (this point should be found on the grid in
                 // the periodic case)
                 ddc::get<I2>(coords_eval(e))
-                        = 2*xN<I2>() + (ddc::select<I2>(ddc::coordinate(e)) - x0<I2>());
+                        = 2 * xN<I2>() + (ddc::select<I2>(ddc::coordinate(e)) - x0<I2>());
             });
 
 

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -337,7 +337,7 @@ static void ExtrapolationRuleSplineTest()
                 ddc::get<I1>(coords_eval(e))
                         = xN<I1>() + (ddc::select<I1>(ddc::coordinate(e)) - x0<I1>()) + 1;
                 ddc::get<I2>(coords_eval(e))
-                        = xN<I2>() + (ddc::select<I2>(ddc::coordinate(e)) - x0<I2>()) + 1;
+                        = xN<I2>() + (ddc::select<I2>(ddc::coordinate(e)) - x0<I2>());
             });
 
 
@@ -368,10 +368,16 @@ static void ExtrapolationRuleSplineTest()
                         discrete_element_type e_batch(e);
                 double tmp;
                 if (ddc::select<I2>(coords_eval(e)) > xN<I2>()) {
+#if defined(BC_PERIODIC)
+                    tmp = vals(ddc::DiscreteElement<IDim<X, I1, I2>...>(
+                            vals.template domain<IDim<I1, I1, I2>>().back(),
+                            e_without_interest));
+#else
                     tmp = vals(ddc::DiscreteElement<IDim<X, I1, I2>...>(
                             vals.template domain<IDim<I1, I1, I2>>().back(),
                             vals.template domain<IDim<I2, I1, I2>>().back(),
                             e_batch));
+#endif
                 } else {
                     tmp = vals(ddc::DiscreteElement<IDim<X, I1, I2>...>(
                             vals.template domain<IDim<I1, I1, I2>>().back(),

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -336,10 +336,8 @@ static void ExtrapolationRuleSplineTest()
                 // Set coords_eval outside of the domain
                 ddc::get<I1>(coords_eval(e))
                         = xN<I1>() + (ddc::select<I1>(ddc::coordinate(e)) - x0<I1>()) + 1;
-#if defined(BC_GREVILLE)
                 ddc::get<I2>(coords_eval(e))
                         = xN<I2>() + (ddc::select<I2>(ddc::coordinate(e)) - x0<I2>()) + 1;
-#endif
             });
 
 

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -333,11 +333,13 @@ static void ExtrapolationRuleSplineTest()
             coords_eval.domain(),
             KOKKOS_LAMBDA(Index<IDim<X, I1, I2>...> const e) {
                 coords_eval(e) = ddc::coordinate(e);
-                // Set coords_eval outside of the domain
+                // Set coords_eval outside of the domain (+1 to ensure left bound is outside domain)
                 ddc::get<I1>(coords_eval(e))
                         = xN<I1>() + (ddc::select<I1>(ddc::coordinate(e)) - x0<I1>()) + 1;
+                // Set coords_eval outside of the domain (this point should be found on the grid in
+                // the periodic case)
                 ddc::get<I2>(coords_eval(e))
-                        = xN<I2>() + (ddc::select<I2>(ddc::coordinate(e)) - x0<I2>());
+                        = 2*xN<I2>() + (ddc::select<I2>(ddc::coordinate(e)) - x0<I2>());
             });
 
 


### PR DESCRIPTION
When using `SplineEvaluator2D` to evaluate a point (r,theta) outside the domain, the periodic conditions should be applied before the non-periodic conditions. This is important because in a periodic direction no points are truly outside the domain. They should therefore be relocated before calling something like `ConstantExtrapolationRule`.