### PR TITLE
Add a batched operator() to SplineEvaluator without the coordinates argument

### DIFF
--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -290,23 +290,21 @@ public:
     }
 
     /**
-     * @brief Evaluate spline function (described by its spline coefficients) on a
-     * mesh.
+     * @brief Evaluate a spline function (described by its spline coefficients) on a mesh.
      *
      * The spline coefficients represent a spline function defined on a cartesian
      * product of batch_domain and B-splines (basis splines). They can be obtained
      * via various methods, such as using a SplineBuilder.
      *
      * This is not a multidimensional evaluation. This is a batched 1D evaluation.
-     * This means that for each slice of coordinates identified by a
-     * batch_domain_type::discrete_element_type, the evaluation is performed with
-     * the 1D set of spline coefficients identified by the same
-     * batch_domain_type::discrete_element_type.
+     * This means that for each slice of spline_eval the evaluation is performed with
+     * the 1D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * Remark: calling SplineBuilder then SplineEvaluator corresponds to a spline
      * interpolation.
      *
-     * @param[out] spline_eval The values of the spline function at the coordinates.
+     * @param[out] spline_eval The values of the spline function at the coordinates
+     * of the mesh.
      * @param[in] spline_coef A ChunkSpan storing the spline coefficients.
      */
     template <class Layout1, class Layout2>
@@ -408,8 +406,9 @@ public:
      * (basis splines). They can be obtained via various methods, such as using a SplineBuilder.
      *
      * The derivation is not performed in a multidimensional way (in any sense). This is a batched 1D derivation.
-     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
-     * the derivation is performed with the 1D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     * This is not a multidimensional evaluation. This is a batched 1D evaluation.
+     * This means that for each slice of spline_eval the evaluation is performed with
+     * the 1D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[out] spline_eval The derivatives of the spline function at the coordinates.
      * @param[in] spline_coef A ChunkSpan storing the spline coefficients.

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -325,7 +325,8 @@ public:
                     const auto spline_eval_1D = spline_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
                     for (auto const i : evaluation_domain) {
-                        ddc::Coordinate<continuous_dimension_type> coord_eval_1D = ddc::coordinate(i);
+                        ddc::Coordinate<continuous_dimension_type> coord_eval_1D
+                                = ddc::coordinate(i);
                         spline_eval_1D(i) = eval(coord_eval_1D, spline_coef_1D);
                     }
                 });
@@ -431,8 +432,10 @@ public:
                     const auto spline_eval_1D = spline_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
                     for (auto const i : evaluation_domain) {
-                        ddc::Coordinate<continuous_dimension_type> coord_eval_1D = ddc::coordinate(i);
-                        spline_eval_1D(i) = eval_no_bc<eval_deriv_type>(coord_eval_1D, spline_coef_1D);
+                        ddc::Coordinate<continuous_dimension_type> coord_eval_1D
+                                = ddc::coordinate(i);
+                        spline_eval_1D(i)
+                                = eval_no_bc<eval_deriv_type>(coord_eval_1D, spline_coef_1D);
                     }
                 });
     }

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -409,14 +409,13 @@ public:
      * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
      * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
      *
-     * This is not a nD evaluation. This is a batched 2D evaluation. This means that for each slice of coordinates
-     * identified by a batch_domain_type::discrete_element_type, the evaluation is performed with the 2D set of
-     * spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     * This is not a multidimensional evaluation. This is a batched 2D evaluation.
+     * This means that for each slice of spline_eval the evaluation is performed with
+     * the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * Remark: calling SplineBuilder2D then SplineEvaluator2D corresponds to a 2D spline interpolation.
      *
-     * @param[out] spline_eval The values of the 2D spline function at their coordinates. For practical reasons those are
-     * stored in a ChunkSpan defined on a batched_evaluation_domain_type.
+     * @param[out] spline_eval The values of the 2D spline function at their coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
      */
     template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
@@ -635,9 +634,9 @@ public:
      * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
      * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
      *
-     * This is not a nD evaluation. This is a batched 2D differentiation.
-     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
-     * the differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     * This is not a multidimensional evaluation. This is a batched 2D evaluation.
+     * This means that for each slice of spline_eval the evaluation is performed with
+     * the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
@@ -728,9 +727,9 @@ public:
      * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
      * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
      *
-     * This is not a nD differentiation. This is a batched 2D differentiation.
-     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
-     * the differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     * This is not a multidimensional evaluation. This is a batched 2D evaluation.
+     * This means that for each slice of spline_eval the evaluation is performed with
+     * the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
@@ -821,9 +820,9 @@ public:
      * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
      * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
      *
-     * This is not a nD cross-differentiation. This is a batched 2D cross-differentiation.
-     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
-     * the cross-differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     * This is not a multidimensional evaluation. This is a batched 2D evaluation.
+     * This means that for each slice of spline_eval the evaluation is performed with
+     * the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @param[out] spline_eval The cross-derivatives of the 2D spline function at the desired coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
@@ -910,9 +909,9 @@ public:
      * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
      * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
      *
-     * This is not a nD evaluation. This is a batched 2D differentiation.
-     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
-     * the differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     * This is not a multidimensional evaluation. This is a batched 2D evaluation.
+     * This means that for each slice of spline_eval the evaluation is performed with
+     * the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * @tparam InterestDim Dimension along which differentiation is performed.
      * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
@@ -1002,9 +1001,9 @@ public:
      * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
      * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
      *
-     * This is not a nD evaluation. This is a batched 2D differentiation.
-     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
-     * the differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     * This is not a multidimensional evaluation. This is a batched 2D evaluation.
+     * This means that for each slice of spline_eval the evaluation is performed with
+     * the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
      *
      * Note: double-differentiation other than cross-differentiation is not supported atm. See #440
      *

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -1013,11 +1013,7 @@ public:
      * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
      */
-    template <
-            class InterestDim1,
-            class InterestDim2,
-            class Layout1,
-            class Layout2>
+    template <class InterestDim1, class InterestDim2, class Layout1, class Layout2>
     void deriv2(
             ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
                     spline_eval,

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -845,6 +845,8 @@ public:
                     const auto spline_coef_2D = spline_coef[j];
                     for (auto const i1 : evaluation_domain1) {
                         for (auto const i2 : evaluation_domain2) {
+                            ddc::Coordinate<continuous_dimension_type1, continuous_dimension_type2>
+                                    coord_eval_2D(ddc::coordinate(i1), ddc::coordinate(i2));
                             spline_eval_2D(i1, i2) = eval_no_bc<
                                     eval_deriv_type,
                                     eval_deriv_type>(coord_eval_2D, spline_coef_2D);

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -404,6 +404,50 @@ public:
     }
 
     /**
+     * @brief Evaluate 2D spline function (described by its spline coefficients) on a mesh.
+     *
+     * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
+     * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
+     *
+     * This is not a nD evaluation. This is a batched 2D evaluation. This means that for each slice of coordinates
+     * identified by a batch_domain_type::discrete_element_type, the evaluation is performed with the 2D set of
+     * spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     *
+     * Remark: calling SplineBuilder2D then SplineEvaluator2D corresponds to a 2D spline interpolation.
+     *
+     * @param[out] spline_eval The values of the 2D spline function at their coordinates. For practical reasons those are
+     * stored in a ChunkSpan defined on a batched_evaluation_domain_type.
+     * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
+     */
+    template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
+    void operator()(
+            ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
+                    spline_eval,
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout3, memory_space> const
+                    spline_coef) const
+    {
+        batch_domain_type const batch_domain(coords_eval.domain());
+        evaluation_domain_type1 const evaluation_domain1(spline_eval.domain());
+        evaluation_domain_type2 const evaluation_domain2(spline_eval.domain());
+        ddc::parallel_for_each(
+                "ddc_splines_evaluate_2d",
+                exec_space(),
+                batch_domain,
+                KOKKOS_CLASS_LAMBDA(typename batch_domain_type::discrete_element_type const j) {
+                    const auto spline_eval_2D = spline_eval[j];
+                    const auto coords_eval_2D = coords_eval[j];
+                    const auto spline_coef_2D = spline_coef[j];
+                    for (auto const i1 : evaluation_domain1) {
+                        for (auto const i2 : evaluation_domain2) {
+                            ddc::Coordinate<continuous_dimension_type1, continuous_dimension_type2>
+                                    coord_eval_2D(ddc::coordinate(i1), ddc::coordinate(i2));
+                            spline_eval_2D(i1, i2) = eval(coords_eval_2D(i1, i2), spline_coef_2D);
+                        }
+                    }
+                });
+    }
+
+    /**
      * @brief Differentiate 2D spline function (described by its spline coefficients) at a given coordinate along first dimension of interest.
      *
      * The spline coefficients represent a 2D spline function defined on a B-splines (basis splines). They can be
@@ -586,6 +630,48 @@ public:
     }
 
     /**
+     * @brief Differentiate 2D spline function (described by its spline coefficients) on a mesh along first dimension of interest.
+     *
+     * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
+     * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
+     *
+     * This is not a nD evaluation. This is a batched 2D differentiation.
+     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
+     * the differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     *
+     * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
+     * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
+     */
+    template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
+    void deriv_dim_1(
+            ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
+                    spline_eval,
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout3, memory_space> const
+                    spline_coef) const
+    {
+        batch_domain_type const batch_domain(coords_eval.domain());
+        evaluation_domain_type1 const evaluation_domain1(spline_eval.domain());
+        evaluation_domain_type2 const evaluation_domain2(spline_eval.domain());
+        ddc::parallel_for_each(
+                "ddc_splines_differentiate_2d_dim_1",
+                exec_space(),
+                batch_domain,
+                KOKKOS_CLASS_LAMBDA(typename batch_domain_type::discrete_element_type const j) {
+                    const auto spline_eval_2D = spline_eval[j];
+                    const auto spline_coef_2D = spline_coef[j];
+                    for (auto const i1 : evaluation_domain1) {
+                        for (auto const i2 : evaluation_domain2) {
+                            ddc::Coordinate<continuous_dimension_type1, continuous_dimension_type2>
+                                    coord_eval_2D(ddc::coordinate(i1), ddc::coordinate(i2));
+                            spline_eval_2D(i1, i2) = eval_no_bc<
+                                    eval_deriv_type,
+                                    eval_type>(coord_eval_2D, spline_coef_2D);
+                        }
+                    }
+                });
+    }
+
+    /**
      * @brief Differentiate 2D spline function (described by its spline coefficients) on a mesh along second dimension of interest.
      *
      * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
@@ -631,6 +717,48 @@ public:
                             spline_eval_2D(i1, i2) = eval_no_bc<
                                     eval_type,
                                     eval_deriv_type>(coords_eval_2D(i1, i2), spline_coef_2D);
+                        }
+                    }
+                });
+    }
+
+    /**
+     * @brief Differentiate 2D spline function (described by its spline coefficients) on a mesh along second dimension of interest.
+     *
+     * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
+     * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
+     *
+     * This is not a nD differentiation. This is a batched 2D differentiation.
+     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
+     * the differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     *
+     * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
+     * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
+     */
+    template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
+    void deriv_dim_2(
+            ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
+                    spline_eval,
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout3, memory_space> const
+                    spline_coef) const
+    {
+        batch_domain_type const batch_domain(spline_eval.domain());
+        evaluation_domain_type1 const evaluation_domain1(spline_eval.domain());
+        evaluation_domain_type2 const evaluation_domain2(spline_eval.domain());
+        ddc::parallel_for_each(
+                "ddc_splines_differentiate_2d_dim_2",
+                exec_space(),
+                batch_domain,
+                KOKKOS_CLASS_LAMBDA(typename batch_domain_type::discrete_element_type const j) {
+                    const auto spline_eval_2D = spline_eval[j];
+                    const auto spline_coef_2D = spline_coef[j];
+                    for (auto const i1 : evaluation_domain1) {
+                        for (auto const i2 : evaluation_domain2) {
+                            ddc::Coordinate<continuous_dimension_type1, continuous_dimension_type2>
+                                    coord_eval_2D(ddc::coordinate(i1), ddc::coordinate(i2));
+                            spline_eval_2D(i1, i2) = eval_no_bc<
+                                    eval_type,
+                                    eval_deriv_type>(coord_eval_2D, spline_coef_2D);
                         }
                     }
                 });
@@ -688,6 +816,46 @@ public:
     }
 
     /**
+     * @brief Cross-differentiate 2D spline function (described by its spline coefficients) on a mesh along dimensions of interest.
+     *
+     * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
+     * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
+     *
+     * This is not a nD cross-differentiation. This is a batched 2D cross-differentiation.
+     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
+     * the cross-differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     *
+     * @param[out] spline_eval The cross-derivatives of the 2D spline function at the desired coordinates.
+     * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
+     */
+    template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
+    void deriv_1_and_2(
+            ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
+                    spline_eval,
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout3, memory_space> const
+                    spline_coef) const
+    {
+        batch_domain_type const batch_domain(spline_eval.domain());
+        evaluation_domain_type1 const evaluation_domain1(spline_eval.domain());
+        evaluation_domain_type2 const evaluation_domain2(spline_eval.domain());
+        ddc::parallel_for_each(
+                "ddc_splines_cross_differentiate",
+                exec_space(),
+                batch_domain,
+                KOKKOS_CLASS_LAMBDA(typename batch_domain_type::discrete_element_type const j) {
+                    const auto spline_eval_2D = spline_eval[j];
+                    const auto spline_coef_2D = spline_coef[j];
+                    for (auto const i1 : evaluation_domain1) {
+                        for (auto const i2 : evaluation_domain2) {
+                            spline_eval_2D(i1, i2) = eval_no_bc<
+                                    eval_deriv_type,
+                                    eval_deriv_type>(coord_eval_2D, spline_coef_2D);
+                        }
+                    }
+                });
+    }
+
+    /**
      * @brief Differentiate spline function (described by its spline coefficients) on a mesh along a specified dimension of interest.
      *
      * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
@@ -733,6 +901,45 @@ public:
                                      typename evaluation_discrete_dimension_type2::
                                              continuous_dimension_type>) {
             return deriv_dim_2(spline_eval, coords_eval, spline_coef);
+        }
+    }
+
+    /**
+     * @brief Differentiate spline function (described by its spline coefficients) on a mesh along a specified dimension of interest.
+     *
+     * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
+     * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
+     *
+     * This is not a nD evaluation. This is a batched 2D differentiation.
+     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
+     * the differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     *
+     * @tparam InterestDim Dimension along which differentiation is performed.
+     * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
+     * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
+     */
+    template <class InterestDim, class Layout1, class Layout2>
+    void deriv(
+            ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
+                    spline_eval,
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout2, memory_space> const
+                    spline_coef) const
+    {
+        static_assert(
+                std::is_same_v<
+                        InterestDim,
+                        typename evaluation_discrete_dimension_type1::continuous_dimension_type>
+                || std::is_same_v<InterestDim, continuous_dimension_type2>);
+        if constexpr (std::is_same_v<
+                              InterestDim,
+                              typename evaluation_discrete_dimension_type1::
+                                      continuous_dimension_type>) {
+            return deriv_dim_1(spline_eval, spline_coef);
+        } else if constexpr (std::is_same_v<
+                                     InterestDim,
+                                     typename evaluation_discrete_dimension_type2::
+                                             continuous_dimension_type>) {
+            return deriv_dim_2(spline_eval, spline_coef);
         }
     }
 
@@ -787,6 +994,47 @@ public:
                             typename evaluation_discrete_dimension_type1::continuous_dimension_type>
                     && std::is_same_v<InterestDim1, continuous_dimension_type2>));
         return deriv_1_and_2(spline_eval, coords_eval, spline_coef);
+    }
+
+    /**
+     * @brief Double-differentiate 2D spline function (described by its spline coefficients) on a mesh along specified dimensions of interest.
+     *
+     * The spline coefficients represent a 2D spline function defined on a cartesian product of batch_domain and B-splines
+     * (basis splines). They can be obtained via various methods, such as using a SplineBuilder2D.
+     *
+     * This is not a nD evaluation. This is a batched 2D differentiation.
+     * This means that for each slice of coordinates identified by a batch_domain_type::discrete_element_type,
+     * the differentiation is performed with the 2D set of spline coefficients identified by the same batch_domain_type::discrete_element_type.
+     *
+     * Note: double-differentiation other than cross-differentiation is not supported atm. See #440
+     *
+     * @tparam InterestDim1 First dimension along which differentiation is performed.
+     * @tparam InterestDim2 Second dimension along which differentiation is performed.
+     *
+     * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
+     * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
+     */
+    template <
+            class InterestDim1,
+            class InterestDim2,
+            class Layout1,
+            class Layout2>
+    void deriv2(
+            ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
+                    spline_eval,
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout2, memory_space> const
+                    spline_coef) const
+    {
+        static_assert(
+                (std::is_same_v<
+                         InterestDim1,
+                         typename evaluation_discrete_dimension_type1::continuous_dimension_type>
+                 && std::is_same_v<InterestDim2, continuous_dimension_type2>)
+                || (std::is_same_v<
+                            InterestDim2,
+                            typename evaluation_discrete_dimension_type1::continuous_dimension_type>
+                    && std::is_same_v<InterestDim1, continuous_dimension_type2>));
+        return deriv_1_and_2(spline_eval, spline_coef);
     }
 
     /** @brief Perform batched 2D integrations of a spline function (described by its spline coefficients) along the dimensions of interest and store results on a subdomain of batch_domain.

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -434,13 +434,12 @@ public:
                 batch_domain,
                 KOKKOS_CLASS_LAMBDA(typename batch_domain_type::discrete_element_type const j) {
                     const auto spline_eval_2D = spline_eval[j];
-                    const auto coords_eval_2D = coords_eval[j];
                     const auto spline_coef_2D = spline_coef[j];
                     for (auto const i1 : evaluation_domain1) {
                         for (auto const i2 : evaluation_domain2) {
                             ddc::Coordinate<continuous_dimension_type1, continuous_dimension_type2>
                                     coord_eval_2D(ddc::coordinate(i1), ddc::coordinate(i2));
-                            spline_eval_2D(i1, i2) = eval(coords_eval_2D(i1, i2), spline_coef_2D);
+                            spline_eval_2D(i1, i2) = eval(coord_eval_2D(i1, i2), spline_coef_2D);
                         }
                     }
                 });

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -418,14 +418,14 @@ public:
      * @param[out] spline_eval The values of the 2D spline function at their coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
      */
-    template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
+    template <class Layout1, class Layout2>
     void operator()(
             ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
                     spline_eval,
-            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout3, memory_space> const
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout2, memory_space> const
                     spline_coef) const
     {
-        batch_domain_type const batch_domain(coords_eval.domain());
+        batch_domain_type const batch_domain(spline_eval.domain());
         evaluation_domain_type1 const evaluation_domain1(spline_eval.domain());
         evaluation_domain_type2 const evaluation_domain2(spline_eval.domain());
         ddc::parallel_for_each(
@@ -641,14 +641,14 @@ public:
      * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
      */
-    template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
+    template <class Layout1, class Layout2>
     void deriv_dim_1(
             ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
                     spline_eval,
-            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout3, memory_space> const
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout2, memory_space> const
                     spline_coef) const
     {
-        batch_domain_type const batch_domain(coords_eval.domain());
+        batch_domain_type const batch_domain(spline_eval.domain());
         evaluation_domain_type1 const evaluation_domain1(spline_eval.domain());
         evaluation_domain_type2 const evaluation_domain2(spline_eval.domain());
         ddc::parallel_for_each(
@@ -734,11 +734,11 @@ public:
      * @param[out] spline_eval The derivatives of the 2D spline function at the desired coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
      */
-    template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
+    template <class Layout1, class Layout2>
     void deriv_dim_2(
             ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
                     spline_eval,
-            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout3, memory_space> const
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout2, memory_space> const
                     spline_coef) const
     {
         batch_domain_type const batch_domain(spline_eval.domain());
@@ -827,11 +827,11 @@ public:
      * @param[out] spline_eval The cross-derivatives of the 2D spline function at the desired coordinates.
      * @param[in] spline_coef A ChunkSpan storing the 2D spline coefficients.
      */
-    template <class Layout1, class Layout2, class Layout3, class... CoordsDims>
+    template <class Layout1, class Layout2>
     void deriv_1_and_2(
             ddc::ChunkSpan<double, batched_evaluation_domain_type, Layout1, memory_space> const
                     spline_eval,
-            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout3, memory_space> const
+            ddc::ChunkSpan<double const, batched_spline_domain_type, Layout2, memory_space> const
                     spline_coef) const
     {
         batch_domain_type const batch_domain(spline_eval.domain());


### PR DESCRIPTION
Add a batched `operator()` and derivative operators to `SplineEvaluator` and `SplineEvaluator2D` without the coordinates argument. Fixes #684 