### PR TITLE
remove_dims_of_t and replace_dims_of_t

### DIFF
--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -389,6 +389,18 @@ struct ConvertTypeSeqToDiscreteDomain<detail::TypeSeq<DDims...>>
 template <class T>
 using convert_type_seq_to_discrete_domain = typename ConvertTypeSeqToDiscreteDomain<T>::type;
 
+template <class T>
+struct ConvertDiscreteDomainToTypeSeq;
+
+template <class... DDims>
+struct ConvertDiscreteDomainToTypeSeq<DiscreteDomain<DDims...>>
+{
+    using type = detail::TypeSeq<DDims...>;
+};
+
+template <class T>
+using convert_discrete_domain_to_type_seq = typename ConvertDiscreteDomainToTypeSeq<T>::type;
+
 } // namespace detail
 
 // Computes the cartesian product of DiscreteDomain types
@@ -417,6 +429,12 @@ struct cartesian_prod<DDom1, DDom2, Tail...>
 
 template <typename... DDom>
 using cartesian_prod_t = typename cartesian_prod<DDom...>::type;
+
+// Remove dimensions from a domain type
+template <typename DDom, typename... DDim>
+using remove_dims_of_t = ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_remove_t<
+                                 ddc::detail::convert_discrete_domain_to_type_seq<DDom>,
+                                 ddc::detail::TypeSeq<DDim...>>>;
 
 // Computes the substraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
 template <class... DDimsA, class... DDimsB>

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -389,18 +389,6 @@ struct ConvertTypeSeqToDiscreteDomain<detail::TypeSeq<DDims...>>
 template <class T>
 using convert_type_seq_to_discrete_domain = typename ConvertTypeSeqToDiscreteDomain<T>::type;
 
-template <class T>
-struct ConvertDiscreteDomainToTypeSeq;
-
-template <class... DDims>
-struct ConvertDiscreteDomainToTypeSeq<DiscreteDomain<DDims...>>
-{
-    using type = detail::TypeSeq<DDims...>;
-};
-
-template <class T>
-using convert_discrete_domain_to_type_seq = typename ConvertDiscreteDomainToTypeSeq<T>::type;
-
 } // namespace detail
 
 // Computes the cartesian product of DiscreteDomain types
@@ -431,10 +419,8 @@ template <typename... DDom>
 using cartesian_prod_t = typename cartesian_prod<DDom...>::type;
 
 // Remove dimensions from a domain type
-template <typename DDom, typename... DDim>
-using remove_dims_of_t = ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_remove_t<
-        ddc::detail::convert_discrete_domain_to_type_seq<DDom>,
-        ddc::detail::TypeSeq<DDim...>>>;
+template <typename DDom, typename... DDims>
+using remove_dims_of_t = decltype(remove_dims_of<DDims...>(std::declval<DDom>()));
 
 // Computes the substraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
 template <class... DDimsA, class... DDimsB>
@@ -464,11 +450,7 @@ KOKKOS_FUNCTION constexpr auto remove_dims_of(DDomA const& DDom_a) noexcept
 
 // Replace dimensions from a domain type
 template <typename DDom, typename DDim1, typename DDim2>
-using replace_dim_of_t =
-        typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_replace_t<
-                ddc::detail::convert_discrete_domain_to_type_seq<DDom>,
-                ddc::detail::TypeSeq<DDim1>,
-                ddc::detail::TypeSeq<DDim2>>>;
+using replace_dim_of_t = decltype(replace_dim_of<DDim1, DDim2>(std::declval<DDom>(), std::declval<DiscreteDomain<DDim2>>()));
 
 namespace detail {
 

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -418,10 +418,6 @@ struct cartesian_prod<DDom1, DDom2, Tail...>
 template <typename... DDom>
 using cartesian_prod_t = typename cartesian_prod<DDom...>::type;
 
-// Remove dimensions from a domain type
-template <typename DDom, typename... DDims>
-using remove_dims_of_t = decltype(remove_dims_of<DDims...>(std::declval<DDom>()));
-
 // Computes the substraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
 template <class... DDimsA, class... DDimsB>
 KOKKOS_FUNCTION constexpr auto remove_dims_of(
@@ -448,9 +444,9 @@ KOKKOS_FUNCTION constexpr auto remove_dims_of(DDomA const& DDom_a) noexcept
     return detail::convert_type_seq_to_discrete_domain<type_seq_r>(DDom_a);
 }
 
-// Replace dimensions from a domain type
-template <typename DDom, typename DDim1, typename DDim2>
-using replace_dim_of_t = decltype(replace_dim_of<DDim1, DDim2>(std::declval<DDom>(), std::declval<DiscreteDomain<DDim2>>()));
+// Remove dimensions from a domain type
+template <typename DDom, typename... DDims>
+using remove_dims_of_t = decltype(remove_dims_of<DDims...>(std::declval<DDom>()));
 
 namespace detail {
 
@@ -492,6 +488,14 @@ KOKKOS_FUNCTION constexpr auto replace_dim_of(
                     DDimsA,
                     DDimsB...>(ddc::select<DDimsA>(DDom_a), DDom_b)...);
 }
+
+// Replace dimensions from a domain type
+template <typename DDom, typename DDim1, typename DDim2>
+using replace_dim_of_t
+        = decltype(replace_dim_of<
+                   DDim1,
+                   DDim2>(std::declval<DDom>(), std::declval<DiscreteDomain<DDim2>>()));
+
 
 template <class... QueryDDims, class... DDims>
 KOKKOS_FUNCTION constexpr DiscreteVector<QueryDDims...> extents(

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -433,8 +433,8 @@ using cartesian_prod_t = typename cartesian_prod<DDom...>::type;
 // Remove dimensions from a domain type
 template <typename DDom, typename... DDim>
 using remove_dims_of_t = ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_remove_t<
-                                 ddc::detail::convert_discrete_domain_to_type_seq<DDom>,
-                                 ddc::detail::TypeSeq<DDim...>>>;
+        ddc::detail::convert_discrete_domain_to_type_seq<DDom>,
+        ddc::detail::TypeSeq<DDim...>>>;
 
 // Computes the substraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
 template <class... DDimsA, class... DDimsB>
@@ -461,6 +461,14 @@ KOKKOS_FUNCTION constexpr auto remove_dims_of(DDomA const& DDom_a) noexcept
     using type_seq_r = type_seq_remove_t<TagSeqA, TagSeqB>;
     return detail::convert_type_seq_to_discrete_domain<type_seq_r>(DDom_a);
 }
+
+// Replace dimensions from a domain type
+template <typename DDom, typename DDim1, typename DDim2>
+using replace_dim_of_t =
+        typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_replace_t<
+                ddc::detail::convert_discrete_domain_to_type_seq<DDom>,
+                ddc::detail::TypeSeq<DDim1>,
+                ddc::detail::TypeSeq<DDim2>>>;
 
 namespace detail {
 

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -92,10 +92,9 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y,
      * this is DiscreteDomain<X,Z>
      */
-    using batch_domain_type =
-            typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_remove_t<
-                    ddc::detail::TypeSeq<IDimX...>,
-                    ddc::detail::TypeSeq<interpolation_discrete_dimension_type>>>;
+    using batch_domain_type = typename ddc::remove_dims_of_t<
+            batched_interpolation_domain_type,
+            interpolation_discrete_dimension_type>;
 
     /**
      * @brief The type of the whole spline domain (cartesian product of 1D spline domain

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -103,11 +103,10 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y
      * (associated to a B-splines tag BSplinesY), this is DiscreteDomain<X,BSplinesY,Z>.
      */
-    using batched_spline_domain_type =
-            typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_replace_t<
-                    ddc::detail::TypeSeq<IDimX...>,
-                    ddc::detail::TypeSeq<interpolation_discrete_dimension_type>,
-                    ddc::detail::TypeSeq<bsplines_type>>>;
+    using batched_spline_domain_type = typename ddc::replace_dim_of_t<
+            batched_interpolation_domain_type,
+            interpolation_discrete_dimension_type,
+            bsplines_type>;
 
 private:
     /**
@@ -132,11 +131,10 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y,
      * this is DiscreteDomain<X,Deriv<Y>,Z>
      */
-    using batched_derivs_domain_type =
-            typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_replace_t<
-                    ddc::detail::TypeSeq<IDimX...>,
-                    ddc::detail::TypeSeq<interpolation_discrete_dimension_type>,
-                    ddc::detail::TypeSeq<deriv_type>>>;
+    using batched_derivs_domain_type = typename ddc::replace_dim_of_t<
+            batched_interpolation_domain_type,
+            interpolation_discrete_dimension_type,
+            deriv_type>;
 
     /// @brief Indicates if the degree of the splines is odd or even.
     static constexpr bool s_odd = BSplines::degree() % 2;

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -92,7 +92,7 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y,
      * this is DiscreteDomain<X,Z>
      */
-    using batch_domain_type = typename ddc::remove_dims_of_t<
+    using batch_domain_type = ddc::remove_dims_of_t<
             batched_interpolation_domain_type,
             interpolation_discrete_dimension_type>;
 
@@ -103,7 +103,7 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y
      * (associated to a B-splines tag BSplinesY), this is DiscreteDomain<X,BSplinesY,Z>.
      */
-    using batched_spline_domain_type = typename ddc::replace_dim_of_t<
+    using batched_spline_domain_type = ddc::replace_dim_of_t<
             batched_interpolation_domain_type,
             interpolation_discrete_dimension_type,
             bsplines_type>;
@@ -131,7 +131,7 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y,
      * this is DiscreteDomain<X,Deriv<Y>,Z>
      */
-    using batched_derivs_domain_type = typename ddc::replace_dim_of_t<
+    using batched_derivs_domain_type = ddc::replace_dim_of_t<
             batched_interpolation_domain_type,
             interpolation_discrete_dimension_type,
             deriv_type>;

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -125,12 +125,10 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Z>.
      */
-    using batch_domain_type
-            = ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_remove_t<
-                    ddc::detail::TypeSeq<IDimX...>,
-                    ddc::detail::TypeSeq<
-                            interpolation_discrete_dimension_type1,
-                            interpolation_discrete_dimension_type2>>>;
+    using batch_domain_type = typename ddc::remove_dims_of_t<
+            batched_interpolation_domain_type,
+            interpolation_discrete_dimension_type1,
+            interpolation_discrete_dimension_type2>;
 
     /** 
      * @brief The type of the whole spline domain (cartesian product of 2D spline domain
@@ -163,11 +161,10 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<X, Deriv<Y>, Z>.
      */
-    using batched_derivs_domain_type2
-            = ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_replace_t<
-                    ddc::detail::TypeSeq<IDimX...>,
-                    ddc::detail::TypeSeq<interpolation_discrete_dimension_type2>,
-                    ddc::detail::TypeSeq<deriv_type2>>>;
+    using batched_derivs_domain_type2 = typename ddc::replace_dim_of_t<
+            batched_interpolation_domain_type,
+            interpolation_discrete_dimension_type1,
+            deriv_type1>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -125,7 +125,7 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Z>.
      */
-    using batch_domain_type = typename ddc::remove_dims_of_t<
+    using batch_domain_type = ddc::remove_dims_of_t<
             batched_interpolation_domain_type,
             interpolation_discrete_dimension_type1,
             interpolation_discrete_dimension_type2>;
@@ -161,10 +161,10 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<X, Deriv<Y>, Z>.
      */
-    using batched_derivs_domain_type2 = typename ddc::replace_dim_of_t<
+    using batched_derivs_domain_type2 = ddc::replace_dim_of_t<
             batched_interpolation_domain_type,
-            interpolation_discrete_dimension_type1,
-            deriv_type1>;
+            interpolation_discrete_dimension_type2,
+            deriv_type2>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -82,20 +82,17 @@ public:
      * @brief The type of the batch domain (obtained by removing the dimension of interest
      * from the whole domain).
      */
-    using batch_domain_type =
-            typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_remove_t<
-                    ddc::detail::TypeSeq<IDimX...>,
-                    ddc::detail::TypeSeq<evaluation_discrete_dimension_type>>>;
+    using batch_domain_type = ddc::
+            remove_dims_of_t<batched_evaluation_domain_type, evaluation_discrete_dimension_type>;
 
     /**
      * @brief The type of the whole spline domain (cartesian product of 1D spline domain
      * and batch domain) preserving the order of dimensions.
      */
-    using batched_spline_domain_type =
-            typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_replace_t<
-                    ddc::detail::TypeSeq<IDimX...>,
-                    ddc::detail::TypeSeq<evaluation_discrete_dimension_type>,
-                    ddc::detail::TypeSeq<bsplines_type>>>;
+    using batched_spline_domain_type = ddc::replace_dim_of_t<
+            batched_evaluation_domain_type,
+            evaluation_discrete_dimension_type,
+            bsplines_type>;
 
     /// @brief The type of the extrapolation rule at the lower boundary.
     using lower_extrapolation_rule_type = LowerExtrapolationRule;

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -113,12 +113,10 @@ public:
      * @brief The type of the batch domain (obtained by removing the dimensions of interest
      * from the whole domain).
      */
-    using batch_domain_type =
-            typename ddc::detail::convert_type_seq_to_discrete_domain<ddc::type_seq_remove_t<
-                    ddc::detail::TypeSeq<IDimX...>,
-                    ddc::detail::TypeSeq<
-                            evaluation_discrete_dimension_type1,
-                            evaluation_discrete_dimension_type2>>>;
+    using batch_domain_type = typename ddc::remove_dims_of_t<
+            batched_evaluation_domain_type,
+            evaluation_discrete_dimension_type1,
+            evaluation_discrete_dimension_type2>;
 
     /**
      * @brief The type of the whole spline domain (cartesian product of 2D spline domain

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -177,8 +177,8 @@ TEST(DiscreteDomainTest, RangeFor)
 TEST(DiscreteDomainTest, DiffEmpty)
 {
     DDomX const dom_x = DDomX();
-    auto const subdomain1 = ddc::remove_dims_of(dom_x, dom_x);
-    auto const subdomain2 = ddc::remove_dims_of<DDimX>(dom_x);
+    ddc::remove_dims_of_t<DDomX, DDimX> const subdomain1 = ddc::remove_dims_of(dom_x, dom_x);
+    ddc::remove_dims_of_t<DDomX, DDimX> const subdomain2 = ddc::remove_dims_of<DDimX>(dom_x);
     EXPECT_EQ(subdomain1, ddc::DiscreteDomain<>());
     EXPECT_EQ(subdomain2, ddc::DiscreteDomain<>());
 }
@@ -188,8 +188,10 @@ TEST(DiscreteDomainTest, Diff)
     DDomX const dom_x = DDomX();
     DDomXY const dom_x_y = DDomXY();
     DDomZY const dom_z_y = DDomZY();
-    auto const subdomain1 = ddc::remove_dims_of(dom_x_y, dom_z_y);
-    auto const subdomain2 = ddc::remove_dims_of<DDimZ, DDimY>(dom_x_y);
+    ddc::remove_dims_of_t<DDomX, DDimZ, DDimY> const subdomain1
+            = ddc::remove_dims_of(dom_x_y, dom_z_y);
+    ddc::remove_dims_of_t<DDomX, DDimZ, DDimY> const subdomain2
+            = ddc::remove_dims_of<DDimZ, DDimY>(dom_x_y);
     EXPECT_EQ(subdomain1, dom_x);
     EXPECT_EQ(subdomain2, dom_x);
 }
@@ -199,7 +201,8 @@ TEST(DiscreteDomainTest, Replace)
     DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
     DDomZ const dom_z(lbound_z, nelems_z);
     DDomXZ const dom_x_z(lbound_x_z, nelems_x_z);
-    auto const subdomain = ddc::replace_dim_of<DDimY, DDimZ>(dom_x_y, dom_z);
+    ddc::replace_dim_of_t<DDomXY, DDimY, DDimZ> const subdomain
+            = ddc::replace_dim_of<DDimY, DDimZ>(dom_x_y, dom_z);
     EXPECT_EQ(subdomain, dom_x_z);
 }
 


### PR DESCRIPTION
Types associated to `remove_dims_of` and `replace_dims_of`.

Necessary for a Gysela MR.