### PR TITLE
Add missing dependencies on installed DDC

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,6 +157,7 @@ jobs:
           esac
 
           export benchmark_ROOT=$PWD/opt/benchmark
+          export DDC_ROOT=$PWD/opt/ddc
           export GTest_ROOT=$PWD/opt/gtest
           export Kokkos_ROOT=$PWD/opt/kokkos
           export KokkosFFT_ROOT=$PWD/opt/kokkos-fft
@@ -250,6 +251,15 @@ jobs:
             ./build/examples/characteristics_advection
           ;;
           esac
+
+          cmake --install build --prefix $DDC_ROOT
+          rm -rf build
+          cmake \
+            -DCMAKE_BUILD_TYPE=${{matrix.cmake_build_type}} \
+            -B build \
+            -S /src/install_test
+          cmake --build build --parallel 2
+
         EOF
         docker run \
           --cidfile='docker.cid' \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: DoozyX/clang-format-lint-action@v0.18
       with:
-        source: 'benchmarks/ examples/ include/ddc/ tests/'
+        source: 'benchmarks/ examples/ include/ddc/ install_test/ tests/'
         exclude: ''
         extensions: 'hpp,cpp'
         clangFormatVersion: 18

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -128,6 +128,14 @@ jobs:
         cat<<-'EOF' > run.sh
           set -xe
           git config --global --add safe.directory '*'
+
+          export benchmark_ROOT=$PWD/opt/benchmark
+          export DDC_ROOT=$PWD/opt/ddc
+          export GTest_ROOT=$PWD/opt/gtest
+          export Kokkos_ROOT=$PWD/opt/kokkos
+          export KokkosFFT_ROOT=$PWD/opt/kokkos-fft
+          export KokkosKernels_ROOT=$PWD/opt/kokkos-kernels
+
           case "${{matrix.backend}}" in
           'cuda')
             export CC=${CUDA_GCC}
@@ -137,7 +145,7 @@ jobs:
           'hip')
             export CC=hipcc
             export CXX=hipcc
-            export CMAKE_PREFIX_PATH=/opt/rocm
+            export CMAKE_PREFIX_PATH="/opt/rocm:$benchmark_ROOT:$DDC_ROOT:$GTest_ROOT:$Kokkos_ROOT:$KokkosFFT_ROOT:$KokkosKernels_ROOT"
             EXTRA_CMAKE_FLAGS="-DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE=ON -DKokkos_ENABLE_ROCTHRUST=OFF -DKokkos_ARCH_AMD_GFX90A=ON"
           ;;
           'cpu-clang')
@@ -155,13 +163,6 @@ jobs:
             fi
           ;;
           esac
-
-          export benchmark_ROOT=$PWD/opt/benchmark
-          export DDC_ROOT=$PWD/opt/ddc
-          export GTest_ROOT=$PWD/opt/gtest
-          export Kokkos_ROOT=$PWD/opt/kokkos
-          export KokkosFFT_ROOT=$PWD/opt/kokkos-fft
-          export KokkosKernels_ROOT=$PWD/opt/kokkos-kernels
 
           cmake \
             -DCMAKE_BUILD_TYPE=${{matrix.cmake_build_type}} \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,6 +145,8 @@ jobs:
           'hip')
             export CC=hipcc
             export CXX=hipcc
+            # We extend the CMAKE_PREFIX_PATH with the content of _ROOT variables to support
+            # rocm 5.7. (likely due to a cmake_minimum_required(VERSION 3.3))
             export CMAKE_PREFIX_PATH="/opt/rocm:$benchmark_ROOT:$DDC_ROOT:$GTest_ROOT:$Kokkos_ROOT:$KokkosFFT_ROOT:$KokkosKernels_ROOT"
             EXTRA_CMAKE_FLAGS="-DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE=ON -DKokkos_ENABLE_ROCTHRUST=OFF -DKokkos_ARCH_AMD_GFX90A=ON"
           ;;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ if("${DDC_BUILD_KERNELS_FFT}")
   endif()
 
   target_link_libraries(DDC INTERFACE KokkosFFT::fft)
+  target_compile_definitions(DDC INTERFACE "DDC_BUILD_KERNELS_FFT")
 endif()
 
 if("${DDC_BUILD_KERNELS_SPLINES}")
@@ -170,6 +171,9 @@ if("${DDC_BUILD_KERNELS_SPLINES}")
   find_package(LAPACKE REQUIRED)
   target_link_libraries(DDC INTERFACE ${LAPACKE_LIBRARIES})
   target_include_directories(DDC SYSTEM INTERFACE ${LAPACKE_INCLUDE_DIRS})
+  install(
+	FILES cmake/FindLAPACKE.cmake
+	DESTINATION lib/cmake/DDC)
 
   # Kokkos-kernels
   set(DDC_KokkosKernels_DEPENDENCY_POLICY "AUTO" CACHE STRING "Policy to find the `KokkosKernels` package. Options: ${DDC_DEPENDENCY_POLICIES}")
@@ -188,6 +192,7 @@ if("${DDC_BUILD_KERNELS_SPLINES}")
   endif()
 
   target_link_libraries(DDC INTERFACE Kokkos::kokkoskernels)
+  target_compile_definitions(DDC INTERFACE "DDC_BUILD_KERNELS_SPLINES")
 endif()
 
 ## The PDI wrapper

--- a/cmake/DDCConfig.cmake.in
+++ b/cmake/DDCConfig.cmake.in
@@ -6,8 +6,23 @@
 
 include(CMakeFindDependencyMacro)
 
+set(DDC_BUILD_DOUBLE_PRECISION @DDC_BUILD_DOUBLE_PRECISION@)
+set(DDC_BUILD_KERNELS_FFT @DDC_BUILD_KERNELS_FFT@)
+set(DDC_BUILD_KERNELS_SPLINES @DDC_BUILD_KERNELS_SPLINES@)
+set(DDC_BUILD_PDI_WRAPPER @DDC_BUILD_PDI_WRAPPER@)
+
+find_package(Kokkos 4.4...4.5 CONFIG)
+
 if(@DDC_BUILD_KERNELS_FFT@)
    find_dependency(KokkosFFT 0.2.1...<1 CONFIG)
+endif()
+
+if(@DDC_BUILD_KERNELS_SPLINES@)
+   find_dependency(Ginkgo 1.8.0 EXACT)
+   list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
+   find_dependency(LAPACKE)
+   list(POP_FRONT CMAKE_MODULE_PATH)
+   find_dependency(KokkosKernels)
 endif()
 
 if(@DDC_BUILD_PDI_WRAPPER@)

--- a/cmake/DDCConfig.cmake.in
+++ b/cmake/DDCConfig.cmake.in
@@ -11,14 +11,17 @@ set(DDC_BUILD_KERNELS_FFT @DDC_BUILD_KERNELS_FFT@)
 set(DDC_BUILD_KERNELS_SPLINES @DDC_BUILD_KERNELS_SPLINES@)
 set(DDC_BUILD_PDI_WRAPPER @DDC_BUILD_PDI_WRAPPER@)
 
-find_package(Kokkos 4.4...4.5 CONFIG)
+find_package(Kokkos 4.4...4.5)
 
 if(@DDC_BUILD_KERNELS_FFT@)
-   find_dependency(KokkosFFT 0.2.1...<1 CONFIG)
+   find_dependency(KokkosFFT 0.2.1...<1)
 endif()
 
 if(@DDC_BUILD_KERNELS_SPLINES@)
    find_dependency(Ginkgo 1.8.0 EXACT)
+   # DDC installs a FindLAPACKE.cmake file.
+   # We choose to rely on it by prepending to CMAKE_MODULE_PATH
+   # only the time of calling find_dependency.
    list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
    find_dependency(LAPACKE)
    list(POP_FRONT CMAKE_MODULE_PATH)

--- a/install_test/CMakeLists.txt
+++ b/install_test/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+cmake_minimum_required(VERSION 3.22)
+project(test-installed-ddc LANGUAGES CXX)
+
+find_package(DDC REQUIRED)
+
+message("DDC options:")
+message("DDC_BUILD_DOUBLE_PRECISION=${DDC_BUILD_DOUBLE_PRECISION}")
+message("DDC_BUILD_KERNELS_FFT=${DDC_BUILD_KERNELS_FFT}")
+message("DDC_BUILD_KERNELS_SPLINES=${DDC_BUILD_KERNELS_SPLINES}")
+message("DDC_BUILD_PDI_WRAPPER=${DDC_BUILD_PDI_WRAPPER}")
+
+add_executable(main main.cpp)
+target_link_libraries(main PRIVATE DDC::DDC DDC::PDI_Wrapper)

--- a/install_test/main.cpp
+++ b/install_test/main.cpp
@@ -1,0 +1,28 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <ddc/ddc.hpp>
+
+#if defined(DDC_BUILD_KERNELS_FFT)
+#include <ddc/kernels/fft.hpp>
+#else
+#error
+#endif
+
+#if defined(DDC_BUILD_KERNELS_SPLINES)
+#include <ddc/kernels/splines.hpp>
+#else
+#error
+#endif
+
+#if defined(DDC_BUILD_PDI_WRAPPER)
+#include <ddc/pdi.hpp>
+#else
+#error
+#endif
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
- [x] declare missing dependencies in DDCConfig.cmake
- [x] install missing FindLAPACKE.cmake, required by DDC when using splines
- [x] add CI test

It seems to be working but could be further improved in future PR.

- The headers related to fft, splines and the PDI wrapper of DDC are being installed whatever the values of the cmake options. I think it could improved with some reorganization.

- Cmake targets about the fft and splines are missing.
 
- We should look at cmake components. As long as the user can adapt it looks ok
```cmake
find_package(DDC REQUIRED)

add_executable(main main.cpp)
target_link_libraries(main PRIVATE DDC::DDC)

if(DDC_BUILD_PDI_WRAPPER)
    target_link_libraries(main PRIVATE DDC::PDI_Wrapper)
endif()
```

but as soon as a user requires an option this looks bad
```cmake
find_package(DDC REQUIRED)

if(NOT DDC_BUILD_KERNELS_FFT)
    message(FATAL_ERROR "Expecting DDC_BUILD_KERNELS_FFT=ON")
endif()
```

- DDC lacks a header configuration file to list enabled options. These are passed as "compile definition" but pollute the user side.