### PR TITLE
Allow the reordering of a DiscreteDomain

### DIFF
--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -101,7 +101,7 @@ public:
     KOKKOS_DEFAULTED_FUNCTION DiscreteDomain& operator=(DiscreteDomain&& x) = default;
 
     /**
-     * @brief Copy a DiscreteDomain by reordering.
+     * @brief Copy a DiscreteDomain by reordering and slicing.
      *
      * An assign operator to build a DiscreteDomain from another compatible domain.
      * A domain is compatible if it either contains the same dimensions as this

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -100,6 +100,25 @@ public:
 
     KOKKOS_DEFAULTED_FUNCTION DiscreteDomain& operator=(DiscreteDomain&& x) = default;
 
+    /**
+     * @brief Copy a DiscreteDomain by reordering.
+     *
+     * An assign operator to build a DiscreteDomain from another compatible domain.
+     * A domain is compatible if it either contains the same dimensions as this
+     * domain (even if they are in a different order) or if it contains at
+     * the dimensions of this domain plus some additional dimensions which will
+     * be unused here.
+     *
+     * @param domain A compatible domain.
+     */
+    template <class... ODDims>
+    DiscreteDomain& KOKKOS_FUNCTION operator=(DiscreteDomain<ODDims...> const& domain)
+    {
+        m_element_begin = DiscreteElement<DDims...>(domain.front());
+        m_element_end = DiscreteElement<DDims...>(domain.back());
+        return *this;
+    }
+
     template <class... ODims>
     KOKKOS_FUNCTION constexpr bool operator==(DiscreteDomain<ODims...> const& other) const
     {

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -115,7 +115,7 @@ public:
     DiscreteDomain& KOKKOS_FUNCTION operator=(DiscreteDomain<ODDims...> const& domain)
     {
         m_element_begin = DiscreteElement<DDims...>(domain.front());
-        m_element_end = DiscreteElement<DDims...>(domain.back());
+        m_element_end = m_element_begin + DiscreteVector<DDims...>(domain.extents());
         return *this;
     }
 

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -78,7 +78,17 @@ public:
     {
     }
 
-    // Construct a DiscreteDomain from a reordered copy of `domain`
+    /**
+     * @brief Construct a DiscreteDomain from a reordered copy of `domain`
+     *
+     * A constructor to build a DiscreteDomain from another compatible domain.
+     * A domain is compatible if it either contains the same dimensions as this
+     * domain (even if they are in a different order) or if it contains at
+     * the dimensions of this domain plus some additional dimensions which will
+     * be unused here.
+     *
+     * @param domain A compatible domain.
+     */
     template <class... ODDims>
     explicit KOKKOS_FUNCTION constexpr DiscreteDomain(
             [[maybe_unused]] DiscreteDomain<ODDims...> const& domain)

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -78,26 +78,6 @@ public:
     {
     }
 
-    /**
-     * @brief Construct a DiscreteDomain from a reordered copy of `domain`
-     *
-     * A constructor to build a DiscreteDomain from another compatible domain.
-     * A domain is compatible if it either contains the same dimensions as this
-     * domain (even if they are in a different order) or if it contains at
-     * the dimensions of this domain plus some additional dimensions which will
-     * be unused here.
-     *
-     * @param domain A compatible domain.
-     */
-    template <class... ODDims>
-    explicit KOKKOS_FUNCTION constexpr DiscreteDomain(
-            [[maybe_unused]] DiscreteDomain<ODDims...> const& domain)
-        : m_element_begin((ddc::select<DDims>(domain.front()))...)
-        , m_element_end(
-                  (ddc::select<DDims>(domain.front()) + ddc::select<DDims>(domain.extents()))...)
-    {
-    }
-
     /** Construct a DiscreteDomain starting from element_begin with size points.
      * @param element_begin the lower bound in each direction
      * @param size the number of points in each direction

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -78,6 +78,15 @@ public:
     {
     }
 
+    // Construct a DiscreteDomain from a reordered copy of `domain`
+    template <class... ODDims>
+    explicit KOKKOS_FUNCTION constexpr DiscreteDomain(
+            [[maybe_unused]] DiscreteDomain<ODDims...> const& domain)
+        : m_element_begin((ddc::select<DDims>(domain.front()))...)
+        , m_element_end((ddc::select<DDims>(domain.front()) + ddc::select<DDims>(domain.extents()))...)
+    {
+    }
+
     /** Construct a DiscreteDomain starting from element_begin with size points.
      * @param element_begin the lower bound in each direction
      * @param size the number of points in each direction

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -83,7 +83,8 @@ public:
     explicit KOKKOS_FUNCTION constexpr DiscreteDomain(
             [[maybe_unused]] DiscreteDomain<ODDims...> const& domain)
         : m_element_begin((ddc::select<DDims>(domain.front()))...)
-        , m_element_end((ddc::select<DDims>(domain.front()) + ddc::select<DDims>(domain.extents()))...)
+        , m_element_end(
+                  (ddc::select<DDims>(domain.front()) + ddc::select<DDims>(domain.extents()))...)
     {
     }
 

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -238,16 +238,6 @@ TEST(ProductMDomainTest, SliceDomainXToolate)
 #endif
 }
 
-TEST(ProductMDomainTest, Transpose2DConstructor)
-{
-    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
-    DDomYX const dom_y_x(dom_x_y);
-    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.front()), ddc::select<DDimX>(lbound_x_y));
-    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.front()), ddc::select<DDimY>(lbound_x_y));
-    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.back()), ddc::select<DDimX>(ubound_x_y));
-    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.back()), ddc::select<DDimY>(ubound_x_y));
-}
-
 TEST(ProductMDomainTest, Transpose3DConstructor)
 {
     DDomX const dom_x(lbound_x, nelems_x);
@@ -261,17 +251,6 @@ TEST(ProductMDomainTest, Transpose3DConstructor)
     EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.back()), ddc::select<DDimX>(dom_z_y_x.back()));
     EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.back()), ddc::select<DDimY>(dom_z_y_x.back()));
     EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.back()), ddc::select<DDimZ>(dom_z_y_x.back()));
-}
-
-TEST(ProductMDomainTest, Transpose2DAssign)
-{
-    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
-    DDomYX dom_y_x;
-    dom_y_x = dom_x_y;
-    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.front()), ddc::select<DDimX>(lbound_x_y));
-    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.front()), ddc::select<DDimY>(lbound_x_y));
-    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.back()), ddc::select<DDimX>(ubound_x_y));
-    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.back()), ddc::select<DDimY>(ubound_x_y));
 }
 
 TEST(ProductMDomainTest, Transpose3DAssign)

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -263,31 +263,6 @@ TEST(ProductMDomainTest, Transpose3DConstructor)
     EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.back()), ddc::select<DDimZ>(dom_z_y_x.back()));
 }
 
-TEST(ProductMDomainTest, Transpose2DAssignConstructor)
-{
-    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
-    DDomYX const dom_y_x = dom_x_y;
-    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.front()), ddc::select<DDimX>(lbound_x_y));
-    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.front()), ddc::select<DDimY>(lbound_x_y));
-    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.back()), ddc::select<DDimX>(ubound_x_y));
-    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.back()), ddc::select<DDimY>(ubound_x_y));
-}
-
-TEST(ProductMDomainTest, Transpose3DAssignConstructor)
-{
-    DDomX const dom_x(lbound_x, nelems_x);
-    DDomY const dom_y(lbound_y, nelems_y);
-    DDomZ const dom_z(lbound_z, nelems_z);
-    DDomXYZ const dom_x_y_z(dom_x, dom_y, dom_z);
-    DDomZYX const dom_z_y_x = dom_x_y_z;
-    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.front()), ddc::select<DDimX>(dom_z_y_x.front()));
-    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.front()), ddc::select<DDimY>(dom_z_y_x.front()));
-    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.front()), ddc::select<DDimZ>(dom_z_y_x.front()));
-    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.back()), ddc::select<DDimX>(dom_z_y_x.back()));
-    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.back()), ddc::select<DDimY>(dom_z_y_x.back()));
-    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.back()), ddc::select<DDimZ>(dom_z_y_x.back()));
-}
-
 TEST(ProductMDomainTest, Transpose2DAssign)
 {
     DDomXY const dom_x_y(lbound_x_y, nelems_x_y);

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -54,6 +54,9 @@ using DElemXYZ = ddc::DiscreteElement<DDimX, DDimY, DDimZ>;
 using DVectXYZ = ddc::DiscreteVector<DDimX, DDimY, DDimZ>;
 using DDomXYZ = ddc::DiscreteDomain<DDimX, DDimY, DDimZ>;
 
+using DElemZYX = ddc::DiscreteElement<DDimZ, DDimY, DDimX>;
+using DVectZYX = ddc::DiscreteVector<DDimZ, DDimY, DDimX>;
+using DDomZYX = ddc::DiscreteDomain<DDimZ, DDimY, DDimX>;
 
 static DElemX constexpr lbound_x(50);
 static DVectX constexpr nelems_x(3);
@@ -233,4 +236,29 @@ TEST(ProductMDomainTest, SliceDomainXToolate)
             dom_x_y.restrict(subdomain_x),
             R"rgx([Aa]ssert.*uid<ODDims>\(m_element_end\).*uid<ODDims>\(odomain\.m_element_end\).*)rgx");
 #endif
+}
+
+TEST(ProductMDomainTest, Transpose2D)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+    DDomYX const dom_y_x(dom_x_y);
+    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.front()), ddc::select<DDimX>(lbound_x_y));
+    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.front()), ddc::select<DDimY>(lbound_x_y));
+    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.back()), ddc::select<DDimX>(ubound_x_y));
+    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.back()), ddc::select<DDimY>(ubound_x_y));
+}
+
+TEST(ProductMDomainTest, Transpose3D)
+{
+    DDomX const dom_x(lbound_x, nelems_x);
+    DDomY const dom_y(lbound_y, nelems_y);
+    DDomZ const dom_z(lbound_z, nelems_z);
+    DDomXYZ const dom_x_y_z(dom_x, dom_y, dom_z);
+    DDomZYX const dom_z_y_x(dom_x_y_z);
+    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.front()), ddc::select<DDimX>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.front()), ddc::select<DDimY>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.front()), ddc::select<DDimZ>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.back()), ddc::select<DDimX>(dom_z_y_x.back()));
+    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.back()), ddc::select<DDimY>(dom_z_y_x.back()));
+    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.back()), ddc::select<DDimZ>(dom_z_y_x.back()));
 }

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -238,7 +238,7 @@ TEST(ProductMDomainTest, SliceDomainXToolate)
 #endif
 }
 
-TEST(ProductMDomainTest, Transpose2D)
+TEST(ProductMDomainTest, Transpose2DConstructor)
 {
     DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
     DDomYX const dom_y_x(dom_x_y);
@@ -248,13 +248,65 @@ TEST(ProductMDomainTest, Transpose2D)
     EXPECT_EQ(ddc::select<DDimY>(dom_y_x.back()), ddc::select<DDimY>(ubound_x_y));
 }
 
-TEST(ProductMDomainTest, Transpose3D)
+TEST(ProductMDomainTest, Transpose3DConstructor)
 {
     DDomX const dom_x(lbound_x, nelems_x);
     DDomY const dom_y(lbound_y, nelems_y);
     DDomZ const dom_z(lbound_z, nelems_z);
     DDomXYZ const dom_x_y_z(dom_x, dom_y, dom_z);
     DDomZYX const dom_z_y_x(dom_x_y_z);
+    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.front()), ddc::select<DDimX>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.front()), ddc::select<DDimY>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.front()), ddc::select<DDimZ>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.back()), ddc::select<DDimX>(dom_z_y_x.back()));
+    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.back()), ddc::select<DDimY>(dom_z_y_x.back()));
+    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.back()), ddc::select<DDimZ>(dom_z_y_x.back()));
+}
+
+TEST(ProductMDomainTest, Transpose2DAssignConstructor)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+    DDomYX const dom_y_x = dom_x_y;
+    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.front()), ddc::select<DDimX>(lbound_x_y));
+    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.front()), ddc::select<DDimY>(lbound_x_y));
+    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.back()), ddc::select<DDimX>(ubound_x_y));
+    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.back()), ddc::select<DDimY>(ubound_x_y));
+}
+
+TEST(ProductMDomainTest, Transpose3DAssignConstructor)
+{
+    DDomX const dom_x(lbound_x, nelems_x);
+    DDomY const dom_y(lbound_y, nelems_y);
+    DDomZ const dom_z(lbound_z, nelems_z);
+    DDomXYZ const dom_x_y_z(dom_x, dom_y, dom_z);
+    DDomZYX const dom_z_y_x = dom_x_y_z;
+    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.front()), ddc::select<DDimX>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.front()), ddc::select<DDimY>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.front()), ddc::select<DDimZ>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.back()), ddc::select<DDimX>(dom_z_y_x.back()));
+    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.back()), ddc::select<DDimY>(dom_z_y_x.back()));
+    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.back()), ddc::select<DDimZ>(dom_z_y_x.back()));
+}
+
+TEST(ProductMDomainTest, Transpose2DAssign)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+    DDomYX dom_y_x;
+    dom_y_x = dom_x_y;
+    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.front()), ddc::select<DDimX>(lbound_x_y));
+    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.front()), ddc::select<DDimY>(lbound_x_y));
+    EXPECT_EQ(ddc::select<DDimX>(dom_y_x.back()), ddc::select<DDimX>(ubound_x_y));
+    EXPECT_EQ(ddc::select<DDimY>(dom_y_x.back()), ddc::select<DDimY>(ubound_x_y));
+}
+
+TEST(ProductMDomainTest, Transpose3DAssign)
+{
+    DDomX const dom_x(lbound_x, nelems_x);
+    DDomY const dom_y(lbound_y, nelems_y);
+    DDomZ const dom_z(lbound_z, nelems_z);
+    DDomXYZ const dom_x_y_z(dom_x, dom_y, dom_z);
+    DDomZYX dom_z_y_x;
+    dom_z_y_x = dom_x_y_z;
     EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.front()), ddc::select<DDimX>(dom_z_y_x.front()));
     EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.front()), ddc::select<DDimY>(dom_z_y_x.front()));
     EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.front()), ddc::select<DDimZ>(dom_z_y_x.front()));


### PR DESCRIPTION
Add a function to initialise a `DiscreteDomain` from a `DiscreteDomain` with a different ordering. Fixes #419 