### PR TITLE
Optimize 3x3 blocks

### DIFF
--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -330,7 +330,7 @@ private:
      */
     batched_spline_tr_domain_type batched_spline_tr_domain() const noexcept
     {
-        int upper_block_size;
+        int upper_block_size = 0;
         if constexpr (Solver == ddc::SplineSolver::LAPACK && !bsplines_type::is_periodic()) {
             int lower_block_size;
             if constexpr (bsplines_type::is_uniform()) {
@@ -338,8 +338,6 @@ private:
             } else {
                 compute_block_sizes_non_uniform(lower_block_size, upper_block_size);
             }
-        } else if constexpr (Solver == ddc::SplineSolver::GINKGO) {
-            upper_block_size = 0;
         }
 
         return batched_spline_tr_domain_type(ddc::replace_dim_of<bsplines_type, bsplines_type>(

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -330,11 +330,16 @@ private:
      */
     batched_spline_tr_domain_type batched_spline_tr_domain() const noexcept
     {
-        int lower_block_size, upper_block_size;
-        if constexpr (bsplines_type::is_uniform()) {
-            compute_block_sizes_uniform(lower_block_size, upper_block_size);
-        } else {
-            compute_block_sizes_non_uniform(lower_block_size, upper_block_size);
+        int upper_block_size;
+        if constexpr (Solver == ddc::SplineSolver::LAPACK) {
+            int lower_block_size;
+            if constexpr (bsplines_type::is_uniform()) {
+                compute_block_sizes_uniform(lower_block_size, upper_block_size);
+            } else {
+                compute_block_sizes_non_uniform(lower_block_size, upper_block_size);
+            }
+        } else if constexpr (Solver == ddc::SplineSolver::GINKGO) {
+            upper_block_size = 0;
         }
 
         return batched_spline_tr_domain_type(ddc::replace_dim_of<bsplines_type, bsplines_type>(

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -330,11 +330,20 @@ private:
      */
     batched_spline_tr_domain_type batched_spline_tr_domain() const noexcept
     {
-        return batched_spline_tr_domain_type(
-                batched_spline_domain().restrict(ddc::DiscreteDomain<bsplines_type>(
+        int lower_block_size, upper_block_size;
+        if constexpr (bsplines_type::is_uniform()) {
+            compute_block_sizes_uniform(lower_block_size, upper_block_size);
+        } else {
+            compute_block_sizes_non_uniform(lower_block_size, upper_block_size);
+        }
+
+        return batched_spline_tr_domain_type(ddc::replace_dim_of<bsplines_type, bsplines_type>(
+                batched_spline_domain(),
+                ddc::DiscreteDomain<bsplines_type>(
                         ddc::DiscreteElement<bsplines_type>(0),
                         ddc::DiscreteVector<bsplines_type>(
-                                ddc::discrete_space<bsplines_type>().nbasis()))));
+                                ddc::discrete_space<bsplines_type>().nbasis()
+                                + upper_block_size))));
     }
 
 public:
@@ -870,7 +879,7 @@ operator()(
     // Create a 2D Kokkos::View to manage spline_tr as a matrix
     Kokkos::View<double**, Kokkos::LayoutRight, exec_space> bcoef_section(
             spline_tr.data_handle(),
-            ddc::discrete_space<bsplines_type>().nbasis(),
+            static_cast<std::size_t>(spline_tr.template extent<bsplines_type>()),
             batch_domain().size());
     // Compute spline coef
     matrix->solve(bcoef_section);

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -330,23 +330,12 @@ private:
      */
     batched_spline_tr_domain_type batched_spline_tr_domain() const noexcept
     {
-        int upper_block_size = 0;
-        if constexpr (Solver == ddc::SplineSolver::LAPACK && !bsplines_type::is_periodic()) {
-            int lower_block_size;
-            if constexpr (bsplines_type::is_uniform()) {
-                compute_block_sizes_uniform(lower_block_size, upper_block_size);
-            } else {
-                compute_block_sizes_non_uniform(lower_block_size, upper_block_size);
-            }
-        }
-
         return batched_spline_tr_domain_type(ddc::replace_dim_of<bsplines_type, bsplines_type>(
                 batched_spline_domain(),
                 ddc::DiscreteDomain<bsplines_type>(
                         ddc::DiscreteElement<bsplines_type>(0),
                         ddc::DiscreteVector<bsplines_type>(
-                                ddc::discrete_space<bsplines_type>().nbasis()
-                                + upper_block_size))));
+                                matrix->required_number_of_rhs_rows()))));
     }
 
 public:

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -324,7 +324,7 @@ private:
     /**
      * @brief Get the whole domain on which spline coefficients are defined, with the dimension of interest being the leading dimension.
      *
-     * This is used internally due to solver limitation and because it may be beneficial to computation performance.
+     * This is used internally due to solver limitation and because it may be beneficial to computation performance. For LAPACK backend and non-periodic upper boundary condition, we are using SplinesLinearSolver3x3Blocks which requires upper_block_size additional rows for internal operations.
      *
      * @return The (transposed) domain for the spline coefficients.
      */

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -324,14 +324,14 @@ private:
     /**
      * @brief Get the whole domain on which spline coefficients are defined, with the dimension of interest being the leading dimension.
      *
-     * This is used internally due to solver limitation and because it may be beneficial to computation performance. For LAPACK backend and non-periodic upper boundary condition, we are using SplinesLinearSolver3x3Blocks which requires upper_block_size additional rows for internal operations.
+     * This is used internally due to solver limitation and because it may be beneficial to computation performance. For LAPACK backend and non-periodic boundary condition, we are using SplinesLinearSolver3x3Blocks which requires upper_block_size additional rows for internal operations.
      *
      * @return The (transposed) domain for the spline coefficients.
      */
     batched_spline_tr_domain_type batched_spline_tr_domain() const noexcept
     {
         int upper_block_size;
-        if constexpr (Solver == ddc::SplineSolver::LAPACK) {
+        if constexpr (Solver == ddc::SplineSolver::LAPACK && !bsplines_type::is_periodic()) {
             int lower_block_size;
             if constexpr (bsplines_type::is_uniform()) {
                 compute_block_sizes_uniform(lower_block_size, upper_block_size);

--- a/include/ddc/kernels/splines/splines_linear_problem.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem.hpp
@@ -82,11 +82,19 @@ public:
     /**
      * @brief Get the required number of rows of the multi-rhs view passed to solve().
      *
-     * It is useful because SplinesLinearSolver3x3Blocks requires additional rows for internal operation.
+     * Implementations may require a number of rows larger than what `size` returns for optimization purposes.
      *
-     * @return The required number of rows of the multi-rhs view.
+     * @return The required number of rows of the multi-rhs view. It is guaranteed to be greater or equal to `size`.
      */
-    virtual std::size_t required_number_of_rhs_rows() const
+    std::size_t required_number_of_rhs_rows() const
+    {
+        std::size_t const nrows = impl_required_number_of_rhs_rows();
+        assert(nrows >= size());
+        return nrows;
+    }
+
+    // in private
+    virtual std::size_t impl_required_number_of_rhs_rows() const
     {
         return m_size;
     }

--- a/include/ddc/kernels/splines/splines_linear_problem.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem.hpp
@@ -78,6 +78,18 @@ public:
     {
         return m_size;
     }
+
+    /**
+     * @brief Get the required number of rows of the multi-rhs view passed to solve().
+     *
+     * It is useful because SplinesLinearSolver3x3Blocks requires additional rows for internal operation.
+     *
+     * @return The required number of rows of the multi-rhs view.
+     */
+    virtual std::size_t required_number_of_rhs_rows() const
+    {
+        return m_size;
+    }
 };
 
 /**

--- a/include/ddc/kernels/splines/splines_linear_problem.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem.hpp
@@ -93,7 +93,7 @@ public:
         return nrows;
     }
 
-    // in private
+private:
     virtual std::size_t impl_required_number_of_rhs_rows() const
     {
         return m_size;

--- a/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
@@ -182,7 +182,7 @@ public:
      * @param[in, out] b A 2D Kokkos::View storing the multiple right-hand sides of the problem and receiving the corresponding solution.
      * @param transpose Choose between the direct or transposed version of the linear problem.
      */
-    void solve(MultiRHS b, bool const transpose) const override
+    void solve(MultiRHS const b, bool const transpose) const override
     {
         assert(b.extent(0) == size() + m_top_size);
 

--- a/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
@@ -207,6 +207,18 @@ public:
                       transpose);
         interchange_rows_from_2_to_3_blocks_rhs(b);
     }
+
+    /**
+     * @brief Get the required number of rows of the multi-rhs view passed to solve().
+     *
+     * It returns size + top_size.
+     *
+     * @return The required number of rows of the multi-rhs view.
+     */
+    std::size_t required_number_of_rhs_rows() const override
+    {
+        return size() + m_top_size;
+    }
 };
 
 } // namespace ddc::detail

--- a/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
@@ -208,14 +208,8 @@ public:
         interchange_rows_from_2_to_3_blocks_rhs(b);
     }
 
-    /**
-     * @brief Get the required number of rows of the multi-rhs view passed to solve().
-     *
-     * It returns size + top_size.
-     *
-     * @return The required number of rows of the multi-rhs view.
-     */
-    std::size_t required_number_of_rhs_rows() const override
+private:
+    std::size_t impl_required_number_of_rhs_rows() const override
     {
         return size() + m_top_size;
     }

--- a/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
@@ -182,9 +182,7 @@ public:
      */
     void solve(MultiRHS b, bool const transpose) const override
     {
-        assert(b.extent(0) == size());
-
-        Kokkos::resize(b, size() + m_top_size, b.extent(1));
+        assert(b.extent(0) == size() + m_top_size);
 
         interchange_rows_from_3_to_2_blocks_rhs(b);
         SplinesLinearProblem2x2Blocks<ExecSpace>::
@@ -196,8 +194,6 @@ public:
                                       Kokkos::ALL),
                       transpose);
         interchange_rows_from_2_to_3_blocks_rhs(b);
-
-        Kokkos::resize(b, size(), b.extent(1));
     }
 };
 

--- a/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
@@ -169,9 +169,6 @@ private:
                                 std::size_t> {2 * m_top_size + nq, m_top_size + size()},
                         Kokkos::ALL);
 
-        // Need a buffer to prevent overlapping
-        MultiRHS const buffer = Kokkos::create_mirror(ExecSpace(), b_bottom);
-
         Kokkos::deep_copy(b_top, b_top_src);
         if (b_bottom.extent(0) > b_top.extent(0)) {
             // Need a buffer to prevent overlapping

--- a/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
@@ -125,11 +125,15 @@ private:
                                 std::size_t> {2 * m_top_size + nq, m_top_size + size()},
                         Kokkos::ALL);
 
-        // Need a buffer to prevent overlapping
-        MultiRHS const buffer = Kokkos::create_mirror(ExecSpace(), b_bottom);
+        if (b_bottom.extent(0) > b_top.extent(0)) {
+            // Need a buffer to prevent overlapping
+            MultiRHS const buffer = Kokkos::create_mirror(ExecSpace(), b_bottom);
 
-        Kokkos::deep_copy(buffer, b_bottom);
-        Kokkos::deep_copy(b_bottom_dst, buffer);
+            Kokkos::deep_copy(buffer, b_bottom);
+            Kokkos::deep_copy(b_bottom_dst, buffer);
+        } else {
+            Kokkos::deep_copy(b_bottom_dst, b_bottom);
+        }
         Kokkos::deep_copy(b_top_dst, b_top);
     }
 
@@ -169,8 +173,15 @@ private:
         MultiRHS const buffer = Kokkos::create_mirror(ExecSpace(), b_bottom);
 
         Kokkos::deep_copy(b_top, b_top_src);
-        Kokkos::deep_copy(buffer, b_bottom_src);
-        Kokkos::deep_copy(b_bottom, buffer);
+        if (b_bottom.extent(0) > b_top.extent(0)) {
+            // Need a buffer to prevent overlapping
+            MultiRHS const buffer = Kokkos::create_mirror(ExecSpace(), b_bottom);
+
+            Kokkos::deep_copy(buffer, b_bottom_src);
+            Kokkos::deep_copy(b_bottom, buffer);
+        } else {
+            Kokkos::deep_copy(b_bottom, b_bottom_src);
+        }
     }
 
 public:

--- a/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
@@ -96,9 +96,10 @@ private:
      * @brief Perform row interchanges on multiple right-hand sides to get a 2-blocks structure (matching the requirements
      * of the SplinesLinearProblem2x2Blocks solver).
      *
-     * |  b_top   |    | b_center |
-     * | b_center | -> |  b_top   | -- Considered as a
-     * | b_bottom |    | b_bottom | -- single bottom block
+     * |  b_top   |    |    -     |
+     * | b_center | -> | b_center |
+     * | b_bottom |    |  b_top   | -- Considered as a
+     * |    -     |    | b_bottom | -- single bottom block
      *
      * @param b The multiple right-hand sides.
      */
@@ -135,9 +136,10 @@ private:
     /**
      * @brief Perform row interchanges on multiple right-hand sides to restore its 3-blocks structure.
      *
-     * | b_center |    |  b_top   |
-     * |  b_top   | -> | b_center |
-     * | b_bottom |    | b_bottom |
+     * |    -     |    |  b_top   |
+     * | b_center | -> | b_center |
+     * |  b_top   |    | b_bottom |
+     * | b_bottom |    |    -     |
      *
      * @param b The multiple right-hand sides.
      */

--- a/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
@@ -190,7 +190,9 @@ public:
      *
      * Perform row interchanges on multiple right-hand sides to obtain a 2x2-blocks linear problem and call the SplinesLinearProblem2x2Blocks solver.
      *
-     * @param[in, out] b A 2D Kokkos::View storing the multiple right-hand sides of the problem and receiving the corresponding solution.
+     * This class requires an additional allocation corresponding to top_size rows for internal operation.
+     *
+     * @param[in, out] b A 2D Kokkos::View storing the multiple right-hand sides (+ additional garbage allocation) of the problem and receiving the corresponding solution.
      * @param transpose Choose between the direct or transposed version of the linear problem.
      */
     void solve(MultiRHS const b, bool const transpose) const override

--- a/tests/splines/matrix.cpp
+++ b/tests/splines/matrix.cpp
@@ -21,7 +21,6 @@ namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MATRIX_CPP)
     void fill_identity(
             ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS mat)
     {
-        assert(mat.extent(0) == mat.required_number_of_rhs_rows());
         for (std::size_t i(0); i < mat.extent(0); ++i) {
             for (std::size_t j(0); j < mat.extent(1); ++j) {
                 mat(i, j) = int(i == j);

--- a/tests/splines/matrix.cpp
+++ b/tests/splines/matrix.cpp
@@ -104,7 +104,7 @@ namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MATRIX_CPP)
         inv_ptr.sync_host();
 
         Kokkos::DualView<double*>
-                inv_tr_ptr("inv_tr_ptr", (matrix.required_number_of_rhs_rows()) * N);
+                inv_tr_ptr("inv_tr_ptr", matrix.required_number_of_rhs_rows() * N);
         ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS
                 inv_tr(inv_tr_ptr.h_view.data(), matrix.required_number_of_rhs_rows(), N);
         fill_identity(inv_tr);

--- a/tests/splines/matrix.cpp
+++ b/tests/splines/matrix.cpp
@@ -84,8 +84,6 @@ namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MATRIX_CPP)
     {
         const std::size_t N = matrix.size();
 
-        std::cout << "lul " << additional_rows;
-
         std::vector<double> val_ptr(N * N);
         ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS
                 val(val_ptr.data(), N, N);

--- a/tests/splines/matrix.cpp
+++ b/tests/splines/matrix.cpp
@@ -21,7 +21,6 @@ namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MATRIX_CPP)
     void fill_identity(
             ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS mat)
     {
-        assert(mat.extent(0) == mat.extent(1));
         for (std::size_t i(0); i < mat.extent(0); ++i) {
             for (std::size_t j(0); j < mat.extent(1); ++j) {
                 mat(i, j) = int(i == j);
@@ -80,9 +79,12 @@ namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MATRIX_CPP)
     }
 
     void solve_and_validate(
-            ddc::detail::SplinesLinearProblem<Kokkos::DefaultExecutionSpace> & matrix)
+            ddc::detail::SplinesLinearProblem<Kokkos::DefaultExecutionSpace> & matrix,
+            std::size_t const additional_rows = 0)
     {
         const std::size_t N = matrix.size();
+
+        std::cout << "lul " << additional_rows;
 
         std::vector<double> val_ptr(N * N);
         ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS
@@ -92,32 +94,36 @@ namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MATRIX_CPP)
 
         matrix.setup_solver();
 
-        Kokkos::DualView<double*> inv_ptr("inv_ptr", N * N);
+        Kokkos::DualView<double*> inv_ptr("inv_ptr", (N + additional_rows) * N);
         ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS
-                inv(inv_ptr.h_view.data(), N, N);
+                inv(inv_ptr.h_view.data(), N + additional_rows, N);
         fill_identity(inv);
         inv_ptr.modify_host();
         inv_ptr.sync_device();
-        matrix.solve(ddc::detail::SplinesLinearProblem<
-                     Kokkos::DefaultExecutionSpace>::MultiRHS(inv_ptr.d_view.data(), N, N));
+        matrix.solve(ddc::detail::SplinesLinearProblem<Kokkos::DefaultExecutionSpace>::
+                             MultiRHS(inv_ptr.d_view.data(), N + additional_rows, N));
         inv_ptr.modify_device();
         inv_ptr.sync_host();
 
-        Kokkos::DualView<double*> inv_tr_ptr("inv_tr_ptr", N * N);
+        Kokkos::DualView<double*> inv_tr_ptr("inv_tr_ptr", (N + additional_rows) * N);
         ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS
-                inv_tr(inv_tr_ptr.h_view.data(), N, N);
+                inv_tr(inv_tr_ptr.h_view.data(), N + additional_rows, N);
         fill_identity(inv_tr);
         inv_tr_ptr.modify_host();
         inv_tr_ptr.sync_device();
         matrix
                 .solve(ddc::detail::SplinesLinearProblem<Kokkos::DefaultExecutionSpace>::
-                               MultiRHS(inv_tr_ptr.d_view.data(), N, N),
+                               MultiRHS(inv_tr_ptr.d_view.data(), N + additional_rows, N),
                        true);
         inv_tr_ptr.modify_device();
         inv_tr_ptr.sync_host();
 
-        check_inverse(val, inv);
-        check_inverse_transpose(val, inv_tr);
+        check_inverse(
+                val,
+                Kokkos::subview(inv, std::pair<std::size_t, std::size_t> {0, N}, Kokkos::ALL));
+        check_inverse_transpose(
+                val,
+                Kokkos::subview(inv_tr, std::pair<std::size_t, std::size_t> {0, N}, Kokkos::ALL));
     }
 
 } // namespace )
@@ -252,12 +258,13 @@ TEST(Matrix, 3x3Blocks)
 {
     std::size_t const N = 10;
     std::size_t const k = 10;
+    std::size_t const top_size = 2;
     std::unique_ptr<ddc::detail::SplinesLinearProblem<Kokkos::DefaultExecutionSpace>> center_block
             = std::make_unique<
                     ddc::detail::SplinesLinearProblemDense<Kokkos::DefaultExecutionSpace>>(N - 5);
     std::unique_ptr<ddc::detail::SplinesLinearProblem<Kokkos::DefaultExecutionSpace>> matrix
             = std::make_unique<ddc::detail::SplinesLinearProblem3x3Blocks<
-                    Kokkos::DefaultExecutionSpace>>(N, 2, std::move(center_block));
+                    Kokkos::DefaultExecutionSpace>>(N, top_size, std::move(center_block));
 
     // Build a non-symmetric full-rank matrix (without zero)
     for (std::size_t i(0); i < N; ++i) {
@@ -271,7 +278,7 @@ TEST(Matrix, 3x3Blocks)
         }
     }
 
-    solve_and_validate(*matrix);
+    solve_and_validate(*matrix, top_size);
 }
 
 class MatrixSizesFixture : public testing::TestWithParam<std::tuple<std::size_t, std::size_t>>
@@ -346,9 +353,10 @@ TEST_P(MatrixSizesFixture, OffsetBanded)
 TEST_P(MatrixSizesFixture, 2x2Blocks)
 {
     auto const [N, k] = GetParam();
+    std::size_t const bottom_size = 3;
     std::unique_ptr<ddc::detail::SplinesLinearProblem<Kokkos::DefaultExecutionSpace>> matrix
             = ddc::detail::SplinesLinearProblemMaker::make_new_block_matrix_with_band_main_block<
-                    Kokkos::DefaultExecutionSpace>(N, k, k, false, 3);
+                    Kokkos::DefaultExecutionSpace>(N, k, k, false, bottom_size);
 
     // Build a non-symmetric full-rank band matrix
     for (std::size_t i(0); i < N; ++i) {
@@ -367,9 +375,11 @@ TEST_P(MatrixSizesFixture, 2x2Blocks)
 TEST_P(MatrixSizesFixture, 3x3Blocks)
 {
     auto const [N, k] = GetParam();
+    std::size_t const bottom_size = 3;
+    std::size_t const top_size = 2;
     std::unique_ptr<ddc::detail::SplinesLinearProblem<Kokkos::DefaultExecutionSpace>> matrix
             = ddc::detail::SplinesLinearProblemMaker::make_new_block_matrix_with_band_main_block<
-                    Kokkos::DefaultExecutionSpace>(N, k, k, false, 3, 2);
+                    Kokkos::DefaultExecutionSpace>(N, k, k, false, bottom_size, top_size);
 
     // Build a non-symmetric full-rank band matrix
     for (std::size_t i(0); i < N; ++i) {
@@ -382,7 +392,7 @@ TEST_P(MatrixSizesFixture, 3x3Blocks)
         }
     }
 
-    solve_and_validate(*matrix);
+    solve_and_validate(*matrix, top_size);
 }
 
 TEST_P(MatrixSizesFixture, PeriodicBand)


### PR DESCRIPTION
Avoid deep_copies of `b_center`

Profiling on reference case with GREVILLE shows a 45% perf improvement (with KK on GPU) with this patch.

The downside of it is the SplinesLinearProblem3x3Blocks requires an allocation of `b` with `top_size` additional rows (which makes the SplineBuilder a bit more complex it already is)