### PR TITLE
Simplify fft full normalization

### DIFF
--- a/include/ddc/kernels/fft.hpp
+++ b/include/ddc/kernels/fft.hpp
@@ -179,14 +179,13 @@ void rescale(
 template <class DDim>
 Real forward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
-    return rlength(ddom) / Kokkos::sqrt(2 * Kokkos::numbers::pi)
-           / (ddc::get<DDim>(ddom.extents()) - 1);
+    return rlength(ddom) / Kokkos::sqrt(2 * Kokkos::numbers::pi) / (ddom.extents() - 1).value();
 }
 
 template <class DDim>
 Real backward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
-    return 1 / (forward_full_norm_coef(ddom) * ddc::get<DDim>(ddom.extents()));
+    return 1 / (forward_full_norm_coef(ddom) * ddom.extents().value());
 }
 
 /// @brief Core internal function to perform the FFT.

--- a/include/ddc/kernels/fft.hpp
+++ b/include/ddc/kernels/fft.hpp
@@ -176,19 +176,19 @@ void rescale(
             });
 }
 
-template <class DDimIn>
-Real forward_full_norm_coef(DiscreteDomain<DDimIn> const& ddom) noexcept
+template <class DDim>
+Real forward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
     return (coordinate(ddom.back()) - coordinate(ddom.front()))
-           / (ddc::get<DDimIn>(ddom.extents()) - 1) / Kokkos::sqrt(2 * Kokkos::numbers::pi);
+           / (ddc::get<DDim>(ddom.extents()) - 1) / Kokkos::sqrt(2 * Kokkos::numbers::pi);
 }
 
-template <class DDimOut>
-Real backward_full_norm_coef(DiscreteDomain<DDimOut> const& ddom) noexcept
+template <class DDim>
+Real backward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
     return Kokkos::sqrt(2 * Kokkos::numbers::pi)
            / (coordinate(ddom.back()) - coordinate(ddom.front()))
-           * (ddc::get<DDimOut>(ddom.extents()) - 1) / ddc::get<DDimOut>(ddom.extents());
+           * (ddc::get<DDim>(ddom.extents()) - 1) / ddc::get<DDim>(ddom.extents());
 }
 
 /// @brief Core internal function to perform the FFT.

--- a/include/ddc/kernels/fft.hpp
+++ b/include/ddc/kernels/fft.hpp
@@ -186,9 +186,7 @@ Real forward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 template <class DDim>
 Real backward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
-    return (Kokkos::sqrt(2 * Kokkos::numbers::pi) * (ddc::get<DDim>(ddom.extents()) - 1)
-            / rlength(ddom))
-           / ddc::get<DDim>(ddom.extents());
+    return 1 / (forward_full_norm_coef(ddom) * ddc::get<DDim>(ddom.extents()));
 }
 
 /// @brief Core internal function to perform the FFT.

--- a/include/ddc/kernels/fft.hpp
+++ b/include/ddc/kernels/fft.hpp
@@ -272,9 +272,11 @@ void impl(
     if (kwargs.normalization == ddc::FFT_Normalization::FULL) {
         real_type_t<Tout> norm_coef;
         if (kwargs.direction == ddc::FFT_Direction::FORWARD) {
-            norm_coef = (forward_full_norm_coef(ddc::select<DDimIn>(in.domain())) * ...);
+            DiscreteDomain<DDimIn...> const ddom_in = in.domain();
+            norm_coef = (forward_full_norm_coef(DiscreteDomain<DDimIn>(ddom_in)) * ...);
         } else {
-            norm_coef = (backward_full_norm_coef(ddc::select<DDimOut>(out.domain())) * ...);
+            DiscreteDomain<DDimOut...> const ddom_out = out.domain();
+            norm_coef = (backward_full_norm_coef(DiscreteDomain<DDimOut>(ddom_out)) * ...);
         }
 
         rescale(exec_space, out, norm_coef);

--- a/include/ddc/kernels/fft.hpp
+++ b/include/ddc/kernels/fft.hpp
@@ -179,15 +179,14 @@ void rescale(
 template <class DDim>
 Real forward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
-    return (coordinate(ddom.back()) - coordinate(ddom.front()))
-           / (ddc::get<DDim>(ddom.extents()) - 1) / Kokkos::sqrt(2 * Kokkos::numbers::pi);
+    return rlength(ddom) / (ddc::get<DDim>(ddom.extents()) - 1)
+           / Kokkos::sqrt(2 * Kokkos::numbers::pi);
 }
 
 template <class DDim>
 Real backward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
-    return Kokkos::sqrt(2 * Kokkos::numbers::pi)
-           / (coordinate(ddom.back()) - coordinate(ddom.front()))
+    return Kokkos::sqrt(2 * Kokkos::numbers::pi) / rlength(ddom)
            * (ddc::get<DDim>(ddom.extents()) - 1) / ddc::get<DDim>(ddom.extents());
 }
 

--- a/include/ddc/kernels/fft.hpp
+++ b/include/ddc/kernels/fft.hpp
@@ -179,15 +179,16 @@ void rescale(
 template <class DDim>
 Real forward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
-    return rlength(ddom) / (ddc::get<DDim>(ddom.extents()) - 1)
-           / Kokkos::sqrt(2 * Kokkos::numbers::pi);
+    return rlength(ddom) / Kokkos::sqrt(2 * Kokkos::numbers::pi)
+           / (ddc::get<DDim>(ddom.extents()) - 1);
 }
 
 template <class DDim>
 Real backward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
-    return Kokkos::sqrt(2 * Kokkos::numbers::pi) / rlength(ddom)
-           * (ddc::get<DDim>(ddom.extents()) - 1) / ddc::get<DDim>(ddom.extents());
+    return (Kokkos::sqrt(2 * Kokkos::numbers::pi) * (ddc::get<DDim>(ddom.extents()) - 1)
+            / rlength(ddom))
+           / ddc::get<DDim>(ddom.extents());
 }
 
 /// @brief Core internal function to perform the FFT.

--- a/include/ddc/kernels/fft.hpp
+++ b/include/ddc/kernels/fft.hpp
@@ -179,7 +179,8 @@ void rescale(
 template <class DDim>
 Real forward_full_norm_coef(DiscreteDomain<DDim> const& ddom) noexcept
 {
-    return rlength(ddom) / Kokkos::sqrt(2 * Kokkos::numbers::pi) / (ddom.extents() - 1).value();
+    return rlength(ddom) / Kokkos::sqrt(2 * Kokkos::numbers::pi_v<Real>)
+           / (ddom.extents() - 1).value();
 }
 
 template <class DDim>
@@ -267,7 +268,7 @@ void impl(
 
     // The FULL normalization is mesh-dependant and thus handled by DDC
     if (kwargs.normalization == ddc::FFT_Normalization::FULL) {
-        real_type_t<Tout> norm_coef;
+        Real norm_coef;
         if (kwargs.direction == ddc::FFT_Direction::FORWARD) {
             DiscreteDomain<DDimIn...> const ddom_in = in.domain();
             norm_coef = (forward_full_norm_coef(DiscreteDomain<DDimIn>(ddom_in)) * ...);
@@ -276,7 +277,7 @@ void impl(
             norm_coef = (backward_full_norm_coef(DiscreteDomain<DDimOut>(ddom_out)) * ...);
         }
 
-        rescale(exec_space, out, norm_coef);
+        rescale(exec_space, out, static_cast<real_type_t<Tout>>(norm_coef));
     }
 }
 


### PR DESCRIPTION
The "full" normalization can be simplified by defining a 1d normalization factor that would also avoid duplication
- [x] fix `double` implicit usage through `Kokkos::numbers::pi`
- [x] introduce two functions to help reading the normalization factors and the link between the forward and backward transformations