### PR TITLE
Splines doc minor corrections

### DIFF
--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -155,9 +155,9 @@ public:
         template <class RandomIt>
         Impl(RandomIt breaks_begin, RandomIt breaks_end);
 
-        /** @brief Copy-constructs from another Impl with a different Kokkos memory space
+        /** @brief Copy-constructs from another Impl with a different Kokkos memory space.
          *
-         * @param impl A reference to the other Impl
+         * @param impl A reference to the other Impl.
          */
         template <class OriginMemorySpace>
         explicit Impl(Impl<DDim, OriginMemorySpace> const& impl)
@@ -166,32 +166,32 @@ public:
         {
         }
 
-        /** @brief Copy-constructs
+        /** @brief Copy-constructs.
          *
-         * @param x A reference to another Impl
+         * @param x A reference to another Impl.
          */
         Impl(Impl const& x) = default;
 
-        /** @brief Move-constructs
+        /** @brief Move-constructs.
          *
-         * @param x An rvalue to another Impl
+         * @param x An rvalue to another Impl.
          */
         Impl(Impl&& x) = default;
 
-        /// @brief Destructs
+        /// @brief Destructs.
         ~Impl() = default;
 
-        /** @brief Copy-assigns
+        /** @brief Copy-assigns.
          *
-         * @param x A reference to another Impl
-         * @return A reference to the copied Impl
+         * @param x A reference to another Impl.
+         * @return A reference to the copied Impl.
          */
         Impl& operator=(Impl const& x) = default;
 
-        /** @brief Move-assigns
+        /** @brief Move-assigns.
          *
-         * @param x An rvalue to another Impl
-         * @return A reference to the moved Impl
+         * @param x An rvalue to another Impl.
+         * @return A reference to this object.
          */
         Impl& operator=(Impl&& x) = default;
 

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -111,11 +111,11 @@ public:
     public:
         Impl() = default;
 
-        /** Constructs a spline basis (B-splines) with n equidistant knots over \f$[a, b]\f$
+        /** Constructs a spline basis (B-splines) with n equidistant knots over \f$[a, b]\f$.
          *
-         * @param rmin    the real ddc::coordinate of the first knot
-         * @param rmax    the real ddc::coordinate of the last knot
-         * @param ncells the number of cells in the range [rmin, rmax]
+         * @param rmin    the real ddc::coordinate of the first knot.
+         * @param rmax    the real ddc::coordinate of the last knot.
+         * @param ncells the number of cells in the range [rmin, rmax].
          */
         explicit Impl(ddc::Coordinate<Tag> rmin, ddc::Coordinate<Tag> rmax, std::size_t ncells)
         {
@@ -132,9 +132,9 @@ public:
                                     ddc::DiscreteVector<knot_mesh_type>(degree())));
         }
 
-        /** @brief Copy-constructs from another Impl with a different Kokkos memory space
+        /** @brief Copy-constructs from another Impl with a different Kokkos memory space.
          *
-         * @param impl A reference to the other Impl
+         * @param impl A reference to the other Impl.
          */
         template <class OriginMemorySpace>
         explicit Impl(Impl<DDim, OriginMemorySpace> const& impl)
@@ -143,32 +143,32 @@ public:
         {
         }
 
-        /** @brief Copy-constructs
+        /** @brief Copy-constructs.
          *
-         * @param x A reference to another Impl
+         * @param x A reference to another Impl.
          */
         Impl(Impl const& x) = default;
 
-        /** @brief Move-constructs
+        /** @brief Move-constructs.
          *
-         * @param x An rvalue to another Impl
+         * @param x An rvalue to another Impl.
          */
         Impl(Impl&& x) = default;
 
-        /// @brief Destructs
+        /// @brief Destructs.
         ~Impl() = default;
 
-        /** @brief Copy-assigns
+        /** @brief Copy-assigns.
          *
-         * @param x A reference to another Impl
-         * @return A reference to the copied Impl
+         * @param x A reference to another Impl.
+         * @return A reference to the copied Impl.
          */
         Impl& operator=(Impl const& x) = default;
 
-        /** @brief Move-assigns
+        /** @brief Move-assigns.
          *
-         * @param x An rvalue to another Impl
-         * @return A reference to the moved Impl
+         * @param x An rvalue to another Impl.
+         * @return A reference to this object.
          */
         Impl& operator=(Impl&& x) = default;
 

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -113,9 +113,9 @@ public:
 
         /** Constructs a spline basis (B-splines) with n equidistant knots over \f$[a, b]\f$.
          *
-         * @param rmin    the real ddc::coordinate of the first knot.
-         * @param rmax    the real ddc::coordinate of the last knot.
-         * @param ncells the number of cells in the range [rmin, rmax].
+         * @param rmin    The real ddc::coordinate of the first knot.
+         * @param rmax    The real ddc::coordinate of the last knot.
+         * @param ncells The number of cells in the range [rmin, rmax].
          */
         explicit Impl(ddc::Coordinate<Tag> rmin, ddc::Coordinate<Tag> rmax, std::size_t ncells)
         {

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -234,22 +234,22 @@ public:
                 preconditionner_max_block_size);
     }
 
-    /// @brief Copy-constructor is deleted
+    /// @brief Copy-constructor is deleted.
     SplineBuilder(SplineBuilder const& x) = delete;
 
-    /** @brief Move-constructs
+    /** @brief Move-constructs.
      *
      * @param x An rvalue to another SplineBuilder.
      */
     SplineBuilder(SplineBuilder&& x) = default;
 
-    /// @brief Destructs
+    /// @brief Destructs.
     ~SplineBuilder() = default;
 
-    /// @brief Copy-assignment is deleted
+    /// @brief Copy-assignment is deleted.
     SplineBuilder& operator=(SplineBuilder const& x) = delete;
 
-    /** @brief Move-assigns
+    /** @brief Move-assigns.
      *
      * @param x An rvalue to another SplineBuilder.
      * @return A reference to this object.

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -217,23 +217,23 @@ public:
     {
     }
 
-    /// @brief Copy-constructor is deleted
+    /// @brief Copy-constructor is deleted.
     SplineBuilder2D(SplineBuilder2D const& x) = delete;
 
     /**
-     * @brief Move-constructs
+     * @brief Move-constructs.
      *
      * @param x An rvalue to another SplineBuilder2D.
      */
     SplineBuilder2D(SplineBuilder2D&& x) = default;
 
-    /// @brief Destructs
+    /// @brief Destructs.
     ~SplineBuilder2D() = default;
 
-    /// @brief Copy-assignment is deleted
+    /// @brief Copy-assignment is deleted.
     SplineBuilder2D& operator=(SplineBuilder2D const& x) = delete;
 
-    /** @brief Move-assigns
+    /** @brief Move-assigns.
      *
      * @param x An rvalue to another SplineBuilder.
      * @return A reference to this object.


### PR DESCRIPTION
- Align bsplines move-constructor docstrings on SplineBuilder one.
- Add missing dots.