### PR TITLE
Make knot dimension into bspline tag

### DIFF
--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -23,7 +23,11 @@ namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(SPLINES_CPP)
         static constexpr bool PERIODIC = true;
     };
 
-    struct BSplinesX : ddc::UniformBSplines<X, s_degree_x>
+    struct KnotsX : ddc::UniformPointSampling<X>
+    {
+    };
+
+    struct BSplinesX : ddc::UniformBSplines<KnotsX, s_degree_x>
     {
     };
     using GrevillePoints = ddc::GrevilleInterpolationPoints<
@@ -176,7 +180,7 @@ static void characteristics_advection(benchmark::State& state)
     /// variables, which is always a bad idea.       ///
     ////////////////////////////////////////////////////
     ddc::detail::g_discrete_space_dual<BSplinesX>.reset();
-    ddc::detail::g_discrete_space_dual<ddc::UniformBsplinesKnots<BSplinesX>>.reset();
+    ddc::detail::g_discrete_space_dual<KnotsX>.reset();
     ddc::detail::g_discrete_space_dual<DDimX>.reset();
     ddc::detail::g_discrete_space_dual<DDimY>.reset();
     ////////////////////////////////////////////////////

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -23,9 +23,16 @@ struct X
 };
 //! [X-dimension]
 
+//! [X-knot-discretization]
+/// The uniform discretization describing the knots of the splines in the X direction
+struct UKnotX : ddc::UniformPointSampling<X>
+{
+};
+//! [X-knot-discretization]
+
 //! [X-discretization]
 /// A uniform discretization of X
-struct BSplinesX : ddc::UniformBSplines<X, s_degree_x>
+struct BSplinesX : ddc::UniformBSplines<UKnotX, s_degree_x>
 {
 };
 using GrevillePoints = ddc::GrevilleInterpolationPoints<

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -23,28 +23,24 @@ struct NonUniformBSplinesBase
 
 } // namespace detail
 
-template <class T>
-struct NonUniformBsplinesKnots : NonUniformPointSampling<typename T::tag_type>
-{
-};
-
 /**
  * The type of a non-uniform 1D spline basis (B-spline).
  *
  * Knots for non-uniform B-splines are non-uniformly distributed (no assumption is made on the uniformity of their distribution,
  * the associated discrete dimension is a NonUniformPointSampling).
  *
- * @tparam Tag The tag identifying the continuous dimension on which the support of the B-spline functions are defined.
+ * @tparam tag_type The tag identifying the continuous dimension on which the support of the B-spline functions are defined.
  * @tparam D The degree of the B-splines.
  */
-template <class Tag, std::size_t D>
+template <class NonUniformBsplinesKnots, std::size_t D>
 class NonUniformBSplines : detail::NonUniformBSplinesBase
 {
     static_assert(D > 0, "Parameter `D` must be positive");
+    static_assert(is_non_uniform_point_sampling_v<NonUniformBsplinesKnots>);
 
 public:
     /// @brief The tag identifying the continuous dimension on which the support of the B-splines are defined.
-    using tag_type = Tag;
+    using tag_type = NonUniformBsplinesKnots::continuous_dimension_type;
 
     /// @brief The discrete dimension identifying B-splines.
     using discrete_dimension_type = NonUniformBSplines;
@@ -64,7 +60,7 @@ public:
      */
     static constexpr bool is_periodic() noexcept
     {
-        return Tag::PERIODIC;
+        return tag_type::PERIODIC;
     }
 
     /** @brief Indicates if the B-splines are uniform or not (this is not the case here).
@@ -89,7 +85,7 @@ public:
 
     public:
         /// @brief The type of the knots defining the B-splines.
-        using knot_mesh_type = NonUniformBsplinesKnots<DDim>;
+        using knot_mesh_type = NonUniformBsplinesKnots;
 
         /// @brief The type of the discrete dimension representing the B-splines.
         using discrete_dimension_type = NonUniformBSplines;
@@ -117,7 +113,7 @@ public:
          *
          * @param breaks The std::initializer_list of the coordinates of break points.
          */
-        explicit Impl(std::initializer_list<ddc::Coordinate<Tag>> breaks)
+        explicit Impl(std::initializer_list<ddc::Coordinate<tag_type>> breaks)
             : Impl(breaks.begin(), breaks.end())
         {
         }
@@ -129,7 +125,7 @@ public:
          *
          * @param breaks The std::vector of the coordinates of break points.
          */
-        explicit Impl(std::vector<ddc::Coordinate<Tag>> const& breaks)
+        explicit Impl(std::vector<ddc::Coordinate<tag_type>> const& breaks)
             : Impl(breaks.begin(), breaks.end())
         {
         }
@@ -208,7 +204,7 @@ public:
          * @return The index of the first B-spline which is evaluated.
          */
         KOKKOS_INLINE_FUNCTION discrete_element_type
-        eval_basis(DSpan1D values, ddc::Coordinate<Tag> const& x) const;
+        eval_basis(DSpan1D values, ddc::Coordinate<tag_type> const& x) const;
 
         /** @brief Evaluates non-zero B-spline derivatives at a given coordinate
          *
@@ -223,7 +219,7 @@ public:
          * @return The index of the first B-spline which is derivated.
          */
         KOKKOS_INLINE_FUNCTION discrete_element_type
-        eval_deriv(DSpan1D derivs, ddc::Coordinate<Tag> const& x) const;
+        eval_deriv(DSpan1D derivs, ddc::Coordinate<tag_type> const& x) const;
 
         /** @brief Evaluates non-zero B-spline values and \f$n\f$ derivatives at a given coordinate
          *
@@ -240,7 +236,7 @@ public:
          */
         KOKKOS_INLINE_FUNCTION discrete_element_type eval_basis_and_n_derivs(
                 ddc::DSpan2D derivs,
-                ddc::Coordinate<Tag> const& x,
+                ddc::Coordinate<tag_type> const& x,
                 std::size_t n) const;
 
         /** @brief Compute the integrals of the B-splines.
@@ -290,7 +286,7 @@ public:
          *
          * @return Coordinate of the lower bound of the domain.
          */
-        KOKKOS_INLINE_FUNCTION ddc::Coordinate<Tag> rmin() const noexcept
+        KOKKOS_INLINE_FUNCTION ddc::Coordinate<tag_type> rmin() const noexcept
         {
             return ddc::coordinate(m_break_point_domain.front());
         }
@@ -299,7 +295,7 @@ public:
          *
          * @return Coordinate of the upper bound of the domain.
          */
-        KOKKOS_INLINE_FUNCTION ddc::Coordinate<Tag> rmax() const noexcept
+        KOKKOS_INLINE_FUNCTION ddc::Coordinate<tag_type> rmax() const noexcept
         {
             return ddc::coordinate(m_break_point_domain.back());
         }
@@ -391,7 +387,7 @@ public:
          * @returns The DiscreteElement describing the knot at the lower bound of the cell of interest.
          */
         KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<knot_mesh_type> find_cell_start(
-                ddc::Coordinate<Tag> const& x) const;
+                ddc::Coordinate<tag_type> const& x) const;
     };
 };
 
@@ -408,10 +404,10 @@ struct is_non_uniform_bsplines : public std::is_base_of<detail::NonUniformBSplin
 template <class DDim>
 constexpr bool is_non_uniform_bsplines_v = is_non_uniform_bsplines<DDim>::value;
 
-template <class Tag, std::size_t D>
+template <class NonUniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
 template <class RandomIt>
-NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::Impl(
+NonUniformBSplines<NonUniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::Impl(
         RandomIt const break_begin,
         RandomIt const break_end)
     : m_domain(
@@ -424,15 +420,15 @@ NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::Impl(
               ddc::DiscreteVector<knot_mesh_type>(
                       (break_end - break_begin))) // Create a mesh of break points
 {
-    std::vector<ddc::Coordinate<Tag>> knots((break_end - break_begin) + 2 * degree());
+    std::vector<ddc::Coordinate<tag_type>> knots((break_end - break_begin) + 2 * degree());
     // Fill the provided knots
     int ii = 0;
     for (RandomIt it = break_begin; it < break_end; ++it) {
         knots[degree() + ii] = *it;
         ++ii;
     }
-    ddc::Coordinate<Tag> const rmin = knots[degree()];
-    ddc::Coordinate<Tag> const rmax = knots[(break_end - break_begin) + degree() - 1];
+    ddc::Coordinate<tag_type> const rmin = knots[degree()];
+    ddc::Coordinate<tag_type> const rmax = knots[(break_end - break_begin) + degree() - 1];
     assert(rmin < rmax);
 
     // Fill out the extra knots
@@ -452,10 +448,10 @@ NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::Impl(
     ddc::init_discrete_space<knot_mesh_type>(knots);
 }
 
-template <class Tag, std::size_t D>
+template <class NonUniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
-        Impl<DDim, MemorySpace>::eval_basis(DSpan1D values, ddc::Coordinate<Tag> const& x) const
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<NonUniformBsplinesKnots, D>::
+        Impl<DDim, MemorySpace>::eval_basis(DSpan1D values, ddc::Coordinate<tag_type> const& x) const
 {
     assert(values.size() == D + 1);
 
@@ -492,10 +488,10 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
     return get_first_bspline_in_cell(icell);
 }
 
-template <class Tag, std::size_t D>
+template <class NonUniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
-        Impl<DDim, MemorySpace>::eval_deriv(DSpan1D derivs, ddc::Coordinate<Tag> const& x) const
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<NonUniformBsplinesKnots, D>::
+        Impl<DDim, MemorySpace>::eval_deriv(DSpan1D derivs, ddc::Coordinate<tag_type> const& x) const
 {
     std::array<double, degree()> left;
     std::array<double, degree()> right;
@@ -551,12 +547,12 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
     return get_first_bspline_in_cell(icell);
 }
 
-template <class Tag, std::size_t D>
+template <class NonUniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<NonUniformBsplinesKnots, D>::
         Impl<DDim, MemorySpace>::eval_basis_and_n_derivs(
                 ddc::DSpan2D const derivs,
-                ddc::Coordinate<Tag> const& x,
+                ddc::Coordinate<tag_type> const& x,
                 std::size_t const n) const
 {
     std::array<double, degree()> left;
@@ -657,11 +653,11 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<Tag, D>::
     return get_first_bspline_in_cell(icell);
 }
 
-template <class Tag, std::size_t D>
+template <class NonUniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<NonUniformBsplinesKnots<DDim>> NonUniformBSplines<
-        Tag,
-        D>::Impl<DDim, MemorySpace>::find_cell_start(ddc::Coordinate<Tag> const& x) const
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<NonUniformBsplinesKnots> NonUniformBSplines<
+        NonUniformBsplinesKnots,
+        D>::Impl<DDim, MemorySpace>::find_cell_start(ddc::Coordinate<tag_type> const& x) const
 {
     assert(x <= rmax());
     assert(x >= rmin());
@@ -686,11 +682,11 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<NonUniformBsplinesKnots<DDim>> NonUn
     return icell;
 }
 
-template <class Tag, std::size_t D>
+template <class NonUniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
 template <class Layout, class MemorySpace2>
 KOKKOS_INLINE_FUNCTION ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>, Layout, MemorySpace2>
-NonUniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::integrals(
+NonUniformBSplines<NonUniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::integrals(
         ddc::ChunkSpan<double, discrete_domain_type, Layout, MemorySpace2> int_vals) const
 {
     if constexpr (is_periodic()) {

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -42,6 +42,9 @@ public:
     /// @brief The tag identifying the continuous dimension on which the support of the B-splines are defined.
     using tag_type = NonUniformBsplinesKnots::continuous_dimension_type;
 
+    /// @brief The type of the knots defining the B-splines.
+    using knot_mesh_type = NonUniformBsplinesKnots;
+
     /// @brief The discrete dimension identifying B-splines.
     using discrete_dimension_type = NonUniformBSplines;
 
@@ -84,9 +87,6 @@ public:
         friend class Impl;
 
     public:
-        /// @brief The type of the knots defining the B-splines.
-        using knot_mesh_type = NonUniformBsplinesKnots;
-
         /// @brief The type of the discrete dimension representing the B-splines.
         using discrete_dimension_type = NonUniformBSplines;
 

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -29,7 +29,7 @@ struct NonUniformBSplinesBase
  * Knots for non-uniform B-splines are non-uniformly distributed (no assumption is made on the uniformity of their distribution,
  * the associated discrete dimension is a NonUniformPointSampling).
  *
- * @tparam tag_type The tag identifying the continuous dimension on which the support of the B-spline functions are defined.
+ * @tparam NonUniformBsplinesKnots The tag identifying the dimension on which the knots of the B-spline functions are defined.
  * @tparam D The degree of the B-splines.
  */
 template <class NonUniformBsplinesKnots, std::size_t D>

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -40,7 +40,7 @@ class NonUniformBSplines : detail::NonUniformBSplinesBase
 
 public:
     /// @brief The tag identifying the continuous dimension on which the support of the B-splines are defined.
-    using tag_type = NonUniformBsplinesKnots::continuous_dimension_type;
+    using tag_type = typename NonUniformBsplinesKnots::continuous_dimension_type;
 
     /// @brief The type of the knots defining the B-splines.
     using knot_mesh_type = NonUniformBsplinesKnots;

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -451,7 +451,8 @@ NonUniformBSplines<NonUniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::Impl(
 template <class NonUniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
 KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<NonUniformBsplinesKnots, D>::
-        Impl<DDim, MemorySpace>::eval_basis(DSpan1D values, ddc::Coordinate<tag_type> const& x) const
+        Impl<DDim, MemorySpace>::eval_basis(DSpan1D values, ddc::Coordinate<tag_type> const& x)
+                const
 {
     assert(values.size() == D + 1);
 
@@ -491,7 +492,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<NonUniformB
 template <class NonUniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
 KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<NonUniformBsplinesKnots, D>::
-        Impl<DDim, MemorySpace>::eval_deriv(DSpan1D derivs, ddc::Coordinate<tag_type> const& x) const
+        Impl<DDim, MemorySpace>::eval_deriv(DSpan1D derivs, ddc::Coordinate<tag_type> const& x)
+                const
 {
     std::array<double, degree()> left;
     std::array<double, degree()> right;

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -112,7 +112,10 @@ public:
          * @param rmax    the real ddc::coordinate of the last knot
          * @param ncells the number of cells in the range [rmin, rmax]
          */
-        explicit Impl(ddc::Coordinate<tag_type> rmin, ddc::Coordinate<tag_type> rmax, std::size_t ncells)
+        explicit Impl(
+                ddc::Coordinate<tag_type> rmin,
+                ddc::Coordinate<tag_type> rmax,
+                std::size_t ncells)
             : m_domain(
                     ddc::DiscreteElement<knot_mesh_type>(0),
                     ddc::DiscreteVector<knot_mesh_type>(
@@ -398,8 +401,8 @@ constexpr bool is_uniform_bsplines_v = is_uniform_bsplines<DDim>::value;
 
 template <class UniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::
-        eval_basis(
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBsplinesKnots, D>::
+        Impl<DDim, MemorySpace>::eval_basis(
                 DSpan1D values,
                 ddc::Coordinate<tag_type> const& x,
                 [[maybe_unused]] std::size_t const deg) const
@@ -432,8 +435,9 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBspline
 
 template <class UniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::
-        eval_deriv(DSpan1D derivs, ddc::Coordinate<tag_type> const& x) const
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBsplinesKnots, D>::Impl<
+        DDim,
+        MemorySpace>::eval_deriv(DSpan1D derivs, ddc::Coordinate<tag_type> const& x) const
 {
     assert(derivs.size() == degree() + 1);
 
@@ -475,8 +479,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBspline
 
 template <class UniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::
-        eval_basis_and_n_derivs(
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBsplinesKnots, D>::
+        Impl<DDim, MemorySpace>::eval_basis_and_n_derivs(
                 ddc::DSpan2D const derivs,
                 ddc::Coordinate<tag_type> const& x,
                 std::size_t const n) const
@@ -568,10 +572,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBspline
 
 template <class UniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION void UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::get_icell_and_offset(
-        int& icell,
-        double& offset,
-        ddc::Coordinate<tag_type> const& x) const
+KOKKOS_INLINE_FUNCTION void UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::
+        get_icell_and_offset(int& icell, double& offset, ddc::Coordinate<tag_type> const& x) const
 {
     assert(x >= rmin());
     assert(x <= rmax());

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -23,28 +23,24 @@ struct UniformBSplinesBase
 
 } // namespace detail
 
-template <class T>
-struct UniformBsplinesKnots : UniformPointSampling<typename T::tag_type>
-{
-};
-
 /**
  * The type of a uniform 1D spline basis (B-spline).
  *
  * Knots for uniform B-splines are uniformly distributed (the associated discrete dimension
  * is a UniformPointSampling).
  *
- * @tparam Tag The tag identifying the continuous dimension on which the support of the B-spline functions are defined.
+ * @tparam tag_type The tag identifying the continuous dimension on which the support of the B-spline functions are defined.
  * @tparam D The degree of the B-splines.
  */
-template <class Tag, std::size_t D>
+template <class UniformBsplinesKnots, std::size_t D>
 class UniformBSplines : detail::UniformBSplinesBase
 {
     static_assert(D > 0, "Parameter `D` must be positive");
+    static_assert(is_uniform_point_sampling_v<UniformBsplinesKnots>);
 
 public:
     /// @brief The tag identifying the continuous dimension on which the support of the B-splines are defined.
-    using tag_type = Tag;
+    using tag_type = UniformBsplinesKnots::continuous_dimension_type;
 
     /// @brief The discrete dimension representing B-splines.
     using discrete_dimension_type = UniformBSplines;
@@ -64,7 +60,7 @@ public:
      */
     static constexpr bool is_periodic() noexcept
     {
-        return Tag::PERIODIC;
+        return tag_type::PERIODIC;
     }
 
     /** @brief Indicates if the B-splines are uniform or not (this is the case here).
@@ -89,7 +85,7 @@ public:
 
     public:
         /// @brief The type of the knots defining the B-splines.
-        using knot_mesh_type = UniformBsplinesKnots<DDim>;
+        using knot_mesh_type = UniformBsplinesKnots;
 
         /// @brief The type of the discrete dimension representing the B-splines.
         using discrete_dimension_type = UniformBSplines;
@@ -116,7 +112,7 @@ public:
          * @param rmax    the real ddc::coordinate of the last knot
          * @param ncells the number of cells in the range [rmin, rmax]
          */
-        explicit Impl(ddc::Coordinate<Tag> rmin, ddc::Coordinate<Tag> rmax, std::size_t ncells)
+        explicit Impl(ddc::Coordinate<tag_type> rmin, ddc::Coordinate<tag_type> rmax, std::size_t ncells)
             : m_domain(
                     ddc::DiscreteElement<knot_mesh_type>(0),
                     ddc::DiscreteVector<knot_mesh_type>(
@@ -180,7 +176,7 @@ public:
          * @return The index of the first B-spline which is evaluated.
          */
         KOKKOS_INLINE_FUNCTION discrete_element_type
-        eval_basis(DSpan1D values, ddc::Coordinate<Tag> const& x) const
+        eval_basis(DSpan1D values, ddc::Coordinate<tag_type> const& x) const
         {
             assert(values.size() == degree() + 1);
             return eval_basis(values, x, degree());
@@ -199,7 +195,7 @@ public:
          * @return The index of the first B-spline which is evaluated.
          */
         KOKKOS_INLINE_FUNCTION discrete_element_type
-        eval_deriv(DSpan1D derivs, ddc::Coordinate<Tag> const& x) const;
+        eval_deriv(DSpan1D derivs, ddc::Coordinate<tag_type> const& x) const;
 
         /** @brief Evaluates non-zero B-spline values and \f$n\f$ derivatives at a given coordinate
          *
@@ -216,7 +212,7 @@ public:
          */
         KOKKOS_INLINE_FUNCTION discrete_element_type eval_basis_and_n_derivs(
                 ddc::DSpan2D derivs,
-                ddc::Coordinate<Tag> const& x,
+                ddc::Coordinate<tag_type> const& x,
                 std::size_t n) const;
 
         /** @brief Compute the integrals of the B-splines.
@@ -242,9 +238,9 @@ public:
          * @param[in] knot_idx Integer identifying index of the knot.
          * @return Coordinate of the knot.
          */
-        KOKKOS_INLINE_FUNCTION ddc::Coordinate<Tag> get_knot(int knot_idx) const noexcept
+        KOKKOS_INLINE_FUNCTION ddc::Coordinate<tag_type> get_knot(int knot_idx) const noexcept
         {
-            return ddc::Coordinate<Tag>(rmin() + knot_idx * ddc::step<knot_mesh_type>());
+            return ddc::Coordinate<tag_type>(rmin() + knot_idx * ddc::step<knot_mesh_type>());
         }
 
         /** @brief Returns the coordinate of the first support knot associated to a DiscreteElement identifying a B-spline.
@@ -294,7 +290,7 @@ public:
          *
          * @return Coordinate of the lower bound of the domain.
          */
-        KOKKOS_INLINE_FUNCTION ddc::Coordinate<Tag> rmin() const noexcept
+        KOKKOS_INLINE_FUNCTION ddc::Coordinate<tag_type> rmin() const noexcept
         {
             return ddc::coordinate(m_domain.front());
         }
@@ -303,7 +299,7 @@ public:
          *
          * @return Coordinate of the upper bound of the domain.
          */
-        KOKKOS_INLINE_FUNCTION ddc::Coordinate<Tag> rmax() const noexcept
+        KOKKOS_INLINE_FUNCTION ddc::Coordinate<tag_type> rmax() const noexcept
         {
             return ddc::coordinate(m_domain.back());
         }
@@ -378,12 +374,12 @@ public:
         }
 
         KOKKOS_INLINE_FUNCTION discrete_element_type
-        eval_basis(DSpan1D values, ddc::Coordinate<Tag> const& x, std::size_t degree) const;
+        eval_basis(DSpan1D values, ddc::Coordinate<tag_type> const& x, std::size_t degree) const;
 
         KOKKOS_INLINE_FUNCTION void get_icell_and_offset(
                 int& icell,
                 double& offset,
-                ddc::Coordinate<Tag> const& x) const;
+                ddc::Coordinate<tag_type> const& x) const;
     };
 };
 
@@ -400,12 +396,12 @@ struct is_uniform_bsplines : public std::is_base_of<detail::UniformBSplinesBase,
 template <class DDim>
 constexpr bool is_uniform_bsplines_v = is_uniform_bsplines<DDim>::value;
 
-template <class Tag, std::size_t D>
+template <class UniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::
         eval_basis(
                 DSpan1D values,
-                ddc::Coordinate<Tag> const& x,
+                ddc::Coordinate<tag_type> const& x,
                 [[maybe_unused]] std::size_t const deg) const
 {
     assert(values.size() == deg + 1);
@@ -434,10 +430,10 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<Tag, D>::Impl<
     return discrete_element_type(jmin);
 }
 
-template <class Tag, std::size_t D>
+template <class UniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::
-        eval_deriv(DSpan1D derivs, ddc::Coordinate<Tag> const& x) const
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::
+        eval_deriv(DSpan1D derivs, ddc::Coordinate<tag_type> const& x) const
 {
     assert(derivs.size() == degree() + 1);
 
@@ -477,12 +473,12 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<Tag, D>::Impl<
     return discrete_element_type(jmin);
 }
 
-template <class Tag, std::size_t D>
+template <class UniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::
+KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::
         eval_basis_and_n_derivs(
                 ddc::DSpan2D const derivs,
-                ddc::Coordinate<Tag> const& x,
+                ddc::Coordinate<tag_type> const& x,
                 std::size_t const n) const
 {
     std::array<double, (degree() + 1) * (degree() + 1)> ndu_ptr;
@@ -570,12 +566,12 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<Tag, D>::Impl<
     return discrete_element_type(jmin);
 }
 
-template <class Tag, std::size_t D>
+template <class UniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
-KOKKOS_INLINE_FUNCTION void UniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::get_icell_and_offset(
+KOKKOS_INLINE_FUNCTION void UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::get_icell_and_offset(
         int& icell,
         double& offset,
-        ddc::Coordinate<Tag> const& x) const
+        ddc::Coordinate<tag_type> const& x) const
 {
     assert(x >= rmin());
     assert(x <= rmax());
@@ -601,11 +597,11 @@ KOKKOS_INLINE_FUNCTION void UniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::ge
     }
 }
 
-template <class Tag, std::size_t D>
+template <class UniformBsplinesKnots, std::size_t D>
 template <class DDim, class MemorySpace>
 template <class Layout, class MemorySpace2>
 KOKKOS_INLINE_FUNCTION ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>, Layout, MemorySpace2>
-UniformBSplines<Tag, D>::Impl<DDim, MemorySpace>::integrals(
+UniformBSplines<UniformBsplinesKnots, D>::Impl<DDim, MemorySpace>::integrals(
         ddc::ChunkSpan<double, discrete_domain_type, Layout, MemorySpace2> int_vals) const
 {
     if constexpr (is_periodic()) {

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -40,7 +40,7 @@ class UniformBSplines : detail::UniformBSplinesBase
 
 public:
     /// @brief The tag identifying the continuous dimension on which the support of the B-splines are defined.
-    using tag_type = UniformBsplinesKnots::continuous_dimension_type;
+    using tag_type = typename UniformBsplinesKnots::continuous_dimension_type;
 
     /// @brief The type of the knots defining the B-splines.
     using knot_mesh_type = UniformBsplinesKnots;

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -29,7 +29,7 @@ struct UniformBSplinesBase
  * Knots for uniform B-splines are uniformly distributed (the associated discrete dimension
  * is a UniformPointSampling).
  *
- * @tparam tag_type The tag identifying the continuous dimension on which the support of the B-spline functions are defined.
+ * @tparam UniformBsplinesKnots The tag identifying the dimension on which the knots of the B-spline functions are defined.
  * @tparam D The degree of the B-splines.
  */
 template <class UniformBsplinesKnots, std::size_t D>

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -42,6 +42,9 @@ public:
     /// @brief The tag identifying the continuous dimension on which the support of the B-splines are defined.
     using tag_type = UniformBsplinesKnots::continuous_dimension_type;
 
+    /// @brief The type of the knots defining the B-splines.
+    using knot_mesh_type = UniformBsplinesKnots;
+
     /// @brief The discrete dimension representing B-splines.
     using discrete_dimension_type = UniformBSplines;
 
@@ -84,9 +87,6 @@ public:
         friend class Impl;
 
     public:
-        /// @brief The type of the knots defining the B-splines.
-        using knot_mesh_type = UniformBsplinesKnots;
-
         /// @brief The type of the discrete dimension representing the B-splines.
         using discrete_dimension_type = UniformBSplines;
 

--- a/include/ddc/kernels/splines/greville_interpolation_points.hpp
+++ b/include/ddc/kernels/splines/greville_interpolation_points.hpp
@@ -67,7 +67,7 @@ class GrevilleInterpolationPoints
                 = ddc::discrete_space<BSplines>().full_domain().take_first(
                         ddc::DiscreteVector<BSplines>(ddc::discrete_space<BSplines>().nbasis()));
 
-        ddc::DiscreteVector<NonUniformBsplinesKnots<BSplines>> n_points_in_average(
+        ddc::DiscreteVector<typename BSplines::knot_mesh_type> n_points_in_average(
                 BSplines::degree());
 
         ddc::DiscreteElement<BSplines> ib0(bspline_domain.front());
@@ -75,7 +75,7 @@ class GrevilleInterpolationPoints
         ddc::for_each(bspline_domain, [&](ddc::DiscreteElement<BSplines> ib) {
             // Define the Greville points from the bspline knots
             greville_points[ib - ib0] = 0.0;
-            ddc::DiscreteDomain<NonUniformBsplinesKnots<BSplines>> sub_domain(
+            ddc::DiscreteDomain<typename BSplines::knot_mesh_type> sub_domain(
                     ddc::discrete_space<BSplines>().get_first_support_knot(ib) + 1,
                     n_points_in_average);
             ddc::for_each(sub_domain, [&](auto ik) {

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -87,7 +87,9 @@ using GrevillePoints = ddc::GrevilleInterpolationPoints<BSpX, s_bcl, s_bcr>;
 
 #if defined(BSPLINES_TYPE_UNIFORM)
 template <typename X>
-struct Knots : ddc::UniformPointSampling<X> {};
+struct Knots : ddc::UniformPointSampling<X>
+{
+};
 template <typename X>
 struct BSplines : ddc::UniformBSplines<Knots<X>, s_degree>
 {
@@ -108,7 +110,9 @@ using IDim = IDim_<X, std::is_same_v<X, I1> || std::is_same_v<X, I2>>;
 
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
 template <typename X>
-struct Knots : ddc::NonUniformPointSampling<X> {};
+struct Knots : ddc::NonUniformPointSampling<X>
+{
+};
 template <typename X>
 struct BSplines : ddc::NonUniformBSplines<Knots<X>, s_degree>
 {

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -87,7 +87,9 @@ using GrevillePoints = ddc::GrevilleInterpolationPoints<BSpX, s_bcl, s_bcr>;
 
 #if defined(BSPLINES_TYPE_UNIFORM)
 template <typename X>
-struct BSplines : ddc::UniformBSplines<X, s_degree>
+struct Knots : ddc::UniformPointSampling<X> {};
+template <typename X>
+struct BSplines : ddc::UniformBSplines<Knots<X>, s_degree>
 {
 };
 
@@ -106,7 +108,9 @@ using IDim = IDim_<X, std::is_same_v<X, I1> || std::is_same_v<X, I2>>;
 
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
 template <typename X>
-struct BSplines : ddc::NonUniformBSplines<X, s_degree>
+struct Knots : ddc::NonUniformPointSampling<X> {};
+template <typename X>
+struct BSplines : ddc::NonUniformBSplines<Knots<X>, s_degree>
 {
 };
 

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -86,7 +86,9 @@ using GrevillePoints = ddc::GrevilleInterpolationPoints<BSpX, s_bcl, s_bcr>;
 
 #if defined(BSPLINES_TYPE_UNIFORM)
 template <typename X>
-struct Knots : ddc::UniformPointSampling<X> {};
+struct Knots : ddc::UniformPointSampling<X>
+{
+};
 template <typename X>
 struct BSplines : ddc::UniformBSplines<Knots<X>, s_degree_x>
 {
@@ -107,7 +109,9 @@ using IDim = IDim_<X, std::is_same_v<X, I>>;
 
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
 template <typename X>
-struct Knots : ddc::NonUniformPointSampling<X> {};
+struct Knots : ddc::NonUniformPointSampling<X>
+{
+};
 template <typename X>
 struct BSplines : ddc::NonUniformBSplines<Knots<X>, s_degree_x>
 {

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -86,7 +86,9 @@ using GrevillePoints = ddc::GrevilleInterpolationPoints<BSpX, s_bcl, s_bcr>;
 
 #if defined(BSPLINES_TYPE_UNIFORM)
 template <typename X>
-struct BSplines : ddc::UniformBSplines<X, s_degree_x>
+struct Knots : ddc::UniformPointSampling<X> {};
+template <typename X>
+struct BSplines : ddc::UniformBSplines<Knots<X>, s_degree_x>
 {
 };
 
@@ -105,7 +107,9 @@ using IDim = IDim_<X, std::is_same_v<X, I>>;
 
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
 template <typename X>
-struct BSplines : ddc::NonUniformBSplines<X, s_degree_x>
+struct Knots : ddc::NonUniformPointSampling<X> {};
+template <typename X>
+struct BSplines : ddc::NonUniformBSplines<Knots<X>, s_degree_x>
 {
 };
 template <class X>

--- a/tests/splines/bsplines.cpp
+++ b/tests/splines/bsplines.cpp
@@ -25,8 +25,8 @@ struct BSplinesFixture<std::tuple<
     {
         static constexpr bool PERIODIC = periodic;
     };
-    struct UKnotDimX : UniformPointSampling<DimX> {};
-    struct NUKnotDimX : NotUniformPointSampling<DimX> {};
+    struct UKnotDimX : ddc::UniformPointSampling<DimX> {};
+    struct NUKnotDimX : ddc::NonUniformPointSampling<DimX> {};
     struct UBSplinesX : ddc::UniformBSplines<UKnotDimX, D>
     {
     };

--- a/tests/splines/bsplines.cpp
+++ b/tests/splines/bsplines.cpp
@@ -25,8 +25,12 @@ struct BSplinesFixture<std::tuple<
     {
         static constexpr bool PERIODIC = periodic;
     };
-    struct UKnotDimX : ddc::UniformPointSampling<DimX> {};
-    struct NUKnotDimX : ddc::NonUniformPointSampling<DimX> {};
+    struct UKnotDimX : ddc::UniformPointSampling<DimX>
+    {
+    };
+    struct NUKnotDimX : ddc::NonUniformPointSampling<DimX>
+    {
+    };
     struct UBSplinesX : ddc::UniformBSplines<UKnotDimX, D>
     {
     };

--- a/tests/splines/bsplines.cpp
+++ b/tests/splines/bsplines.cpp
@@ -25,10 +25,12 @@ struct BSplinesFixture<std::tuple<
     {
         static constexpr bool PERIODIC = periodic;
     };
-    struct UBSplinesX : ddc::UniformBSplines<DimX, D>
+    struct UKnotDimX : UniformPointSampling<DimX> {};
+    struct NUKnotDimX : NotUniformPointSampling<DimX> {};
+    struct UBSplinesX : ddc::UniformBSplines<UKnotDimX, D>
     {
     };
-    struct NUBSplinesX : ddc::NonUniformBSplines<DimX, D>
+    struct NUBSplinesX : ddc::NonUniformBSplines<NUKnotDimX, D>
     {
     };
     static constexpr std::size_t spline_degree = D;

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -69,7 +69,9 @@ using GrevillePoints = ddc::
 
 #if defined(BSPLINES_TYPE_UNIFORM)
 template <typename X>
-struct BSplines : ddc::UniformBSplines<X, s_degree>
+struct Knots : ddc::UniformPointSampling<X> {};
+template <typename X>
+struct BSplines : ddc::UniformBSplines<Knots<X>, s_degree>
 {
 };
 
@@ -85,7 +87,9 @@ struct IDim
 
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
 template <typename X>
-struct BSplines : ddc::NonUniformBSplines<X, s_degree>
+struct Knots : ddc::NonUniformPointSampling<X> {};
+template <typename X>
+struct BSplines : ddc::NonUniformBSplines<Knots<X>, s_degree>
 {
 };
 

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -69,7 +69,9 @@ using GrevillePoints = ddc::
 
 #if defined(BSPLINES_TYPE_UNIFORM)
 template <typename X>
-struct Knots : ddc::UniformPointSampling<X> {};
+struct Knots : ddc::UniformPointSampling<X>
+{
+};
 template <typename X>
 struct BSplines : ddc::UniformBSplines<Knots<X>, s_degree>
 {
@@ -87,7 +89,9 @@ struct IDim
 
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
 template <typename X>
-struct Knots : ddc::NonUniformPointSampling<X> {};
+struct Knots : ddc::NonUniformPointSampling<X>
+{
+};
 template <typename X>
 struct BSplines : ddc::NonUniformBSplines<Knots<X>, s_degree>
 {

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -39,11 +39,13 @@ static constexpr ddc::BoundCond s_bcr = ddc::BoundCond::HERMITE;
 #endif
 
 #if defined(BSPLINES_TYPE_UNIFORM)
-struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+struct KnotsX : ddc::UniformPointSampling<DimX> {};
+struct BSplinesX : ddc::UniformBSplines<KnotsX, s_degree_x>
 {
 };
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
-struct BSplinesX : ddc::NonUniformBSplines<DimX, s_degree_x>
+struct KnotsX : ddc::NonUniformPointSampling<DimX> {};
+struct BSplinesX : ddc::NonUniformBSplines<KnotsX, s_degree_x>
 {
 };
 #endif

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -39,12 +39,16 @@ static constexpr ddc::BoundCond s_bcr = ddc::BoundCond::HERMITE;
 #endif
 
 #if defined(BSPLINES_TYPE_UNIFORM)
-struct KnotsX : ddc::UniformPointSampling<DimX> {};
+struct KnotsX : ddc::UniformPointSampling<DimX>
+{
+};
 struct BSplinesX : ddc::UniformBSplines<KnotsX, s_degree_x>
 {
 };
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
-struct KnotsX : ddc::NonUniformPointSampling<DimX> {};
+struct KnotsX : ddc::NonUniformPointSampling<DimX>
+{
+};
 struct BSplinesX : ddc::NonUniformBSplines<KnotsX, s_degree_x>
 {
 };

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -27,11 +27,13 @@ struct DimX
 static constexpr std::size_t s_degree_x = DEGREE_X;
 
 #if defined(BSPLINES_TYPE_UNIFORM)
-struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+struct KnotsX : ddc::UniformPointSampling<DimX> {};
+struct BSplinesX : ddc::UniformBSplines<KnotsX, s_degree_x>
 {
 };
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
-struct BSplinesX : ddc::NonUniformBSplines<DimX, s_degree_x>
+struct KnotsX : ddc::NonUniformPointSampling<DimX> {};
+struct BSplinesX : ddc::NonUniformBSplines<KnotsX, s_degree_x>
 {
 };
 #endif

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -27,13 +27,17 @@ struct DimX
 static constexpr std::size_t s_degree_x = DEGREE_X;
 
 #if defined(BSPLINES_TYPE_UNIFORM)
-struct KnotsX : ddc::UniformPointSampling<DimX> {};
-struct BSplinesX : ddc::UniformBSplines<KnotsX, s_degree_x>
+struct UKnotsX : ddc::UniformPointSampling<DimX>
+{
+};
+struct BSplinesX : ddc::UniformBSplines<UKnotsX, s_degree_x>
 {
 };
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
-struct KnotsX : ddc::NonUniformPointSampling<DimX> {};
-struct BSplinesX : ddc::NonUniformBSplines<KnotsX, s_degree_x>
+struct NUKnotsX : ddc::NonUniformPointSampling<DimX>
+{
+};
+struct BSplinesX : ddc::NonUniformBSplines<NUKnotsX, s_degree_x>
 {
 };
 #endif

--- a/tests/splines/periodic_spline_builder_ordered_points.cpp
+++ b/tests/splines/periodic_spline_builder_ordered_points.cpp
@@ -22,7 +22,11 @@ struct DimX
 
 static constexpr std::size_t s_degree_x = DEGREE_X;
 
-struct BSplinesX : ddc::NonUniformBSplines<DimX, s_degree_x>
+struct KnotsX : ddc::NonUniformPointSampling<DimX>
+{
+};
+
+struct BSplinesX : ddc::NonUniformBSplines<KnotsX, s_degree_x>
 {
 };
 

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -32,7 +32,9 @@ using GrevillePoints = ddc::
 
 #if defined(BSPLINES_TYPE_UNIFORM)
 template <typename X>
-struct Knots : ddc::UniformPointSampling<X> {};
+struct Knots : ddc::UniformPointSampling<X>
+{
+};
 template <typename X>
 struct BSplines : ddc::UniformBSplines<Knots<X>, s_degree_x>
 {
@@ -46,7 +48,9 @@ struct IDim : GrevillePoints<BSplines<X>>::interpolation_mesh_type
 
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
 template <typename X>
-struct Knots : ddc::NonUniformPointSampling<X> {};
+struct Knots : ddc::NonUniformPointSampling<X>
+{
+};
 template <typename X>
 struct BSplines : ddc::NonUniformBSplines<Knots<X>, s_degree_x>
 {

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -32,7 +32,9 @@ using GrevillePoints = ddc::
 
 #if defined(BSPLINES_TYPE_UNIFORM)
 template <typename X>
-struct BSplines : ddc::UniformBSplines<X, s_degree_x>
+struct Knots : ddc::UniformPointSampling<X> {};
+template <typename X>
+struct BSplines : ddc::UniformBSplines<Knots<X>, s_degree_x>
 {
 };
 
@@ -44,7 +46,9 @@ struct IDim : GrevillePoints<BSplines<X>>::interpolation_mesh_type
 
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
 template <typename X>
-struct BSplines : ddc::NonUniformBSplines<X, s_degree_x>
+struct Knots : ddc::NonUniformPointSampling<X> {};
+template <typename X>
+struct BSplines : ddc::NonUniformBSplines<Knots<X>, s_degree_x>
 {
 };
 


### PR DESCRIPTION
Make the knot dimension into a bspline tag in place of the continuous dimension. This ensures that multiple splines can be created along the same physical dimension but with different knots. Fixes #488 