### PR TITLE
Remove spline_dim_type

### DIFF
--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -85,10 +85,6 @@ public:
                     ddc::detail::TypeSeq<IDimX...>,
                     ddc::detail::TypeSeq<interpolation_mesh_type>>>;
 
-    template <typename Tag>
-    using spline_dim_type
-            = std::conditional_t<std::is_same_v<Tag, interpolation_mesh_type>, bsplines_type, Tag>;
-
     using spline_domain_type =
             typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_replace_t<
                     ddc::detail::TypeSeq<IDimX...>,

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -58,10 +58,6 @@ public:
                     ddc::detail::TypeSeq<IDimX...>,
                     ddc::detail::TypeSeq<interpolation_mesh_type>>>;
 
-    template <typename Tag>
-    using spline_dim_type
-            = std::conditional_t<std::is_same_v<Tag, interpolation_mesh_type>, bsplines_type, Tag>;
-
     using spline_domain_type =
             typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_replace_t<
                     ddc::detail::TypeSeq<IDimX...>,

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -77,12 +77,6 @@ public:
                     ddc::detail::TypeSeq<IDimX...>,
                     ddc::detail::TypeSeq<interpolation_mesh_type1, interpolation_mesh_type2>>>;
 
-    template <typename Tag>
-    using spline_dim_type = std::conditional_t<
-            std::is_same_v<Tag, interpolation_mesh_type1>,
-            bsplines_type1,
-            std::conditional_t<std::is_same_v<Tag, interpolation_mesh_type2>, bsplines_type2, Tag>>;
-
     using spline_domain_type =
             typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_replace_t<
                     ddc::detail::TypeSeq<IDimX...>,


### PR DESCRIPTION
spline_dim_type is unused in ddc and gysela.

If we have no practical use case I think we should remove it