### PR TITLE
Readability improvement in splines tests

### DIFF
--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -390,7 +390,6 @@ static void Batched2dSplineTest()
                     derivs2_lhs1_host(e) = evaluator.deriv(x1, x0<I2>(), 0, deriv_idx + shift - 1);
                 });
 
-
         auto derivs2_lhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_lhs1_host);
         ddc::ChunkSpan derivs2_lhs1 = derivs2_lhs1_alloc.span_view();
 

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -296,9 +296,8 @@ static void Batched2dSplineTest()
     ddc::ChunkSpan vals1_host = vals1_host_alloc.span_view();
     evaluator_type<IDim<I1, I1, I2>, IDim<I2, I1, I2>> evaluator(dom_interpolation);
     evaluator(vals1_host);
-    ddc::Chunk vals1_alloc(dom_interpolation, ddc::KokkosAllocator<double, MemorySpace>());
+    auto vals1_alloc = ddc::create_mirror_view_and_copy(exec_space, vals1_host);
     ddc::ChunkSpan vals1 = vals1_alloc.span_view();
-    ddc::parallel_deepcopy(vals1, vals1_host);
 
     ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan vals = vals_alloc.span_view();
@@ -328,13 +327,8 @@ static void Batched2dSplineTest()
                     auto x2 = ddc::coordinate(ddc::DiscreteElement<IDim<I2, I1, I2>>(e));
                     derivs1_lhs1_host(e) = evaluator.deriv(x0<I1>(), x2, deriv_idx + shift - 1, 0);
                 });
-        ddc::Chunk derivs1_lhs1_alloc(
-                ddc::DiscreteDomain<
-                        ddc::Deriv<I1>,
-                        IDim<I2, I1, I2>>(derivs_domain1, interpolation_domain2),
-                ddc::KokkosAllocator<double, MemorySpace>());
+        auto derivs1_lhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_lhs1_host);
         ddc::ChunkSpan derivs1_lhs1 = derivs1_lhs1_alloc.span_view();
-        ddc::parallel_deepcopy(derivs1_lhs1, derivs1_lhs1_host);
 
         ddc::parallel_for_each(
                 exec_space,
@@ -361,13 +355,8 @@ static void Batched2dSplineTest()
                     auto x2 = ddc::coordinate(ddc::DiscreteElement<IDim<I2, I1, I2>>(e));
                     derivs1_rhs1_host(e) = evaluator.deriv(xN<I1>(), x2, deriv_idx + shift - 1, 0);
                 });
-        ddc::Chunk derivs1_rhs1_alloc(
-                ddc::DiscreteDomain<
-                        ddc::Deriv<I1>,
-                        IDim<I2, I1, I2>>(derivs_domain1, interpolation_domain2),
-                ddc::KokkosAllocator<double, MemorySpace>());
+        auto derivs1_rhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs1_rhs1_host);
         ddc::ChunkSpan derivs1_rhs1 = derivs1_rhs1_alloc.span_view();
-        ddc::parallel_deepcopy(derivs1_rhs1, derivs1_rhs1_host);
 
         ddc::parallel_for_each(
                 exec_space,
@@ -395,13 +384,9 @@ static void Batched2dSplineTest()
                     derivs2_lhs1_host(e) = evaluator.deriv(x1, x0<I2>(), 0, deriv_idx + shift - 1);
                 });
 
-        ddc::Chunk derivs2_lhs1_alloc(
-                ddc::DiscreteDomain<
-                        IDim<I1, I1, I2>,
-                        ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
-                ddc::KokkosAllocator<double, MemorySpace>());
+
+        auto derivs2_lhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_lhs1_host);
         ddc::ChunkSpan derivs2_lhs1 = derivs2_lhs1_alloc.span_view();
-        ddc::parallel_deepcopy(derivs2_lhs1, derivs2_lhs1_host);
 
         ddc::parallel_for_each(
                 exec_space,
@@ -429,11 +414,7 @@ static void Batched2dSplineTest()
                     derivs2_rhs1_host(e) = evaluator.deriv(x1, xN<I2>(), 0, deriv_idx + shift - 1);
                 });
 
-        ddc::Chunk derivs2_rhs1_alloc(
-                ddc::DiscreteDomain<
-                        IDim<I1, I1, I2>,
-                        ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
-                ddc::KokkosAllocator<double, MemorySpace>());
+        auto derivs2_rhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs2_rhs1_host);
         ddc::ChunkSpan derivs2_rhs1 = derivs2_rhs1_alloc.span_view();
         ddc::parallel_deepcopy(derivs2_rhs1, derivs2_rhs1_host);
 
@@ -485,26 +466,14 @@ static void Batched2dSplineTest()
                         = evaluator.deriv(xN<I1>(), xN<I2>(), ii + shift - 1, jj + shift - 1);
             }
         }
-        ddc::Chunk derivs_mixed_lhs_lhs1_alloc(
-                derivs_domain,
-                ddc::KokkosAllocator<double, MemorySpace>());
+        auto derivs_mixed_lhs_lhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs_lhs1_host);
         ddc::ChunkSpan derivs_mixed_lhs_lhs1 = derivs_mixed_lhs_lhs1_alloc.span_view();
-        ddc::parallel_deepcopy(derivs_mixed_lhs_lhs1, derivs_mixed_lhs_lhs1_host);
-        ddc::Chunk derivs_mixed_rhs_lhs1_alloc(
-                derivs_domain,
-                ddc::KokkosAllocator<double, MemorySpace>());
+        auto derivs_mixed_rhs_lhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs_lhs1_host);
         ddc::ChunkSpan derivs_mixed_rhs_lhs1 = derivs_mixed_rhs_lhs1_alloc.span_view();
-        ddc::parallel_deepcopy(derivs_mixed_rhs_lhs1, derivs_mixed_rhs_lhs1_host);
-        ddc::Chunk derivs_mixed_lhs_rhs1_alloc(
-                derivs_domain,
-                ddc::KokkosAllocator<double, MemorySpace>());
+        auto derivs_mixed_lhs_rhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_lhs_rhs1_host);
         ddc::ChunkSpan derivs_mixed_lhs_rhs1 = derivs_mixed_lhs_rhs1_alloc.span_view();
-        ddc::parallel_deepcopy(derivs_mixed_lhs_rhs1, derivs_mixed_lhs_rhs1_host);
-        ddc::Chunk derivs_mixed_rhs_rhs1_alloc(
-                derivs_domain,
-                ddc::KokkosAllocator<double, MemorySpace>());
+        auto derivs_mixed_rhs_rhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_mixed_rhs_rhs1_host);
         ddc::ChunkSpan derivs_mixed_rhs_rhs1 = derivs_mixed_rhs_rhs1_alloc.span_view();
-        ddc::parallel_deepcopy(derivs_mixed_rhs_rhs1, derivs_mixed_rhs_rhs1_host);
 
         ddc::parallel_for_each(
                 exec_space,

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -245,14 +245,14 @@ static void BatchedSplineTest()
     auto const dom_spline = spline_builder.batched_spline_domain();
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals1_host_alloc(
+    ddc::Chunk vals_1d_host_alloc(
             dom_interpolation,
             ddc::KokkosAllocator<double, Kokkos::DefaultHostExecutionSpace::memory_space>());
-    ddc::ChunkSpan vals1_host = vals1_host_alloc.span_view();
+    ddc::ChunkSpan vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<IDim<I, I>> evaluator(dom_interpolation);
-    evaluator(vals1_host);
-    auto vals1_alloc = ddc::create_mirror_view_and_copy(exec_space, vals1_host);
-    ddc::ChunkSpan vals1 = vals1_alloc.span_view();
+    evaluator(vals_1d_host);
+    auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
+    ddc::ChunkSpan vals_1d = vals_1d_alloc.span_view();
 
     ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan vals = vals_alloc.span_view();
@@ -260,7 +260,7 @@ static void BatchedSplineTest()
             exec_space,
             vals.domain(),
             KOKKOS_LAMBDA(Index<IDim<X, I>...> const e) {
-                vals(e) = vals1(ddc::select<IDim<I, I>>(e));
+                vals(e) = vals_1d(ddc::select<IDim<I, I>>(e));
             });
 
 #if defined(BC_HERMITE)
@@ -301,7 +301,6 @@ static void BatchedSplineTest()
         }
         auto derivs_rhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_rhs1_host);
         ddc::ChunkSpan derivs_rhs1 = derivs_rhs1_alloc.span_view();
-        ddc::parallel_deepcopy(derivs_rhs1, derivs_rhs1_host);
 
         ddc::parallel_for_each(
                 exec_space,

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -251,9 +251,8 @@ static void BatchedSplineTest()
     ddc::ChunkSpan vals1_host = vals1_host_alloc.span_view();
     evaluator_type<IDim<I, I>> evaluator(dom_interpolation);
     evaluator(vals1_host);
-    ddc::Chunk vals1_alloc(dom_interpolation, ddc::KokkosAllocator<double, MemorySpace>());
+    auto vals1_alloc = ddc::create_mirror_view_and_copy(exec_space, vals1_host);
     ddc::ChunkSpan vals1 = vals1_alloc.span_view();
-    ddc::parallel_deepcopy(vals1, vals1_host);
 
     ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan vals = vals_alloc.span_view();
@@ -278,9 +277,8 @@ static void BatchedSplineTest()
                     typename decltype(derivs_lhs1_host.domain())::discrete_element_type(ii))
                     = evaluator.deriv(x0<I>(), ii + shift - 1);
         }
-        ddc::Chunk derivs_lhs1_alloc(derivs_domain, ddc::KokkosAllocator<double, MemorySpace>());
+        auto derivs_lhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_lhs1_host);
         ddc::ChunkSpan derivs_lhs1 = derivs_lhs1_alloc.span_view();
-        ddc::parallel_deepcopy(derivs_lhs1, derivs_lhs1_host);
         ddc::parallel_for_each(
                 exec_space,
                 derivs_lhs.domain(),
@@ -301,7 +299,7 @@ static void BatchedSplineTest()
                     typename decltype(derivs_rhs1_host.domain())::discrete_element_type(ii))
                     = evaluator.deriv(xN<I>(), ii + shift - 1);
         }
-        ddc::Chunk derivs_rhs1_alloc(derivs_domain, ddc::KokkosAllocator<double, MemorySpace>());
+        auto derivs_rhs1_alloc = ddc::create_mirror_view_and_copy(exec_space, derivs_rhs1_host);
         ddc::ChunkSpan derivs_rhs1 = derivs_rhs1_alloc.span_view();
         ddc::parallel_deepcopy(derivs_rhs1, derivs_rhs1_host);
 

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -247,15 +247,15 @@ static void ExtrapolationRuleSplineTest()
     auto const dom_spline = spline_builder.batched_spline_domain();
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals1_cpu_alloc(
+    ddc::Chunk vals1_host_alloc(
             dom_interpolation,
             ddc::KokkosAllocator<double, Kokkos::DefaultHostExecutionSpace::memory_space>());
-    ddc::ChunkSpan vals1_cpu = vals1_cpu_alloc.span_view();
+    ddc::ChunkSpan vals1_host = vals1_host_alloc.span_view();
     evaluator_type<IDim<I1, I1, I2>, IDim<I2, I1, I2>> evaluator(dom_interpolation);
-    evaluator(vals1_cpu);
+    evaluator(vals1_host);
     ddc::Chunk vals1_alloc(dom_interpolation, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan vals1 = vals1_alloc.span_view();
-    ddc::parallel_deepcopy(vals1, vals1_cpu);
+    ddc::parallel_deepcopy(vals1, vals1_host);
 
     ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan vals = vals_alloc.span_view();

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -122,33 +122,33 @@ TEST(NonPeriodicSplineBuilderTest, Identity)
     evaluator(yvals.span_view());
 
     int constexpr shift = s_degree_x % 2; // shift = 0 for even order, 1 for odd order
-    ddc::Chunk Sderiv_lhs_alloc(derivs_domain, ddc::HostAllocator<double>());
-    ddc::ChunkSpan Sderiv_lhs = Sderiv_lhs_alloc.span_view();
+    ddc::Chunk derivs_lhs_alloc(derivs_domain, ddc::HostAllocator<double>());
+    ddc::ChunkSpan derivs_lhs = derivs_lhs_alloc.span_view();
     if (s_bcl == ddc::BoundCond::HERMITE) {
         for (ddc::DiscreteElement<ddc::Deriv<DimX>> const ii : derivs_domain) {
-            Sderiv_lhs(ii) = evaluator.deriv(x0, ii - derivs_domain.front() + shift);
+            derivs_lhs(ii) = evaluator.deriv(x0, ii - derivs_domain.front() + shift);
         }
     }
 
-    ddc::Chunk Sderiv_rhs_alloc(derivs_domain, ddc::HostAllocator<double>());
-    ddc::ChunkSpan Sderiv_rhs = Sderiv_rhs_alloc.span_view();
+    ddc::Chunk derivs_rhs_alloc(derivs_domain, ddc::HostAllocator<double>());
+    ddc::ChunkSpan derivs_rhs = derivs_rhs_alloc.span_view();
     if (s_bcr == ddc::BoundCond::HERMITE) {
         for (ddc::DiscreteElement<ddc::Deriv<DimX>> const ii : derivs_domain) {
-            Sderiv_rhs(ii) = evaluator.deriv(xN, ii - derivs_domain.front() + shift);
+            derivs_rhs(ii) = evaluator.deriv(xN, ii - derivs_domain.front() + shift);
         }
     }
 
 // 6. Finally build the spline by filling `coef`
 #if defined(BCL_HERMITE)
-    auto deriv_l = std::optional(Sderiv_lhs.span_cview());
+    auto deriv_l = std::optional(derivs_lhs.span_cview());
 #else
-    decltype(std::optional(Sderiv_lhs.span_cview())) deriv_l = std::nullopt;
+    decltype(std::optional(derivs_lhs.span_cview())) deriv_l = std::nullopt;
 #endif
 
 #if defined(BCR_HERMITE)
-    auto deriv_r = std::optional(Sderiv_rhs.span_cview());
+    auto deriv_r = std::optional(derivs_rhs.span_cview());
 #else
-    decltype(std::optional(Sderiv_rhs.span_cview())) deriv_r = std::nullopt;
+    decltype(std::optional(derivs_rhs.span_cview())) deriv_r = std::nullopt;
 #endif
 
     spline_builder(coef.span_view(), yvals.span_cview(), deriv_l, deriv_r);

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -150,15 +150,15 @@ static void PeriodicitySplineBuilderTest()
     ddc::DiscreteDomain<BSplines<X>> const dom_bsplines = spline_builder.spline_domain();
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals1_cpu_alloc(
+    ddc::Chunk vals1_host_alloc(
             dom_vals,
             ddc::KokkosAllocator<double, Kokkos::DefaultHostExecutionSpace::memory_space>());
-    ddc::ChunkSpan vals1_cpu = vals1_cpu_alloc.span_view();
+    ddc::ChunkSpan vals1_host = vals1_host_alloc.span_view();
     evaluator_type<IDim<X>> evaluator(dom_vals);
-    evaluator(vals1_cpu);
+    evaluator(vals1_host);
     ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan vals = vals_alloc.span_view();
-    ddc::parallel_deepcopy(vals, vals1_cpu);
+    ddc::parallel_deepcopy(vals, vals1_host);
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
     ddc::Chunk coef_alloc(dom_bsplines, ddc::KokkosAllocator<double, MemorySpace>());

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -150,15 +150,14 @@ static void PeriodicitySplineBuilderTest()
     ddc::DiscreteDomain<BSplines<X>> const dom_bsplines = spline_builder.spline_domain();
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals1_host_alloc(
+    ddc::Chunk vals_host_alloc(
             dom_vals,
             ddc::KokkosAllocator<double, Kokkos::DefaultHostExecutionSpace::memory_space>());
-    ddc::ChunkSpan vals1_host = vals1_host_alloc.span_view();
+    ddc::ChunkSpan vals_host = vals_host_alloc.span_view();
     evaluator_type<IDim<X>> evaluator(dom_vals);
-    evaluator(vals1_host);
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    evaluator(vals_host);
+    auto vals_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_host);
     ddc::ChunkSpan vals = vals_alloc.span_view();
-    ddc::parallel_deepcopy(vals, vals1_host);
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
     ddc::Chunk coef_alloc(dom_bsplines, ddc::KokkosAllocator<double, MemorySpace>());


### PR DESCRIPTION
Closes #231 

`1` suffixing -> `_1d` suffixing
`_cpu` -> `_host`
`Sderiv`-> `derivs`
Rely on `ddc::create_mirror_view_and_copy` for CPU<->GPU deepcopies.