### PR TITLE
Workaround ginkgo omp problem (use Gmres)

### DIFF
--- a/include/ddc/kernels/splines/matrix_sparse.hpp
+++ b/include/ddc/kernels/splines/matrix_sparse.hpp
@@ -77,7 +77,7 @@ unsigned int default_preconditionner_max_block_size() noexcept
 #endif
 #ifdef KOKKOS_ENABLE_OPENMP
     if (std::is_same_v<ExecSpace, Kokkos::OpenMP>) {
-        return 32u;
+        return 1u;
     }
 #endif
 #ifdef KOKKOS_ENABLE_CUDA
@@ -104,7 +104,7 @@ private:
 
     std::shared_ptr<matrix_sparse_type> m_matrix_sparse;
 
-    std::shared_ptr<gko::solver::Bicgstab<double>> m_solver;
+    std::shared_ptr<gko::solver::Gmres<double>> m_solver;
     std::shared_ptr<gko::LinOp> m_solver_tr;
 
     int m_cols_per_chunk; // Maximum number of columns of B to be passed to a Ginkgo solver
@@ -152,7 +152,7 @@ public:
 
         // Create the solver factory
         std::shared_ptr const residual_criterion
-                = gko::stop::ResidualNorm<double>::build().with_reduction_factor(1e-19).on(
+                = gko::stop::ResidualNorm<double>::build().with_reduction_factor(1e-16).on(
                         gko_exec);
 
         std::shared_ptr const iterations_criterion
@@ -164,7 +164,7 @@ public:
                           .on(gko_exec);
 
         std::unique_ptr const solver_factory
-                = gko::solver::Bicgstab<double>::build()
+                = gko::solver::Gmres<double>::build()
                           .with_preconditioner(preconditioner)
                           .with_criteria(residual_criterion, iterations_criterion)
                           .on(gko_exec);


### PR DESCRIPTION
Following https://github.com/ginkgo-project/ginkgo/issues/1563#issuecomment-2024928079

Using Gmres avoid the problem. Stopping criteria needed to be relaxed to make all tests pass (2D splines were slightly failing which means 1e-19 leads to some kind of non-convergency. It is also in accord with recommandation here: https://github.com/ginkgo-project/ginkgo/issues/1563#issuecomment-1986031356)

OMP preconditionner parameter (Jacobi-block-size) is set to 1 again because of Ginkgo recommandation, and because we do not observe huge performance improvement on splines with preconditionner (~18% at most in old benchmarks).

BiCGStab should be recovered once the problem has been fixed from Ginkgo side.

It solves all problems we had due to this issue (in Gysela or DDC)