### PR TITLE
Remove definition MDSPAN_USE_PAREN_OPERATOR=1 from DDC target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -122,6 +122,9 @@ jobs:
         - image: 'oldest' # nvcc 11 only supports C++-17
           backend: 'cuda'
           cxx_version: '23'
+        - image: 'oldest' # clang bug with multidimensional bracket operator and parameter packs
+          backend: 'hip'
+          cxx_version: '23'
         - image: 'latest' # nvcc 12 only supports C++-20
           backend: 'cuda'
           cxx_version: '23'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,6 @@ target_include_directories(
         "$<INSTALL_INTERFACE:include>"
 )
 target_link_libraries(DDC INTERFACE Kokkos::kokkos)
-target_compile_definitions(DDC INTERFACE MDSPAN_USE_PAREN_OPERATOR=1)
 if("${DDC_BUILD_DOUBLE_PRECISION}")
     target_compile_definitions(DDC INTERFACE DDC_BUILD_DOUBLE_PRECISION)
 endif()

--- a/include/ddc/chunk.hpp
+++ b/include/ddc/chunk.hpp
@@ -193,7 +193,7 @@ public:
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
         assert(((select<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain)) && ...));
         assert(((select<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain)) && ...));
-        return detail::mdspan_call(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
+        return DDC_MDSPAN_ACCESS_OP(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
     }
 
     /** Element access using a list of DiscreteElement
@@ -209,7 +209,7 @@ public:
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
         assert(((select<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain)) && ...));
         assert(((select<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain)) && ...));
-        return detail::mdspan_call(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
+        return DDC_MDSPAN_ACCESS_OP(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
     }
 
     /** Returns the label of the Chunk

--- a/include/ddc/chunk.hpp
+++ b/include/ddc/chunk.hpp
@@ -13,6 +13,7 @@
 #include "ddc/chunk_common.hpp"
 #include "ddc/chunk_span.hpp"
 #include "ddc/chunk_traits.hpp"
+#include "ddc/detail/kokkos.hpp"
 #include "ddc/kokkos_allocator.hpp"
 
 namespace ddc {
@@ -192,7 +193,7 @@ public:
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
         assert(((select<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain)) && ...));
         assert(((select<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain)) && ...));
-        return this->m_internal_mdspan(uid<DDims>(take<DDims>(delems...))...);
+        return detail::mdspan_call(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
     }
 
     /** Element access using a list of DiscreteElement
@@ -208,7 +209,7 @@ public:
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
         assert(((select<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain)) && ...));
         assert(((select<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain)) && ...));
-        return this->m_internal_mdspan(uid<DDims>(take<DDims>(delems...))...);
+        return detail::mdspan_call(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
     }
 
     /** Returns the label of the Chunk

--- a/include/ddc/chunk_span.hpp
+++ b/include/ddc/chunk_span.hpp
@@ -330,7 +330,7 @@ public:
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
         assert(((select<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain)) && ...));
         assert(((select<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain)) && ...));
-        return detail::mdspan_call(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
+        return DDC_MDSPAN_ACCESS_OP(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
     }
 
     /** Access to the underlying allocation pointer

--- a/include/ddc/chunk_span.hpp
+++ b/include/ddc/chunk_span.hpp
@@ -330,7 +330,7 @@ public:
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
         assert(((select<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain)) && ...));
         assert(((select<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain)) && ...));
-        return this->m_internal_mdspan(uid<DDims>(take<DDims>(delems...))...);
+        return detail::mdspan_call(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
     }
 
     /** Access to the underlying allocation pointer

--- a/include/ddc/detail/kokkos.hpp
+++ b/include/ddc/detail/kokkos.hpp
@@ -13,12 +13,16 @@
 
 #include "macros.hpp"
 
+// if MDSPAN_USE_BRACKET_OPERATOR is defined then we are likely
+// using the Kokkos implementation of mdspan
 #if defined(MDSPAN_USE_BRACKET_OPERATOR)
 #if MDSPAN_USE_BRACKET_OPERATOR
 #define DDC_MDSPAN_ACCESS_OP(mds, ...) mds[__VA_ARGS__]
 #else
 #define DDC_MDSPAN_ACCESS_OP(mds, ...) mds(__VA_ARGS__)
 #endif
+// else we are likely using an other implementation
+// then we can only use the bracket operator
 #else
 #define DDC_MDSPAN_ACCESS_OP(mds, ...) mds[__VA_ARGS__]
 #endif

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -600,7 +600,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     double saved;
     double temp;
-    detail::mdspan_call(ndu, 0, 0) = 1.0;
+    DDC_MDSPAN_ACCESS_OP(ndu, 0, 0) = 1.0;
     for (std::size_t j = 0; j < degree(); ++j) {
         left[j] = x - ddc::coordinate(icell - j);
         right[j] = ddc::coordinate(icell + j + 1) - x;
@@ -608,47 +608,47 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
         for (std::size_t r = 0; r < j + 1; ++r) {
             // compute inverse of knot differences and save them into lower
             // triangular part of ndu
-            detail::mdspan_call(ndu, r, j + 1) = 1.0 / (right[r] + left[j - r]);
+            DDC_MDSPAN_ACCESS_OP(ndu, r, j + 1) = 1.0 / (right[r] + left[j - r]);
             // compute basis functions and save them into upper triangular part
             // of ndu
-            temp = detail::mdspan_call(ndu, j, r) * detail::mdspan_call(ndu, r, j + 1);
-            detail::mdspan_call(ndu, j + 1, r) = saved + right[r] * temp;
+            temp = DDC_MDSPAN_ACCESS_OP(ndu, j, r) * DDC_MDSPAN_ACCESS_OP(ndu, r, j + 1);
+            DDC_MDSPAN_ACCESS_OP(ndu, j + 1, r) = saved + right[r] * temp;
             saved = left[j - r] * temp;
         }
-        detail::mdspan_call(ndu, j + 1, j + 1) = saved;
+        DDC_MDSPAN_ACCESS_OP(ndu, j + 1, j + 1) = saved;
     }
     // Save 0-th derivative
     for (std::size_t j = 0; j < degree() + 1; ++j) {
-        detail::mdspan_call(derivs, j, 0) = detail::mdspan_call(ndu, degree(), j);
+        DDC_MDSPAN_ACCESS_OP(derivs, j, 0) = DDC_MDSPAN_ACCESS_OP(ndu, degree(), j);
     }
 
     for (int r = 0; r < int(degree() + 1); ++r) {
         int s1 = 0;
         int s2 = 1;
-        detail::mdspan_call(a, 0, 0) = 1.0;
+        DDC_MDSPAN_ACCESS_OP(a, 0, 0) = 1.0;
         for (int k = 1; k < int(n + 1); ++k) {
             double d = 0.0;
             int const rk = r - k;
             int const pk = degree() - k;
             if (r >= k) {
-                detail::mdspan_call(a, 0, s2)
-                        = detail::mdspan_call(a, 0, s1) * detail::mdspan_call(ndu, rk, pk + 1);
-                d = detail::mdspan_call(a, 0, s2) * detail::mdspan_call(ndu, pk, rk);
+                DDC_MDSPAN_ACCESS_OP(a, 0, s2)
+                        = DDC_MDSPAN_ACCESS_OP(a, 0, s1) * DDC_MDSPAN_ACCESS_OP(ndu, rk, pk + 1);
+                d = DDC_MDSPAN_ACCESS_OP(a, 0, s2) * DDC_MDSPAN_ACCESS_OP(ndu, pk, rk);
             }
             int const j1 = rk > -1 ? 1 : (-rk);
             int const j2 = (r - 1) <= pk ? k : (degree() - r + 1);
             for (int j = j1; j < j2; ++j) {
-                detail::mdspan_call(a, j, s2)
-                        = (detail::mdspan_call(a, j, s1) - detail::mdspan_call(a, j - 1, s1))
-                          * detail::mdspan_call(ndu, rk + j, pk + 1);
-                d += detail::mdspan_call(a, j, s2) * detail::mdspan_call(ndu, pk, rk + j);
+                DDC_MDSPAN_ACCESS_OP(a, j, s2)
+                        = (DDC_MDSPAN_ACCESS_OP(a, j, s1) - DDC_MDSPAN_ACCESS_OP(a, j - 1, s1))
+                          * DDC_MDSPAN_ACCESS_OP(ndu, rk + j, pk + 1);
+                d += DDC_MDSPAN_ACCESS_OP(a, j, s2) * DDC_MDSPAN_ACCESS_OP(ndu, pk, rk + j);
             }
             if (r <= pk) {
-                detail::mdspan_call(a, k, s2)
-                        = -detail::mdspan_call(a, k - 1, s1) * detail::mdspan_call(ndu, r, pk + 1);
-                d += detail::mdspan_call(a, k, s2) * detail::mdspan_call(ndu, pk, r);
+                DDC_MDSPAN_ACCESS_OP(a, k, s2) = -DDC_MDSPAN_ACCESS_OP(a, k - 1, s1)
+                                                 * DDC_MDSPAN_ACCESS_OP(ndu, r, pk + 1);
+                d += DDC_MDSPAN_ACCESS_OP(a, k, s2) * DDC_MDSPAN_ACCESS_OP(ndu, pk, r);
             }
-            detail::mdspan_call(derivs, r, k) = d;
+            DDC_MDSPAN_ACCESS_OP(derivs, r, k) = d;
             Kokkos::kokkos_swap(s1, s2);
         }
     }
@@ -656,7 +656,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     int r = degree();
     for (int k = 1; k < int(n + 1); ++k) {
         for (std::size_t i = 0; i < derivs.extent(0); ++i) {
-            detail::mdspan_call(derivs, i, k) *= r;
+            DDC_MDSPAN_ACCESS_OP(derivs, i, k) *= r;
         }
         r *= degree() - k;
     }

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -413,17 +413,17 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     double xx;
     double temp;
     double saved;
-    detail::mdspan_call(values, 0) = 1.0;
+    DDC_MDSPAN_ACCESS_OP(values, 0) = 1.0;
     for (std::size_t j = 1; j < values.size(); ++j) {
         xx = -offset;
         saved = 0.0;
         for (std::size_t r = 0; r < j; ++r) {
             xx += 1;
-            temp = detail::mdspan_call(values, r) / j;
-            detail::mdspan_call(values, r) = saved + xx * temp;
+            temp = DDC_MDSPAN_ACCESS_OP(values, r) / j;
+            DDC_MDSPAN_ACCESS_OP(values, r) = saved + xx * temp;
             saved = (j - xx) * temp;
         }
-        detail::mdspan_call(values, j) = saved;
+        DDC_MDSPAN_ACCESS_OP(values, j) = saved;
     }
 
     return discrete_element_type(jmin);
@@ -447,29 +447,29 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     double xx;
     double temp;
     double saved;
-    detail::mdspan_call(derivs, 0) = 1.0 / ddc::step<knot_discrete_dimension_type>();
+    DDC_MDSPAN_ACCESS_OP(derivs, 0) = 1.0 / ddc::step<knot_discrete_dimension_type>();
     for (std::size_t j = 1; j < degree(); ++j) {
         xx = -offset;
         saved = 0.0;
         for (std::size_t r = 0; r < j; ++r) {
             xx += 1.0;
-            temp = detail::mdspan_call(derivs, r) / j;
-            detail::mdspan_call(derivs, r) = saved + xx * temp;
+            temp = DDC_MDSPAN_ACCESS_OP(derivs, r) / j;
+            DDC_MDSPAN_ACCESS_OP(derivs, r) = saved + xx * temp;
             saved = (j - xx) * temp;
         }
-        detail::mdspan_call(derivs, j) = saved;
+        DDC_MDSPAN_ACCESS_OP(derivs, j) = saved;
     }
 
     // Compute derivatives
     double bjm1 = derivs[0];
     double bj = bjm1;
-    detail::mdspan_call(derivs, 0) = -bjm1;
+    DDC_MDSPAN_ACCESS_OP(derivs, 0) = -bjm1;
     for (std::size_t j = 1; j < degree(); ++j) {
-        bj = detail::mdspan_call(derivs, j);
-        detail::mdspan_call(derivs, j) = bjm1 - bj;
+        bj = DDC_MDSPAN_ACCESS_OP(derivs, j);
+        DDC_MDSPAN_ACCESS_OP(derivs, j) = bjm1 - bj;
         bjm1 = bj;
     }
-    detail::mdspan_call(derivs, degree()) = bj;
+    DDC_MDSPAN_ACCESS_OP(derivs, degree()) = bj;
 
     return discrete_element_type(jmin);
 }
@@ -507,47 +507,47 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     double xx;
     double temp;
     double saved;
-    detail::mdspan_call(ndu, 0, 0) = 1.0;
+    DDC_MDSPAN_ACCESS_OP(ndu, 0, 0) = 1.0;
     for (std::size_t j = 1; j < degree() + 1; ++j) {
         xx = -offset;
         saved = 0.0;
         for (std::size_t r = 0; r < j; ++r) {
             xx += 1.0;
-            temp = detail::mdspan_call(ndu, j - 1, r) / j;
-            detail::mdspan_call(ndu, j, r) = saved + xx * temp;
+            temp = DDC_MDSPAN_ACCESS_OP(ndu, j - 1, r) / j;
+            DDC_MDSPAN_ACCESS_OP(ndu, j, r) = saved + xx * temp;
             saved = (j - xx) * temp;
         }
-        detail::mdspan_call(ndu, j, j) = saved;
+        DDC_MDSPAN_ACCESS_OP(ndu, j, j) = saved;
     }
     for (std::size_t i = 0; i < ndu.extent(1); ++i) {
-        detail::mdspan_call(derivs, i, 0) = detail::mdspan_call(ndu, degree(), i);
+        DDC_MDSPAN_ACCESS_OP(derivs, i, 0) = DDC_MDSPAN_ACCESS_OP(ndu, degree(), i);
     }
 
     for (int r = 0; r < int(degree() + 1); ++r) {
         int s1 = 0;
         int s2 = 1;
-        detail::mdspan_call(a, 0, 0) = 1.0;
+        DDC_MDSPAN_ACCESS_OP(a, 0, 0) = 1.0;
         for (int k = 1; k < int(n + 1); ++k) {
             double d = 0.0;
             int const rk = r - k;
             int const pk = degree() - k;
             if (r >= k) {
-                detail::mdspan_call(a, 0, s2) = detail::mdspan_call(a, 0, s1) / (pk + 1);
-                d = detail::mdspan_call(a, 0, s2) * detail::mdspan_call(ndu, pk, rk);
+                DDC_MDSPAN_ACCESS_OP(a, 0, s2) = DDC_MDSPAN_ACCESS_OP(a, 0, s1) / (pk + 1);
+                d = DDC_MDSPAN_ACCESS_OP(a, 0, s2) * DDC_MDSPAN_ACCESS_OP(ndu, pk, rk);
             }
             int const j1 = rk > -1 ? 1 : (-rk);
             int const j2 = (r - 1) <= pk ? k : (degree() - r + 1);
             for (int j = j1; j < j2; ++j) {
-                detail::mdspan_call(a, j, s2)
-                        = (detail::mdspan_call(a, j, s1) - detail::mdspan_call(a, j - 1, s1))
+                DDC_MDSPAN_ACCESS_OP(a, j, s2)
+                        = (DDC_MDSPAN_ACCESS_OP(a, j, s1) - DDC_MDSPAN_ACCESS_OP(a, j - 1, s1))
                           / (pk + 1);
-                d += detail::mdspan_call(a, j, s2) * detail::mdspan_call(ndu, pk, rk + j);
+                d += DDC_MDSPAN_ACCESS_OP(a, j, s2) * DDC_MDSPAN_ACCESS_OP(ndu, pk, rk + j);
             }
             if (r <= pk) {
-                detail::mdspan_call(a, k, s2) = -detail::mdspan_call(a, k - 1, s1) / (pk + 1);
-                d += detail::mdspan_call(a, k, s2) * detail::mdspan_call(ndu, pk, r);
+                DDC_MDSPAN_ACCESS_OP(a, k, s2) = -DDC_MDSPAN_ACCESS_OP(a, k - 1, s1) / (pk + 1);
+                d += DDC_MDSPAN_ACCESS_OP(a, k, s2) * DDC_MDSPAN_ACCESS_OP(ndu, pk, r);
             }
-            detail::mdspan_call(derivs, r, k) = d;
+            DDC_MDSPAN_ACCESS_OP(derivs, r, k) = d;
             Kokkos::kokkos_swap(s1, s2);
         }
     }
@@ -559,7 +559,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     double d = degree() * inv_dx;
     for (int k = 1; k < int(n + 1); ++k) {
         for (std::size_t i = 0; i < derivs.extent(0); ++i) {
-            detail::mdspan_call(derivs, i, k) *= d;
+            DDC_MDSPAN_ACCESS_OP(derivs, i, k) *= d;
         }
         d *= (degree() - k) * inv_dx;
     }

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -501,7 +501,7 @@ int SplineBuilder<
         } else {
             int const mid = bsplines_type::degree() / 2;
             offset = jmin.uid() - start.uid()
-                     + (detail::mdspan_call(values, mid) > detail::mdspan_call(values, mid + 1)
+                     + (DDC_MDSPAN_ACCESS_OP(values, mid) > DDC_MDSPAN_ACCESS_OP(values, mid + 1)
                                 ? mid
                                 : mid + 1)
                      - BSplines::degree();
@@ -680,7 +680,7 @@ void SplineBuilder<
         // all derivatives by multiplying the i-th derivative by dx^i
         for (std::size_t i = 0; i < bsplines_type::degree() + 1; ++i) {
             for (std::size_t j = 1; j < bsplines_type::degree() / 2 + 1; ++j) {
-                detail::mdspan_call(derivs, i, j) *= ddc::detail::ipow(m_dx, j);
+                DDC_MDSPAN_ACCESS_OP(derivs, i, j) *= ddc::detail::ipow(m_dx, j);
             }
         }
 
@@ -690,7 +690,7 @@ void SplineBuilder<
                 matrix->set_element(
                         i,
                         j,
-                        detail::mdspan_call(derivs, j, s_nbc_xmin - i - 1 + s_odd));
+                        DDC_MDSPAN_ACCESS_OP(derivs, j, s_nbc_xmin - i - 1 + s_odd));
             }
         }
     }
@@ -709,7 +709,7 @@ void SplineBuilder<
             int const j = ddc::detail::
                     modulo(int(jmin.uid() - m_offset + s),
                            static_cast<int>(ddc::discrete_space<BSplines>().nbasis()));
-            matrix->set_element(ix.uid() - start + s_nbc_xmin, j, detail::mdspan_call(values, s));
+            matrix->set_element(ix.uid() - start + s_nbc_xmin, j, DDC_MDSPAN_ACCESS_OP(values, s));
         }
     });
 
@@ -733,7 +733,7 @@ void SplineBuilder<
         // all derivatives by multiplying the i-th derivative by dx^i
         for (std::size_t i = 0; i < bsplines_type::degree() + 1; ++i) {
             for (std::size_t j = 1; j < bsplines_type::degree() / 2 + 1; ++j) {
-                detail::mdspan_call(derivs, i, j) *= ddc::detail::ipow(m_dx, j);
+                DDC_MDSPAN_ACCESS_OP(derivs, i, j) *= ddc::detail::ipow(m_dx, j);
             }
         }
 
@@ -741,7 +741,7 @@ void SplineBuilder<
         int const j0 = ddc::discrete_space<BSplines>().nbasis() - bsplines_type::degree();
         for (std::size_t j = 0; j < bsplines_type::degree(); ++j) {
             for (std::size_t i = 0; i < s_nbc_xmax; ++i) {
-                matrix->set_element(i0 + i, j0 + j, detail::mdspan_call(derivs, j + 1, i + s_odd));
+                matrix->set_element(i0 + i, j0 + j, DDC_MDSPAN_ACCESS_OP(derivs, j + 1, i + s_odd));
             }
         }
     }

--- a/tests/splines/bsplines.cpp
+++ b/tests/splines/bsplines.cpp
@@ -75,7 +75,7 @@ TYPED_TEST(BSplinesFixture, PartitionOfUnityUniform)
         ddc::discrete_space<BSplinesX>().eval_basis(values, test_point);
         double sum = 0.0;
         for (std::size_t j(0); j < degree + 1; ++j) {
-            sum += values(j);
+            sum += ddc::detail::mdspan_call(values, j);
         }
         EXPECT_LE(fabs(sum - 1.0), 1.0e-15);
     }
@@ -110,7 +110,7 @@ TYPED_TEST(BSplinesFixture, PartitionOfUnityNonUniform)
         ddc::discrete_space<BSplinesX>().eval_basis(values, test_point);
         double sum = 0.0;
         for (std::size_t j(0); j < degree + 1; ++j) {
-            sum += values(j);
+            sum += ddc::detail::mdspan_call(values, j);
         }
         EXPECT_LE(fabs(sum - 1.0), 1.0e-15);
     }

--- a/tests/splines/bsplines.cpp
+++ b/tests/splines/bsplines.cpp
@@ -75,7 +75,7 @@ TYPED_TEST(BSplinesFixture, PartitionOfUnityUniform)
         ddc::discrete_space<BSplinesX>().eval_basis(values, test_point);
         double sum = 0.0;
         for (std::size_t j(0); j < degree + 1; ++j) {
-            sum += ddc::detail::mdspan_call(values, j);
+            sum += DDC_MDSPAN_ACCESS_OP(values, j);
         }
         EXPECT_LE(fabs(sum - 1.0), 1.0e-15);
     }
@@ -110,7 +110,7 @@ TYPED_TEST(BSplinesFixture, PartitionOfUnityNonUniform)
         ddc::discrete_space<BSplinesX>().eval_basis(values, test_point);
         double sum = 0.0;
         for (std::size_t j(0); j < degree + 1; ++j) {
-            sum += ddc::detail::mdspan_call(values, j);
+            sum += DDC_MDSPAN_ACCESS_OP(values, j);
         }
         EXPECT_LE(fabs(sum - 1.0), 1.0e-15);
     }


### PR DESCRIPTION
DDC should not force dependent projects to use `MDSPAN_USE_PAREN_OPERATOR=1`. Moreover this variable only makes sense in the Kokkos implementation of mdspan. A compiler provided implementation will likely not provide this variable neither the function call operator, see [cppref](https://en.cppreference.com/w/cpp/container/mdspan).

In this PR, DDC adapts to the mdspan implementation, defaulting on using the bracket operator.

Note that there is a bug with llvm 15/16, see the reproducer on [godbolt](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:13,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:1,endLineNumber:20,positionColumn:1,positionLineNumber:20,selectionStartColumn:1,selectionStartLineNumber:20,startColumn:1,startLineNumber:20),source:'%23include+%3Carray%3E%0A%0A%23if+defined(__cpp_multidimensional_subscript)%0A%0A%23define+VERSION+2%0A%0A%23if+VERSION+%3D%3D+1%0A%23define+CALL_BRACKET_OP(container,+...)+container%5B__VA_ARGS__%5D%0A%23elif+VERSION+%3D%3D+2%0Adecltype(auto)+CALL_BRACKET_OP(auto+const%26+container,+auto...+args)+%7B%0A++++return+container%5Bargs...%5D%3B%0A%7D%0A%23endif%0A%0Aint+main()+%7B%0A++++std::array+const+a%7B0%7D%3B%0A++++return+CALL_BRACKET_OP(a,+0)%3B%0A%7D%0A%23endif%0A'),l:'5',n:'1',o:'C%2B%2B+source+%231',t:'0')),k:54.385964912280706,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((g:!((h:compiler,i:(compiler:clang1500,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'0',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'-std%3Dc%2B%2B2b',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+x86-64+clang+15.0.0+(Editor+%231)',t:'0')),k:50,l:'4',m:58.48234754699679,n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'clang+rocm-5.7.0',editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'0'),l:'5',n:'0',o:'Output+of+x86-64+clang+15.0.0+(Compiler+%231)',t:'0')),header:(),l:'4',m:41.51765245300321,n:'0',o:'',s:0,t:'0')),k:45.614035087719294,l:'3',n:'0',o:'',t:'0')),l:'2',n:'0',o:'',t:'0')),version:4). It has been reported on the mdspan repo, see [here](https://github.com/kokkos/mdspan/issues/361).

The two first commits provide alternative implementations that correctly call mdspan either with:
- a new function
- a new preprocessor macro