### PR TITLE
Use DDC concepts for B-spline knots

### DIFF
--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -175,7 +175,7 @@ static void characteristics_advection(benchmark::State& state)
     /// variables, which is always a bad idea.       ///
     ////////////////////////////////////////////////////
     ddc::detail::g_discrete_space_dual<BSplinesX>.reset();
-    ddc::detail::g_discrete_space_dual<ddc::detail::UniformBsplinesKnots<BSplinesX>>.reset();
+    ddc::detail::g_discrete_space_dual<ddc::UniformBsplinesKnots<BSplinesX>>.reset();
     ddc::detail::g_discrete_space_dual<DDimX>.reset();
     ddc::detail::g_discrete_space_dual<DDimY>.reset();
     ////////////////////////////////////////////////////

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -303,7 +303,7 @@ public:
          */
         KOKKOS_INLINE_FUNCTION ddc::Coordinate<Tag> rmax() const noexcept
         {
-            return ddc::coordinate(m_break_point_domain.back() + 1);
+            return ddc::coordinate(m_break_point_domain.back());
         }
 
         /** @brief Returns the length of the domain.

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -671,7 +671,7 @@ NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::find_cell(ddc::Coordinate<T
     if (x == rmin())
         return m_break_point_domain.front();
     if (x == rmax())
-        return m_break_point_domain.back()-1;
+        return m_break_point_domain.back() - 1;
 
     // Binary search
     ddc::DiscreteElement<knot_mesh_type> low = m_break_point_domain.front();

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -657,8 +657,9 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
 
 template <class Tag, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<NonUniformBsplinesKnots<DDim>>
-NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::find_cell_start(ddc::Coordinate<Tag> const& x) const
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<NonUniformBsplinesKnots<DDim>> NonUniformBSplines<
+        Tag,
+        D>::Impl<DDim, MemorySpace>::find_cell_start(ddc::Coordinate<Tag> const& x) const
 {
     assert(x <= rmax());
     assert(x >= rmin());

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -671,7 +671,7 @@ NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::find_cell(ddc::Coordinate<T
     if (x == rmin())
         return m_break_point_domain.front();
     if (x == rmax())
-        return m_break_point_domain.back();
+        return m_break_point_domain.back()-1;
 
     // Binary search
     ddc::DiscreteElement<knot_mesh_type> low = m_break_point_domain.front();

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -285,7 +285,7 @@ public:
         KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<knot_mesh_type> get_last_support_knot(
                 discrete_element_type const& ix) const
         {
-            return get_first_support_knot(ix) + ddc::DiscreteVector<knot_mesh_type>(degree() + 2);
+            return get_first_support_knot(ix) + ddc::DiscreteVector<knot_mesh_type>(degree() + 1);
         }
 
         /** @brief Returns the coordinate of the first break point of the domain on which the B-splines are defined.

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -17,16 +17,16 @@ namespace ddc {
 
 namespace detail {
 
-template <class T>
-struct NonUniformBsplinesKnots : NonUniformPointSampling<typename T::tag_type>
-{
-};
-
 struct NonUniformBSplinesBase
 {
 };
 
 } // namespace detail
+
+template <class T>
+struct NonUniformBsplinesKnots : NonUniformPointSampling<typename T::tag_type>
+{
+};
 
 /**
  * The type of a non-uniform 1D spline basis (B-spline).
@@ -89,7 +89,7 @@ public:
 
     public:
         /// @brief The type of the knots defining the B-splines.
-        using knot_mesh_type = detail::NonUniformBsplinesKnots<DDim>;
+        using knot_mesh_type = NonUniformBsplinesKnots<DDim>;
 
         /// @brief The type of the discrete dimension representing the B-splines.
         using discrete_dimension_type = NonUniformBSplines;
@@ -160,8 +160,7 @@ public:
          * @param impl A reference to the other Impl
          */
         template <class OriginMemorySpace>
-        explicit Impl(Impl<DDim, OriginMemorySpace> const& impl)
-            : m_domain(impl.m_domain)
+        explicit Impl(Impl<DDim, OriginMemorySpace> const& impl) : m_domain(impl.m_domain)
         {
         }
 

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -288,12 +288,6 @@ public:
             return get_first_support_knot(ix) + ddc::DiscreteVector<knot_mesh_type>(degree() + 2);
         }
 
-        KOKKOS_INLINE_FUNCTION discrete_element_type
-        get_bspline_from_first_support_knot(ddc::DiscreteElement<knot_mesh_type> const& ix) const
-        {
-            return discrete_element_type((ix - ddc::DiscreteElement<knot_mesh_type>(0)).value());
-        }
-
         /** @brief Returns the coordinate of the first break point of the domain on which the B-splines are defined.
          *
          * @return Coordinate of the lower bound of the domain.
@@ -343,6 +337,10 @@ public:
             return discrete_domain_type(discrete_element_type(0), discrete_vector_type(size()));
         }
 
+        /** @brief Returns the discrete domain which describes the break points.
+         *
+         * @return The discrete domain describing the break points.
+         */
         KOKKOS_INLINE_FUNCTION ddc::DiscreteDomain<knot_mesh_type> break_point_domain() const
         {
             return m_break_point_domain;
@@ -383,6 +381,12 @@ public:
         }
 
     private:
+        KOKKOS_INLINE_FUNCTION discrete_element_type
+        get_bspline_from_first_support_knot(ddc::DiscreteElement<knot_mesh_type> const& ix) const
+        {
+            return discrete_element_type((ix - ddc::DiscreteElement<knot_mesh_type>(0)).value());
+        }
+
         /**
          * @brief Get the cell where x is found
          * @param x The point whose location must be determined.

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -261,7 +261,7 @@ public:
          * In other words it returns the lower bound of the support.
          *
          * @param[in] ix DiscreteElement identifying the B-spline.
-         * @return Index of the lower bound of the support of the B-spline.
+         * @return DiscreteElement of the lower bound of the support of the B-spline.
          */
         KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<knot_mesh_type> get_first_support_knot(
                 discrete_element_type const& ix) const
@@ -276,7 +276,7 @@ public:
          * In other words it returns the upper bound of the support.
          *
          * @param[in] ix DiscreteElement identifying the B-spline.
-         * @return Index of the upper bound of the support of the B-spline.
+         * @return DiscreteElement of the upper bound of the support of the B-spline.
          */
         KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<knot_mesh_type> get_last_support_knot(
                 discrete_element_type const& ix) const

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -382,9 +382,9 @@ public:
 
     private:
         KOKKOS_INLINE_FUNCTION discrete_element_type
-        get_bspline_from_first_support_knot(ddc::DiscreteElement<knot_mesh_type> const& ix) const
+        get_first_bspline_in_cell(ddc::DiscreteElement<knot_mesh_type> const& ic) const
         {
-            return discrete_element_type((ix - m_break_point_domain.front()).value());
+            return discrete_element_type((ic - m_break_point_domain.front()).value());
         }
 
         /**
@@ -492,7 +492,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
         values[j + 1] = saved;
     }
 
-    return get_bspline_from_first_support_knot(icell);
+    return get_first_bspline_in_cell(icell);
 }
 
 template <class Tag, std::size_t D>
@@ -551,7 +551,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
     }
     derivs[degree()] = saved;
 
-    return get_bspline_from_first_support_knot(icell);
+    return get_first_bspline_in_cell(icell);
 }
 
 template <class Tag, std::size_t D>
@@ -657,7 +657,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
         r *= degree() - k;
     }
 
-    return get_bspline_from_first_support_knot(icell);
+    return get_first_bspline_in_cell(icell);
 }
 
 template <class Tag, std::size_t D>

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -107,8 +107,6 @@ public:
         ddc::DiscreteDomain<knot_mesh_type> m_domain;
         ddc::DiscreteDomain<knot_mesh_type> m_break_point_domain;
 
-        int m_nknots;
-
     public:
         Impl() = default;
 
@@ -164,7 +162,6 @@ public:
         template <class OriginMemorySpace>
         explicit Impl(Impl<DDim, OriginMemorySpace> const& impl)
             : m_domain(impl.m_domain)
-            , m_nknots(impl.m_nknots)
         {
         }
 
@@ -354,7 +351,7 @@ public:
          */
         KOKKOS_INLINE_FUNCTION std::size_t npoints() const noexcept
         {
-            return m_nknots - 2 * degree();
+            return m_domain.size() - 2 * degree();
         }
 
         /** @brief Returns the number of basis functions.
@@ -425,7 +422,6 @@ NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::Impl(
               ddc::DiscreteElement<knot_mesh_type>(degree()),
               ddc::DiscreteVector<knot_mesh_type>(
                       (break_end - break_begin))) // Create a mesh of break points
-    , m_nknots((break_end - break_begin) + 2 * degree())
 {
     std::vector<ddc::Coordinate<Tag>> knots((break_end - break_begin) + 2 * degree());
     // Fill the provided knots

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -385,11 +385,11 @@ public:
         }
 
         /**
-         * @brief Get the cell where x is found
+         * @brief Get the DiscreteElement describing the knot at the start of the cell where x is found.
          * @param x The point whose location must be determined.
          * @returns The DiscreteElement describing the knot at the lower bound of the cell of interest.
          */
-        KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<knot_mesh_type> find_cell(
+        KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<knot_mesh_type> find_cell_start(
                 ddc::Coordinate<Tag> const& x) const;
     };
 };
@@ -466,7 +466,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
     assert(values.size() == degree() + 1);
 
     // 1. Compute cell index 'icell'
-    ddc::DiscreteElement<knot_mesh_type> const icell = find_cell(x);
+    ddc::DiscreteElement<knot_mesh_type> const icell = find_cell_start(x);
 
     assert(icell >= m_break_point_domain.front());
     assert(icell <= m_break_point_domain.back());
@@ -504,7 +504,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
     assert(derivs.size() == degree() + 1);
 
     // 1. Compute cell index 'icell'
-    ddc::DiscreteElement<knot_mesh_type> const icell = find_cell(x);
+    ddc::DiscreteElement<knot_mesh_type> const icell = find_cell_start(x);
 
     assert(icell >= m_break_point_domain.front());
     assert(icell <= m_break_point_domain.back());
@@ -580,7 +580,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
     assert(derivs.extent(1) == 1 + n);
 
     // 1. Compute cell index 'icell' and x_offset
-    ddc::DiscreteElement<knot_mesh_type> const icell = find_cell(x);
+    ddc::DiscreteElement<knot_mesh_type> const icell = find_cell_start(x);
 
     assert(icell >= m_break_point_domain.front());
     assert(icell <= m_break_point_domain.back());
@@ -659,7 +659,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
 template <class Tag, std::size_t D>
 template <class DDim, class MemorySpace>
 KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<detail::NonUniformBsplinesKnots<DDim>>
-NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::find_cell(ddc::Coordinate<Tag> const& x) const
+NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::find_cell_start(ddc::Coordinate<Tag> const& x) const
 {
     assert(x <= rmax());
     assert(x >= rmin());

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -384,7 +384,7 @@ public:
         KOKKOS_INLINE_FUNCTION discrete_element_type
         get_bspline_from_first_support_knot(ddc::DiscreteElement<knot_mesh_type> const& ix) const
         {
-            return discrete_element_type((ix - ddc::DiscreteElement<knot_mesh_type>(0)).value());
+            return discrete_element_type((ix - m_break_point_domain.front()).value());
         }
 
         /**

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -657,7 +657,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
 
 template <class Tag, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<detail::NonUniformBsplinesKnots<DDim>>
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<NonUniformBsplinesKnots<DDim>>
 NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::find_cell_start(ddc::Coordinate<Tag> const& x) const
 {
     assert(x <= rmax());

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -123,9 +123,10 @@ public:
                             ncells + 1)) // Create a mesh including the eventual periodic point
         {
             assert(ncells > 0);
-            ddc::init_discrete_space<knot_mesh_type>(
-                    knot_mesh_type::template init<
-                            knot_mesh_type>(rmin, rmax, ddc::DiscreteVector<knot_mesh_type>(ncells + 1)));
+            ddc::init_discrete_space<knot_mesh_type>(knot_mesh_type::template init<knot_mesh_type>(
+                    rmin,
+                    rmax,
+                    ddc::DiscreteVector<knot_mesh_type>(ncells + 1)));
         }
 
         /** @brief Copy-constructs from another Impl with a different Kokkos memory space

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -17,16 +17,16 @@ namespace ddc {
 
 namespace detail {
 
-template <class T>
-struct UniformBsplinesKnots : UniformPointSampling<typename T::tag_type>
-{
-};
-
 struct UniformBSplinesBase
 {
 };
 
 } // namespace detail
+
+template <class T>
+struct UniformBsplinesKnots : UniformPointSampling<typename T::tag_type>
+{
+};
 
 /**
  * The type of a uniform 1D spline basis (B-spline).
@@ -89,7 +89,7 @@ public:
 
     public:
         /// @brief The type of the knots defining the B-splines.
-        using knot_mesh_type = detail::UniformBsplinesKnots<DDim>;
+        using knot_mesh_type = UniformBsplinesKnots<DDim>;
 
         /// @brief The type of the discrete dimension representing the B-splines.
         using discrete_dimension_type = UniformBSplines;

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -87,13 +87,10 @@ public:
         template <class ODDim, class OMemorySpace>
         friend class Impl;
 
-    private:
-        using mesh_type = detail::UniformBsplinesKnots<DDim>;
-
-        // In the periodic case, it contains twice the periodic point!!!
-        ddc::DiscreteDomain<mesh_type> m_domain;
-
     public:
+        /// @brief The type of the knots defining the B-splines.
+        using knot_mesh_type = detail::UniformBsplinesKnots<DDim>;
+
         /// @brief The type of the discrete dimension representing the B-splines.
         using discrete_dimension_type = UniformBSplines;
 
@@ -106,6 +103,11 @@ public:
         /// @brief The type of a DiscreteVector representing an "index displacement" between two B-splines.
         using discrete_vector_type = DiscreteVector<DDim>;
 
+    private:
+        // In the periodic case, it contains twice the periodic point!!!
+        ddc::DiscreteDomain<knot_mesh_type> m_domain;
+
+    public:
         Impl() = default;
 
         /** Constructs a spline basis (B-splines) with n equidistant knots over \f$[a, b]\f$
@@ -116,14 +118,14 @@ public:
          */
         explicit Impl(ddc::Coordinate<Tag> rmin, ddc::Coordinate<Tag> rmax, std::size_t ncells)
             : m_domain(
-                    ddc::DiscreteElement<mesh_type>(0),
-                    ddc::DiscreteVector<mesh_type>(
+                    ddc::DiscreteElement<knot_mesh_type>(0),
+                    ddc::DiscreteVector<knot_mesh_type>(
                             ncells + 1)) // Create a mesh including the eventual periodic point
         {
             assert(ncells > 0);
-            ddc::init_discrete_space<mesh_type>(
-                    mesh_type::template init<
-                            mesh_type>(rmin, rmax, ddc::DiscreteVector<mesh_type>(ncells + 1)));
+            ddc::init_discrete_space<knot_mesh_type>(
+                    knot_mesh_type::template init<
+                            knot_mesh_type>(rmin, rmax, ddc::DiscreteVector<knot_mesh_type>(ncells + 1)));
         }
 
         /** @brief Copy-constructs from another Impl with a different Kokkos memory space
@@ -241,7 +243,7 @@ public:
          */
         KOKKOS_INLINE_FUNCTION ddc::Coordinate<Tag> get_knot(int knot_idx) const noexcept
         {
-            return ddc::Coordinate<Tag>(rmin() + knot_idx * ddc::step<mesh_type>());
+            return ddc::Coordinate<Tag>(rmin() + knot_idx * ddc::step<knot_mesh_type>());
         }
 
         /** @brief Returns the coordinate of the first support knot associated to a DiscreteElement identifying a B-spline.
@@ -362,7 +364,7 @@ public:
     private:
         KOKKOS_INLINE_FUNCTION double inv_step() const noexcept
         {
-            return 1.0 / ddc::step<mesh_type>();
+            return 1.0 / ddc::step<knot_mesh_type>();
         }
 
         KOKKOS_INLINE_FUNCTION discrete_element_type
@@ -438,7 +440,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<Tag, D>::Impl<
     // 3. Compute derivatives of aforementioned B-splines
     //    Derivatives are normalized, hence they should be divided by dx
     double xx, temp, saved;
-    derivs(0) = 1.0 / ddc::step<mesh_type>();
+    derivs(0) = 1.0 / ddc::step<knot_mesh_type>();
     for (std::size_t j = 1; j < degree(); ++j) {
         xx = -offset;
         saved = 0.0;
@@ -607,7 +609,7 @@ UniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::integrals(
         discrete_domain_type const dom_bsplines(
                 full_dom_splines.take_first(discrete_vector_type {nbasis()}));
         for (auto ix : dom_bsplines) {
-            int_vals(ix) = ddc::step<mesh_type>();
+            int_vals(ix) = ddc::step<knot_mesh_type>();
         }
         if (int_vals.size() == size()) {
             discrete_domain_type const dom_bsplines_repeated(
@@ -621,7 +623,7 @@ UniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::integrals(
                 = full_dom_splines
                           .remove(discrete_vector_type(degree()), discrete_vector_type(degree()));
         for (auto ix : dom_bspline_entirely_in_domain) {
-            int_vals(ix) = ddc::step<mesh_type>();
+            int_vals(ix) = ddc::step<knot_mesh_type>();
         }
 
         std::array<double, degree() + 2> edge_vals_ptr;
@@ -636,7 +638,7 @@ UniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::integrals(
         for (std::size_t i = 0; i < degree(); ++i) {
             double const c_eval = ddc::detail::sum(edge_vals, 0, degree() - i);
 
-            double const edge_value = ddc::step<mesh_type>() * (d_eval - c_eval);
+            double const edge_value = ddc::step<knot_mesh_type>() * (d_eval - c_eval);
 
             int_vals(discrete_element_type(i)) = edge_value;
             int_vals(discrete_element_type(nbasis() - 1 - i)) = edge_value;

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -339,6 +339,15 @@ public:
             return discrete_domain_type(discrete_element_type(0), discrete_vector_type(size()));
         }
 
+        /** @brief Returns the discrete domain which describes the break points.
+         *
+         * @return The discrete domain describing the break points.
+         */
+        KOKKOS_INLINE_FUNCTION ddc::DiscreteDomain<knot_mesh_type> break_point_domain() const
+        {
+            return m_domain;
+        }
+
         /** @brief Returns the number of basis functions.
          *
          * The number of functions in the spline basis.

--- a/include/ddc/kernels/splines/greville_interpolation_points.hpp
+++ b/include/ddc/kernels/splines/greville_interpolation_points.hpp
@@ -70,10 +70,12 @@ class GrevilleInterpolationPoints
         ddc::for_each(bspline_domain, [&](ddc::DiscreteElement<BSplines> ib) {
             // Define the Greville points from the bspline knots
             greville_points[ib.uid()] = 0.0;
-            for (std::size_t i(0); i < BSplines::degree(); ++i) {
-                greville_points[ib.uid()]
-                        += ddc::discrete_space<BSplines>().get_support_knot_n(ib, i + 1);
-            }
+            ddc::DiscreteDomain<detail::NonUniformBsplinesKnots<BSplines>> sub_domain(
+                    ddc::discrete_space<BSplines>().get_first_support_knot(ib) + 1,
+                    BSplines::degree());
+            ddc::for_each(sub_domain, [&](auto ik) {
+                greville_points[ib.uid()] += ddc::coordinate(ik);
+            });
             greville_points[ib.uid()] /= BSplines::degree();
         });
 

--- a/include/ddc/kernels/splines/greville_interpolation_points.hpp
+++ b/include/ddc/kernels/splines/greville_interpolation_points.hpp
@@ -67,16 +67,19 @@ class GrevilleInterpolationPoints
                 = ddc::discrete_space<BSplines>().full_domain().take_first(
                         ddc::DiscreteVector<BSplines>(ddc::discrete_space<BSplines>().nbasis()));
 
+        ddc::DiscreteVector<detail::NonUniformBsplinesKnots<BSplines>> n_points_in_average(
+                BSplines::degree());
+
         ddc::for_each(bspline_domain, [&](ddc::DiscreteElement<BSplines> ib) {
             // Define the Greville points from the bspline knots
             greville_points[ib.uid()] = 0.0;
             ddc::DiscreteDomain<detail::NonUniformBsplinesKnots<BSplines>> sub_domain(
                     ddc::discrete_space<BSplines>().get_first_support_knot(ib) + 1,
-                    BSplines::degree());
+                    n_points_in_average);
             ddc::for_each(sub_domain, [&](auto ik) {
                 greville_points[ib.uid()] += ddc::coordinate(ik);
             });
-            greville_points[ib.uid()] /= BSplines::degree();
+            greville_points[ib.uid()] /= n_points_in_average.value();
         });
 
         std::vector<double> temp_knots(BSplines::degree());

--- a/include/ddc/kernels/splines/greville_interpolation_points.hpp
+++ b/include/ddc/kernels/splines/greville_interpolation_points.hpp
@@ -67,7 +67,7 @@ class GrevilleInterpolationPoints
                 = ddc::discrete_space<BSplines>().full_domain().take_first(
                         ddc::DiscreteVector<BSplines>(ddc::discrete_space<BSplines>().nbasis()));
 
-        ddc::DiscreteVector<detail::NonUniformBsplinesKnots<BSplines>> n_points_in_average(
+        ddc::DiscreteVector<NonUniformBsplinesKnots<BSplines>> n_points_in_average(
                 BSplines::degree());
 
         ddc::DiscreteElement<BSplines> ib0(bspline_domain.front());
@@ -75,7 +75,7 @@ class GrevilleInterpolationPoints
         ddc::for_each(bspline_domain, [&](ddc::DiscreteElement<BSplines> ib) {
             // Define the Greville points from the bspline knots
             greville_points[ib - ib0] = 0.0;
-            ddc::DiscreteDomain<detail::NonUniformBsplinesKnots<BSplines>> sub_domain(
+            ddc::DiscreteDomain<NonUniformBsplinesKnots<BSplines>> sub_domain(
                     ddc::discrete_space<BSplines>().get_first_support_knot(ib) + 1,
                     n_points_in_average);
             ddc::for_each(sub_domain, [&](auto ik) {

--- a/include/ddc/kernels/splines/knots_as_interpolation_points.hpp
+++ b/include/ddc/kernels/splines/knots_as_interpolation_points.hpp
@@ -49,9 +49,11 @@ public:
         } else {
             using SamplingImpl = typename Sampling::template Impl<Sampling, Kokkos::HostSpace>;
             std::vector<double> knots(ddc::discrete_space<BSplines>().npoints());
-            for (int i(0); i < ddc::discrete_space<BSplines>().npoints(); ++i) {
-                knots[i] = ddc::discrete_space<BSplines>().get_knot(i);
-            }
+            ddc::DiscreteDomain<typename BSplines::knot_mesh_type> break_point_domain(
+                    ddc::discrete_space<BSplines>().break_point_domain());
+            ddc::for_each(break_point_domain, [&](ddc::DiscreteElement<typename BSplines::knot_mesh_type> ik) {
+                knots[ik - break_point_domain.front()] = ddc::coordinate(ik);
+            });
             return SamplingImpl(knots);
         }
     }

--- a/include/ddc/kernels/splines/knots_as_interpolation_points.hpp
+++ b/include/ddc/kernels/splines/knots_as_interpolation_points.hpp
@@ -51,9 +51,11 @@ public:
             std::vector<double> knots(ddc::discrete_space<BSplines>().npoints());
             ddc::DiscreteDomain<typename BSplines::knot_mesh_type> break_point_domain(
                     ddc::discrete_space<BSplines>().break_point_domain());
-            ddc::for_each(break_point_domain, [&](ddc::DiscreteElement<typename BSplines::knot_mesh_type> ik) {
-                knots[ik - break_point_domain.front()] = ddc::coordinate(ik);
-            });
+            ddc::for_each(
+                    break_point_domain,
+                    [&](ddc::DiscreteElement<typename BSplines::knot_mesh_type> ik) {
+                        knots[ik - break_point_domain.front()] = ddc::coordinate(ik);
+                    });
             return SamplingImpl(knots);
         }
     }


### PR DESCRIPTION
Use DDC concepts for B-spline knots.

- Rename `mesh_type` -> `knot_mesh_type` and make it public
- Remove `get_knot` function
- Modify `get_first_support_knot` and `get_last_support_knot` to return `DiscreteElement`s
- Remove arithmetic on `uid` objects