### PR TITLE
[Splines] Remove NATURAL boundary condition

### DIFF
--- a/include/ddc/kernels/splines/spline_boundary_conditions.hpp
+++ b/include/ddc/kernels/splines/spline_boundary_conditions.hpp
@@ -16,8 +16,6 @@ enum class BoundCond {
     // Use Greville points instead of conditions on derivative for B-Spline
     // interpolation
     GREVILLE,
-    // Natural boundary condition
-    NATURAL
 };
 
 static inline std::ostream& operator<<(std::ostream& out, ddc::BoundCond const bc)
@@ -29,8 +27,6 @@ static inline std::ostream& operator<<(std::ostream& out, ddc::BoundCond const b
         return out << "HERMITE";
     case ddc::BoundCond::GREVILLE:
         return out << "GREVILLE";
-    case ddc::BoundCond::NATURAL:
-        return out << "NATURAL";
     default:
         throw std::runtime_error("ddc::BoundCond not handled");
     }
@@ -43,23 +39,6 @@ constexpr int n_boundary_equations(ddc::BoundCond const bc, std::size_t const de
     } else if (bc == ddc::BoundCond::HERMITE) {
         return degree / 2;
     } else if (bc == ddc::BoundCond::GREVILLE) {
-        return 0;
-    } else if (bc == ddc::BoundCond::NATURAL) {
-        return degree / 2;
-    } else {
-        throw std::runtime_error("ddc::BoundCond not handled");
-    }
-}
-
-constexpr int n_user_input(ddc::BoundCond const bc, std::size_t const degree)
-{
-    if (bc == ddc::BoundCond::PERIODIC) {
-        return 0;
-    } else if (bc == ddc::BoundCond::HERMITE) {
-        return degree / 2;
-    } else if (bc == ddc::BoundCond::GREVILLE) {
-        return 0;
-    } else if (bc == ddc::BoundCond::NATURAL) {
         return 0;
     } else {
         throw std::runtime_error("ddc::BoundCond not handled");

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -111,30 +111,12 @@ public:
     /**
      * @brief The number of equations which define the boundary conditions at the lower bound.
      */
-    static constexpr int s_nbe_xmin = n_boundary_equations(BcXmin, BSplines::degree());
+    static constexpr int s_nbc_xmin = n_boundary_equations(BcXmin, BSplines::degree());
 
     /**
      * @brief The number of equations which define the boundary conditions at the upper bound.
      */
-    static constexpr int s_nbe_xmax = n_boundary_equations(BcXmax, BSplines::degree());
-
-    /**
-     * @brief The number of boundary conditions which must be provided by the user at the lower bound.
-     *
-     * This value is usually equal to s_nbe_xmin, but it may be difference if the chosen boundary
-     * conditions impose a specific value (e.g. no values need to be provided for Dirichlet boundary
-     * conditions).
-     */
-    static constexpr int s_nbc_xmin = n_user_input(BcXmin, BSplines::degree());
-
-    /**
-     * @brief The number of boundary conditions which must be provided by the user at the upper bound.
-     *
-     * This value is usually equal to s_nbe_xmin, but it may be difference if the chosen boundary
-     * conditions impose a specific value (e.g. no values need to be provided for Dirichlet boundary
-     * conditions).
-     */
-    static constexpr int s_nbc_xmax = n_user_input(BcXmax, BSplines::degree());
+    static constexpr int s_nbc_xmax = n_boundary_equations(BcXmax, BSplines::degree());
 
     /**
      * @brief The boundary condition implemented at the lower bound.
@@ -400,7 +382,6 @@ void SplineBuilder<
     case ddc::BoundCond::PERIODIC:
         upper_block_size = (bsplines_type::degree()) / 2;
         break;
-    case ddc::BoundCond::NATURAL:
     case ddc::BoundCond::HERMITE:
         upper_block_size = s_nbc_xmin;
         break;
@@ -414,7 +395,6 @@ void SplineBuilder<
     case ddc::BoundCond::PERIODIC:
         lower_block_size = (bsplines_type::degree()) / 2;
         break;
-    case ddc::BoundCond::NATURAL:
     case ddc::BoundCond::HERMITE:
         lower_block_size = s_nbc_xmax;
         break;
@@ -652,7 +632,7 @@ operator()(
                 memory_space>> const derivs_xmax) const
 {
     assert(vals.template extent<interpolation_mesh_type>()
-           == ddc::discrete_space<bsplines_type>().nbasis() - s_nbe_xmin - s_nbe_xmax);
+           == ddc::discrete_space<bsplines_type>().nbasis() - s_nbc_xmin - s_nbc_xmax);
 
     assert((BcXmin == ddc::BoundCond::HERMITE)
            != (!derivs_xmin.has_value() || derivs_xmin->template extent<deriv_type>() == 0));


### PR DESCRIPTION
`ddc::BoundCond::NATURAL` is used nowhere, not tested and even not fully implement.

`n_user_input()` is also removed because the returned value was different from `n_boundary_equations()`