### PR TITLE
Add ddc, fft, pdi and splines targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,24 +127,24 @@ add_library(DDC INTERFACE)
 add_library(DDC::DDC ALIAS DDC)
 install(TARGETS DDC EXPORT DDCTargets)
 
-add_library(ddc INTERFACE)
-add_library(DDC::ddc ALIAS ddc)
-install(TARGETS ddc EXPORT DDCTargets)
-target_compile_definitions(ddc INTERFACE MDSPAN_USE_PAREN_OPERATOR=1)
+add_library(ddc_core INTERFACE)
+add_library(DDC::core ALIAS ddc_core)
+install(TARGETS ddc_core EXPORT DDCTargets)
+target_compile_definitions(ddc_core INTERFACE MDSPAN_USE_PAREN_OPERATOR=1)
 if("${DDC_BUILD_DOUBLE_PRECISION}")
-    target_compile_definitions(ddc INTERFACE DDC_BUILD_DOUBLE_PRECISION)
+    target_compile_definitions(ddc_core INTERFACE DDC_BUILD_DOUBLE_PRECISION)
 endif()
-target_compile_features(ddc INTERFACE cxx_std_17)
+target_compile_features(ddc_core INTERFACE cxx_std_17)
 target_include_directories(
-    ddc
+    ddc_core
     INTERFACE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:include>"
 )
-target_link_libraries(ddc INTERFACE Kokkos::kokkos)
+target_link_libraries(ddc_core INTERFACE Kokkos::kokkos)
 
 ### DDC legacy target
-target_link_libraries(DDC INTERFACE ddc)
+target_link_libraries(DDC INTERFACE ddc_core)
 
 # Link library to DDC
 
@@ -177,7 +177,7 @@ if("${DDC_BUILD_KERNELS_FFT}")
     add_library(DDC::fft ALIAS ddc_fft)
     install(TARGETS ddc_fft EXPORT DDCTargets)
     target_compile_definitions(ddc_fft INTERFACE "DDC_BUILD_KERNELS_FFT")
-    target_link_libraries(ddc_fft INTERFACE ddc Kokkos::kokkos KokkosFFT::fft)
+    target_link_libraries(ddc_fft INTERFACE ddc_core Kokkos::kokkos KokkosFFT::fft)
 
     ### DDC legacy target
     target_link_libraries(DDC INTERFACE ddc_fft)
@@ -221,7 +221,7 @@ if("${DDC_BUILD_KERNELS_SPLINES}")
     target_include_directories(ddc_splines SYSTEM INTERFACE ${LAPACKE_INCLUDE_DIRS})
     target_link_libraries(
         ddc_splines
-        INTERFACE ddc Ginkgo::ginkgo Kokkos::kokkos Kokkos::kokkoskernels ${LAPACKE_LIBRARIES}
+        INTERFACE ddc_core Ginkgo::ginkgo Kokkos::kokkos Kokkos::kokkoskernels ${LAPACKE_LIBRARIES}
     )
 
     ### DDC legacy target
@@ -242,10 +242,11 @@ if("${DDC_BUILD_PDI_WRAPPER}")
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
             "$<INSTALL_INTERFACE:include>"
     )
-    target_link_libraries(ddc_pdi INTERFACE ddc PDI::PDI_C)
+    target_link_libraries(ddc_pdi INTERFACE ddc_core PDI::PDI_C)
 
     ### PDI_Wrapper legacy target
     add_library(PDI_Wrapper INTERFACE)
+    set_target_properties(PDI_Wrapper PROPERTIES DEPRECATION "Use DDC::pdi instead")
     add_library(DDC::PDI_Wrapper ALIAS PDI_Wrapper)
     install(TARGETS PDI_Wrapper EXPORT DDCTargets)
     target_link_libraries(PDI_Wrapper INTERFACE ddc_pdi)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,20 +122,29 @@ endif()
 
 ## The library itself
 
+### DDC legacy target
 add_library(DDC INTERFACE)
-target_compile_features(DDC INTERFACE cxx_std_17)
+add_library(DDC::DDC ALIAS DDC)
+install(TARGETS DDC EXPORT DDCTargets)
+
+add_library(ddc INTERFACE)
+add_library(DDC::ddc ALIAS ddc)
+install(TARGETS ddc EXPORT DDCTargets)
+target_compile_definitions(ddc INTERFACE MDSPAN_USE_PAREN_OPERATOR=1)
+if("${DDC_BUILD_DOUBLE_PRECISION}")
+    target_compile_definitions(ddc INTERFACE DDC_BUILD_DOUBLE_PRECISION)
+endif()
+target_compile_features(ddc INTERFACE cxx_std_17)
 target_include_directories(
-    DDC
+    ddc
     INTERFACE
         "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
         "$<INSTALL_INTERFACE:include>"
 )
-target_link_libraries(DDC INTERFACE Kokkos::kokkos)
-if("${DDC_BUILD_DOUBLE_PRECISION}")
-    target_compile_definitions(DDC INTERFACE DDC_BUILD_DOUBLE_PRECISION)
-endif()
-add_library(DDC::DDC ALIAS DDC)
-install(TARGETS DDC EXPORT DDCTargets)
+target_link_libraries(ddc INTERFACE Kokkos::kokkos)
+
+### DDC legacy target
+target_link_libraries(DDC INTERFACE ddc)
 
 # Link library to DDC
 
@@ -164,20 +173,22 @@ if("${DDC_BUILD_KERNELS_FFT}")
         find_package(KokkosFFT 0.2.1...<1 REQUIRED)
     endif()
 
-    target_link_libraries(DDC INTERFACE KokkosFFT::fft)
-    target_compile_definitions(DDC INTERFACE "DDC_BUILD_KERNELS_FFT")
+    add_library(ddc_fft INTERFACE)
+    add_library(DDC::fft ALIAS ddc_fft)
+    install(TARGETS ddc_fft EXPORT DDCTargets)
+    target_compile_definitions(ddc_fft INTERFACE "DDC_BUILD_KERNELS_FFT")
+    target_link_libraries(ddc_fft INTERFACE ddc Kokkos::kokkos KokkosFFT::fft)
+
+    ### DDC legacy target
+    target_link_libraries(DDC INTERFACE ddc_fft)
 endif()
 
 if("${DDC_BUILD_KERNELS_SPLINES}")
     # Ginkgo
     find_package(Ginkgo 1.8.0 EXACT REQUIRED)
-    target_link_libraries(DDC INTERFACE Ginkgo::ginkgo)
 
     # Lapacke
     find_package(LAPACKE REQUIRED)
-    target_link_libraries(DDC INTERFACE ${LAPACKE_LIBRARIES})
-    target_include_directories(DDC SYSTEM INTERFACE ${LAPACKE_INCLUDE_DIRS})
-    install(FILES cmake/FindLAPACKE.cmake DESTINATION lib/cmake/DDC)
 
     # Kokkos-kernels
     set(DDC_KokkosKernels_DEPENDENCY_POLICY
@@ -202,25 +213,45 @@ if("${DDC_BUILD_KERNELS_SPLINES}")
         find_package(KokkosKernels REQUIRED)
     endif()
 
-    target_link_libraries(DDC INTERFACE Kokkos::kokkoskernels)
-    target_compile_definitions(DDC INTERFACE "DDC_BUILD_KERNELS_SPLINES")
+    add_library(ddc_splines INTERFACE)
+    add_library(DDC::splines ALIAS ddc_splines)
+    install(FILES cmake/FindLAPACKE.cmake DESTINATION lib/cmake/DDC)
+    install(TARGETS ddc_splines EXPORT DDCTargets)
+    target_compile_definitions(ddc_splines INTERFACE "DDC_BUILD_KERNELS_SPLINES")
+    target_include_directories(ddc_splines SYSTEM INTERFACE ${LAPACKE_INCLUDE_DIRS})
+    target_link_libraries(
+        ddc_splines
+        INTERFACE ddc Ginkgo::ginkgo Kokkos::kokkos Kokkos::kokkoskernels ${LAPACKE_LIBRARIES}
+    )
+
+    ### DDC legacy target
+    target_link_libraries(DDC INTERFACE ddc_splines)
 endif()
 
 ## The PDI wrapper
 
 if("${DDC_BUILD_PDI_WRAPPER}")
-    add_library(PDI_Wrapper INTERFACE)
-    target_compile_features(PDI_Wrapper INTERFACE cxx_std_17)
+    add_library(ddc_pdi INTERFACE)
+    add_library(DDC::pdi ALIAS ddc_pdi)
+    install(TARGETS ddc_pdi EXPORT DDCTargets)
+    target_compile_definitions(ddc_pdi INTERFACE "DDC_BUILD_PDI_WRAPPER")
+    target_compile_features(ddc_pdi INTERFACE cxx_std_17)
     target_include_directories(
-        PDI_Wrapper
+        ddc_pdi
         INTERFACE
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
             "$<INSTALL_INTERFACE:include>"
     )
-    target_link_libraries(PDI_Wrapper INTERFACE DDC::DDC PDI::PDI_C)
-    target_compile_definitions(PDI_Wrapper INTERFACE "DDC_BUILD_PDI_WRAPPER")
+    target_link_libraries(ddc_pdi INTERFACE ddc PDI::PDI_C)
+
+    ### PDI_Wrapper legacy target
+    add_library(PDI_Wrapper INTERFACE)
     add_library(DDC::PDI_Wrapper ALIAS PDI_Wrapper)
     install(TARGETS PDI_Wrapper EXPORT DDCTargets)
+    target_link_libraries(PDI_Wrapper INTERFACE ddc_pdi)
+
+    ### DDC legacy target
+    target_link_libraries(DDC INTERFACE ddc_pdi)
 endif()
 
 ## if examples are enabled, build them

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,7 @@ target_include_directories(
 target_link_libraries(ddc_core INTERFACE Kokkos::kokkos)
 
 ### DDC legacy target
-target_link_libraries(DDC INTERFACE ddc_core)
+target_link_libraries(DDC INTERFACE DDC::core)
 
 # Link library to DDC
 
@@ -177,10 +177,10 @@ if("${DDC_BUILD_KERNELS_FFT}")
     add_library(DDC::fft ALIAS ddc_fft)
     install(TARGETS ddc_fft EXPORT DDCTargets)
     target_compile_definitions(ddc_fft INTERFACE "DDC_BUILD_KERNELS_FFT")
-    target_link_libraries(ddc_fft INTERFACE ddc_core Kokkos::kokkos KokkosFFT::fft)
+    target_link_libraries(ddc_fft INTERFACE DDC::core Kokkos::kokkos KokkosFFT::fft)
 
     ### DDC legacy target
-    target_link_libraries(DDC INTERFACE ddc_fft)
+    target_link_libraries(DDC INTERFACE DDC::fft)
 endif()
 
 if("${DDC_BUILD_KERNELS_SPLINES}")
@@ -221,11 +221,11 @@ if("${DDC_BUILD_KERNELS_SPLINES}")
     target_include_directories(ddc_splines SYSTEM INTERFACE ${LAPACKE_INCLUDE_DIRS})
     target_link_libraries(
         ddc_splines
-        INTERFACE ddc_core Ginkgo::ginkgo Kokkos::kokkos Kokkos::kokkoskernels ${LAPACKE_LIBRARIES}
+        INTERFACE DDC::core Ginkgo::ginkgo Kokkos::kokkos Kokkos::kokkoskernels ${LAPACKE_LIBRARIES}
     )
 
     ### DDC legacy target
-    target_link_libraries(DDC INTERFACE ddc_splines)
+    target_link_libraries(DDC INTERFACE DDC::splines)
 endif()
 
 ## The PDI wrapper
@@ -242,17 +242,17 @@ if("${DDC_BUILD_PDI_WRAPPER}")
             "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
             "$<INSTALL_INTERFACE:include>"
     )
-    target_link_libraries(ddc_pdi INTERFACE ddc_core PDI::PDI_C)
+    target_link_libraries(ddc_pdi INTERFACE DDC::core PDI::PDI_C)
 
     ### PDI_Wrapper legacy target
     add_library(PDI_Wrapper INTERFACE)
     set_target_properties(PDI_Wrapper PROPERTIES DEPRECATION "Use DDC::pdi instead")
     add_library(DDC::PDI_Wrapper ALIAS PDI_Wrapper)
     install(TARGETS PDI_Wrapper EXPORT DDCTargets)
-    target_link_libraries(PDI_Wrapper INTERFACE ddc_pdi)
+    target_link_libraries(PDI_Wrapper INTERFACE DDC::pdi)
 
     ### DDC legacy target
-    target_link_libraries(DDC INTERFACE ddc_pdi)
+    target_link_libraries(DDC INTERFACE DDC::pdi)
 endif()
 
 ## if examples are enabled, build them
@@ -281,7 +281,7 @@ endif()
 
 ## installation
 
-install(EXPORT DDCTargets NAMESPACE DDC:: DESTINATION lib/cmake/DDC)
+install(EXPORT DDCTargets NAMESPACE DDC::impl:: DESTINATION lib/cmake/DDC)
 
 install(DIRECTORY include/ TYPE INCLUDE)
 

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 add_executable(ddc_benchmark_deepcopy deepcopy.cpp)
-target_link_libraries(ddc_benchmark_deepcopy PUBLIC benchmark::benchmark DDC::DDC)
+target_link_libraries(ddc_benchmark_deepcopy PUBLIC benchmark::benchmark ddc_core)
 
 if("${DDC_BUILD_KERNELS_SPLINES}")
     add_executable(ddc_benchmark_splines splines.cpp)
-    target_link_libraries(ddc_benchmark_splines PUBLIC benchmark::benchmark DDC::DDC)
+    target_link_libraries(ddc_benchmark_splines PUBLIC benchmark::benchmark ddc_core ddc_splines)
 endif()

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 add_executable(ddc_benchmark_deepcopy deepcopy.cpp)
-target_link_libraries(ddc_benchmark_deepcopy PUBLIC benchmark::benchmark ddc_core)
+target_link_libraries(ddc_benchmark_deepcopy PUBLIC benchmark::benchmark DDC::core)
 
 if("${DDC_BUILD_KERNELS_SPLINES}")
     add_executable(ddc_benchmark_splines splines.cpp)
-    target_link_libraries(ddc_benchmark_splines PUBLIC benchmark::benchmark ddc_core ddc_splines)
+    target_link_libraries(ddc_benchmark_splines PUBLIC benchmark::benchmark DDC::core DDC::splines)
 endif()

--- a/cmake/DDCConfig.cmake.in
+++ b/cmake/DDCConfig.cmake.in
@@ -35,8 +35,8 @@ endif()
 include(${CMAKE_CURRENT_LIST_DIR}/DDCTargets.cmake)
 
 foreach(target core fft pdi splines)
-   if(TARGET DDC::ddc_${target})
-      add_library(DDC::${target} ALIAS DDC::ddc_${target})
+   if(TARGET DDC::impl::ddc_${target})
+      add_library(DDC::${target} ALIAS DDC::impl::ddc_${target})
    endif()
 endforeach()
 

--- a/cmake/DDCConfig.cmake.in
+++ b/cmake/DDCConfig.cmake.in
@@ -34,4 +34,10 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/DDCTargets.cmake)
 
+foreach(target fft;pdi;splines)
+   if(TARGET DDC::ddc_${target})
+      add_library(DDC::${target} ALIAS DDC::ddc_${target})
+   endif()
+endforeach()
+
 check_required_components(DDC)

--- a/cmake/DDCConfig.cmake.in
+++ b/cmake/DDCConfig.cmake.in
@@ -34,7 +34,7 @@ endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/DDCTargets.cmake)
 
-foreach(target fft;pdi;splines)
+foreach(target core fft pdi splines)
    if(TARGET DDC::ddc_${target})
       add_library(DDC::${target} ALIAS DDC::ddc_${target})
    endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,28 +2,30 @@
 #
 # SPDX-License-Identifier: MIT
 
+add_executable(game_of_life game_of_life.cpp)
+target_link_libraries(game_of_life PUBLIC DDC::ddc)
+
 add_executable(heat_equation heat_equation.cpp)
-target_link_libraries(heat_equation PUBLIC DDC::DDC)
+target_link_libraries(heat_equation PUBLIC DDC::ddc)
 
 add_executable(uniform_heat_equation uniform_heat_equation.cpp)
-add_executable(non_uniform_heat_equation non_uniform_heat_equation.cpp)
+target_link_libraries(uniform_heat_equation PUBLIC DDC::ddc)
 
-target_link_libraries(uniform_heat_equation PUBLIC DDC::DDC)
-target_link_libraries(non_uniform_heat_equation PUBLIC DDC::DDC)
-target_link_libraries(uniform_heat_equation PUBLIC DDC::DDC)
+add_executable(non_uniform_heat_equation non_uniform_heat_equation.cpp)
+target_link_libraries(non_uniform_heat_equation PUBLIC DDC::ddc)
 
 if("${DDC_BUILD_PDI_WRAPPER}")
-    target_link_libraries(heat_equation PUBLIC DDC::PDI_Wrapper)
-    target_link_libraries(uniform_heat_equation PUBLIC DDC::PDI_Wrapper)
-    target_link_libraries(non_uniform_heat_equation PUBLIC DDC::PDI_Wrapper)
+    target_link_libraries(heat_equation PUBLIC DDC::pdi)
+    target_link_libraries(uniform_heat_equation PUBLIC DDC::pdi)
+    target_link_libraries(non_uniform_heat_equation PUBLIC DDC::pdi)
 endif()
+
 if("${DDC_BUILD_KERNELS_FFT}")
     add_executable(heat_equation_spectral heat_equation_spectral.cpp)
-    target_link_libraries(heat_equation_spectral PUBLIC DDC::DDC)
+    target_link_libraries(heat_equation_spectral PUBLIC DDC::ddc DDC::fft)
 endif()
-add_executable(game_of_life game_of_life.cpp)
-target_link_libraries(game_of_life PUBLIC DDC::DDC)
+
 if("${DDC_BUILD_KERNELS_SPLINES}")
     add_executable(characteristics_advection characteristics_advection.cpp)
-    target_link_libraries(characteristics_advection PUBLIC DDC::DDC)
+    target_link_libraries(characteristics_advection PUBLIC DDC::ddc DDC::splines)
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,16 +3,16 @@
 # SPDX-License-Identifier: MIT
 
 add_executable(game_of_life game_of_life.cpp)
-target_link_libraries(game_of_life PUBLIC DDC::ddc)
+target_link_libraries(game_of_life PUBLIC DDC::core)
 
 add_executable(heat_equation heat_equation.cpp)
-target_link_libraries(heat_equation PUBLIC DDC::ddc)
+target_link_libraries(heat_equation PUBLIC DDC::core)
 
 add_executable(uniform_heat_equation uniform_heat_equation.cpp)
-target_link_libraries(uniform_heat_equation PUBLIC DDC::ddc)
+target_link_libraries(uniform_heat_equation PUBLIC DDC::core)
 
 add_executable(non_uniform_heat_equation non_uniform_heat_equation.cpp)
-target_link_libraries(non_uniform_heat_equation PUBLIC DDC::ddc)
+target_link_libraries(non_uniform_heat_equation PUBLIC DDC::core)
 
 if("${DDC_BUILD_PDI_WRAPPER}")
     target_link_libraries(heat_equation PUBLIC DDC::pdi)
@@ -22,10 +22,10 @@ endif()
 
 if("${DDC_BUILD_KERNELS_FFT}")
     add_executable(heat_equation_spectral heat_equation_spectral.cpp)
-    target_link_libraries(heat_equation_spectral PUBLIC DDC::ddc DDC::fft)
+    target_link_libraries(heat_equation_spectral PUBLIC DDC::core DDC::fft)
 endif()
 
 if("${DDC_BUILD_KERNELS_SPLINES}")
     add_executable(characteristics_advection characteristics_advection.cpp)
-    target_link_libraries(characteristics_advection PUBLIC DDC::ddc DDC::splines)
+    target_link_libraries(characteristics_advection PUBLIC DDC::core DDC::splines)
 endif()

--- a/install_test/CMakeLists.txt
+++ b/install_test/CMakeLists.txt
@@ -14,4 +14,4 @@ message("DDC_BUILD_KERNELS_SPLINES=${DDC_BUILD_KERNELS_SPLINES}")
 message("DDC_BUILD_PDI_WRAPPER=${DDC_BUILD_PDI_WRAPPER}")
 
 add_executable(main main.cpp)
-target_link_libraries(main PRIVATE DDC::DDC DDC::PDI_Wrapper)
+target_link_libraries(main PRIVATE DDC::ddc DDC::fft DDC::pdi DDC::splines)

--- a/install_test/CMakeLists.txt
+++ b/install_test/CMakeLists.txt
@@ -14,4 +14,4 @@ message("DDC_BUILD_KERNELS_SPLINES=${DDC_BUILD_KERNELS_SPLINES}")
 message("DDC_BUILD_PDI_WRAPPER=${DDC_BUILD_PDI_WRAPPER}")
 
 add_executable(main main.cpp)
-target_link_libraries(main PRIVATE DDC::ddc DDC::fft DDC::pdi DDC::splines)
+target_link_libraries(main PRIVATE DDC::core DDC::fft DDC::pdi DDC::splines)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,7 @@ add_executable(
     multiple_discrete_dimensions.cpp
 )
 target_compile_features(ddc_tests PUBLIC cxx_std_17)
-target_link_libraries(ddc_tests PUBLIC GTest::gtest DDC::DDC)
+target_link_libraries(ddc_tests PUBLIC GTest::gtest DDC::core)
 gtest_discover_tests(ddc_tests DISCOVERY_MODE PRE_TEST)
 
 if("${DDC_BUILD_KERNELS_FFT}")

--- a/tests/discrete_space/CMakeLists.txt
+++ b/tests/discrete_space/CMakeLists.txt
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: MIT
 
 add_library(discrete_space_tests_lib STATIC discrete_space.cpp)
-target_link_libraries(discrete_space_tests_lib PUBLIC GTest::gtest DDC::DDC)
+target_link_libraries(discrete_space_tests_lib PUBLIC GTest::gtest DDC::core)
 
 add_executable(discrete_space_tests main.cpp)
-target_link_libraries(discrete_space_tests PUBLIC discrete_space_tests_lib GTest::gtest DDC::DDC)
+target_link_libraries(discrete_space_tests PUBLIC discrete_space_tests_lib GTest::gtest DDC::core)
 
 gtest_discover_tests(discrete_space_tests DISCOVERY_MODE PRE_TEST)

--- a/tests/fft/CMakeLists.txt
+++ b/tests/fft/CMakeLists.txt
@@ -8,5 +8,5 @@ include(GoogleTest)
 
 add_executable(fft_tests ../main.cpp fft.cpp)
 target_compile_features(fft_tests PUBLIC cxx_std_17)
-target_link_libraries(fft_tests PUBLIC GTest::gtest DDC::DDC)
+target_link_libraries(fft_tests PUBLIC GTest::gtest DDC::core DDC::fft)
 gtest_discover_tests(fft_tests DISCOVERY_MODE PRE_TEST)

--- a/tests/splines/CMakeLists.txt
+++ b/tests/splines/CMakeLists.txt
@@ -12,17 +12,17 @@ set(SPLINES_TEST_DEGREE_MAX 3 CACHE STRING "Maximum degree to test splines.")
 add_executable(splines_tests ../main.cpp knots_as_interpolation_points.cpp view.cpp)
 
 target_compile_features(splines_tests PUBLIC cxx_std_17)
-target_link_libraries(splines_tests PUBLIC GTest::gtest DDC::DDC)
+target_link_libraries(splines_tests PUBLIC DDC::core DDC::splines GTest::gtest)
 gtest_discover_tests(splines_tests DISCOVERY_MODE PRE_TEST)
 
 add_executable(bsplines_tests ../main.cpp bsplines.cpp)
 target_compile_features(bsplines_tests PUBLIC cxx_std_17)
-target_link_libraries(bsplines_tests PUBLIC GTest::gtest DDC::DDC)
+target_link_libraries(bsplines_tests PUBLIC DDC::core DDC::splines GTest::gtest)
 gtest_discover_tests(bsplines_tests DISCOVERY_MODE PRE_TEST)
 
 add_executable(splines_linear_problem_tests ../main.cpp splines_linear_problem.cpp)
 target_compile_features(splines_linear_problem_tests PUBLIC cxx_std_17)
-target_link_libraries(splines_linear_problem_tests PUBLIC GTest::gtest DDC::DDC)
+target_link_libraries(splines_linear_problem_tests PUBLIC DDC::core DDC::splines GTest::gtest)
 gtest_discover_tests(splines_linear_problem_tests DISCOVERY_MODE PRE_TEST)
 
 foreach(DEGREE_X RANGE "${SPLINES_TEST_DEGREE_MIN}" "${SPLINES_TEST_DEGREE_MAX}")
@@ -30,7 +30,7 @@ foreach(DEGREE_X RANGE "${SPLINES_TEST_DEGREE_MIN}" "${SPLINES_TEST_DEGREE_MAX}"
         set(test_name "splines_tests_DEGREE_X_${DEGREE_X}_${BSPLINES_TYPE}")
         add_executable("${test_name}" ../main.cpp periodic_spline_builder.cpp)
         target_compile_features("${test_name}" PUBLIC cxx_std_17)
-        target_link_libraries("${test_name}" PUBLIC GTest::gtest DDC::DDC)
+        target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
         target_compile_definitions("${test_name}" PUBLIC -DDEGREE_X=${DEGREE_X} -D${BSPLINES_TYPE})
         add_test("${test_name}" "${test_name}")
     endforeach()
@@ -46,7 +46,7 @@ foreach(BCL "BCL_GREVILLE" "BCL_HERMITE")
                     )
                     add_executable("${test_name}" ../main.cpp non_periodic_spline_builder.cpp)
                     target_compile_features("${test_name}" PUBLIC cxx_std_17)
-                    target_link_libraries("${test_name}" PUBLIC GTest::gtest DDC::DDC)
+                    target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
                     target_compile_definitions(
                         "${test_name}"
                         PUBLIC
@@ -72,7 +72,7 @@ foreach(BC "BC_PERIODIC" "BC_GREVILLE")
                 )
                 add_executable("${test_name}" ../main.cpp extrapolation_rule.cpp)
                 target_compile_features("${test_name}" PUBLIC cxx_std_17)
-                target_link_libraries("${test_name}" PUBLIC GTest::gtest DDC::DDC)
+                target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
                 target_compile_definitions(
                     "${test_name}"
                     PUBLIC -DDEGREE=${DEGREE_X} -D${BSPLINES_TYPE} -D${EVALUATOR} -D${BC} -D${ER}
@@ -93,7 +93,7 @@ foreach(BC "BC_PERIODIC" "BC_GREVILLE" "BC_HERMITE")
             )
             add_executable("${test_name}" ../main.cpp batched_spline_builder.cpp)
             target_compile_features("${test_name}" PUBLIC cxx_std_17)
-            target_link_libraries("${test_name}" PUBLIC GTest::gtest DDC::DDC)
+            target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
             target_compile_definitions(
                 "${test_name}"
                 PUBLIC -DDEGREE_X=${DEGREE_X} -D${BSPLINES_TYPE} -D${BC} -DSOLVER_LAPACK
@@ -113,7 +113,7 @@ foreach(BC "BC_PERIODIC" "BC_GREVILLE" "BC_HERMITE")
             )
             add_executable("${test_name}" ../main.cpp batched_spline_builder.cpp)
             target_compile_features("${test_name}" PUBLIC cxx_std_17)
-            target_link_libraries("${test_name}" PUBLIC GTest::gtest DDC::DDC)
+            target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
             target_compile_definitions(
                 "${test_name}"
                 PUBLIC -DDEGREE_X=${DEGREE_X} -D${BSPLINES_TYPE} -D${BC} -DSOLVER_GINKGO
@@ -128,7 +128,7 @@ foreach(DEGREE_X RANGE "${SPLINES_TEST_DEGREE_MIN}" "${SPLINES_TEST_DEGREE_MAX}"
     set(test_name "splines_ordered_points_DEGREE_X_${DEGREE_X}")
     add_executable("${test_name}" ../main.cpp periodic_spline_builder_ordered_points.cpp)
     target_compile_features("${test_name}" PUBLIC cxx_std_17)
-    target_link_libraries("${test_name}" PUBLIC GTest::gtest DDC::DDC)
+    target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
     target_compile_definitions("${test_name}" PUBLIC -DDEGREE_X=${DEGREE_X})
     add_test("${test_name}" "${test_name}")
 endforeach()
@@ -138,7 +138,7 @@ foreach(DEGREE_X RANGE "${SPLINES_TEST_DEGREE_MIN}" "${SPLINES_TEST_DEGREE_MAX}"
         set(test_name "splines_tests_PERIODICITY_DEGREE_X_${DEGREE_X}_${BSPLINES_TYPE}")
         add_executable("${test_name}" ../main.cpp periodicity_spline_builder.cpp)
         target_compile_features("${test_name}" PUBLIC cxx_std_17)
-        target_link_libraries("${test_name}" PUBLIC GTest::gtest DDC::DDC)
+        target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
         target_compile_definitions("${test_name}" PUBLIC -DDEGREE_X=${DEGREE_X} -D${BSPLINES_TYPE})
         # add_test("${test_name}" "${test_name}")
         gtest_discover_tests("${test_name}" DISCOVERY_MODE PRE_TEST)
@@ -154,7 +154,7 @@ foreach(BC "BC_PERIODIC" "BC_GREVILLE" "BC_HERMITE")
                 )
                 add_executable("${test_name}" ../main.cpp batched_2d_spline_builder.cpp)
                 target_compile_features("${test_name}" PUBLIC cxx_std_17)
-                target_link_libraries("${test_name}" PUBLIC GTest::gtest DDC::DDC)
+                target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
                 target_compile_definitions(
                     "${test_name}"
                     PUBLIC -DDEGREE=${DEGREE} -D${BSPLINES_TYPE} -D${EVALUATOR} -D${BC}


### PR DESCRIPTION
Current public targets:
- `DDC::core` contains the core part of DDC
- `DDC::pdi` and `DDC::PDI_Wrapper` (deprecated) contain the PDI extension
- `DDC::fft` contains the FFT extension
- `DDC::splines` contains the Splines extension
- `DDC::DDC` contains all