### PR TITLE
[Splines] remove rank()

### DIFF
--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -37,11 +37,6 @@ public:
     using discrete_dimension_type = NonUniformBSplines;
 
 public:
-    static constexpr std::size_t rank()
-    {
-        return 1;
-    }
-
     static constexpr std::size_t degree() noexcept
     {
         return D;

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -36,11 +36,6 @@ public:
     using discrete_dimension_type = UniformBSplines;
 
 public:
-    static constexpr std::size_t rank()
-    {
-        return 1;
-    }
-
     static constexpr std::size_t degree() noexcept
     {
         return D;


### PR DESCRIPTION
`rank()` is a residual from an old functionning of DDC.