### PR TITLE
Generalized domains

### DIFF
--- a/include/ddc/chunk.hpp
+++ b/include/ddc/chunk.hpp
@@ -187,13 +187,10 @@ public:
                 sizeof...(DDims) == (0 + ... + DElems::size()),
                 "Invalid number of dimensions");
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
-        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain))
-                && ...));
-        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain))
-                && ...));
+        assert(this->m_domain.is_inside(delems...));
         return DDC_MDSPAN_ACCESS_OP(
                 this->m_allocation_mdspan,
-                (DiscreteElement<DDims>(take<DDims>(delems...)) - front<DDims>(this->m_domain))...);
+                detail::array(this->m_domain.distance_from_front(delems...)));
     }
 
     /** Element access using a list of DiscreteElement
@@ -207,13 +204,10 @@ public:
                 sizeof...(DDims) == (0 + ... + DElems::size()),
                 "Invalid number of dimensions");
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
-        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain))
-                && ...));
-        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain))
-                && ...));
+        assert(this->m_domain.is_inside(delems...));
         return DDC_MDSPAN_ACCESS_OP(
                 this->m_allocation_mdspan,
-                (DiscreteElement<DDims>(take<DDims>(delems...)) - front<DDims>(this->m_domain))...);
+                detail::array(this->m_domain.distance_from_front(delems...)));
     }
 
     /** Returns the label of the Chunk

--- a/include/ddc/chunk.hpp
+++ b/include/ddc/chunk.hpp
@@ -449,7 +449,7 @@ public:
                 SupportType::rank() == (0 + ... + DElems::size()),
                 "Invalid number of dimensions");
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
-        assert(this->m_domain.is_inside(delems...));
+        assert(this->m_domain.contains(delems...));
         return DDC_MDSPAN_ACCESS_OP(
                 this->m_allocation_mdspan,
                 detail::array(this->m_domain.distance_from_front(delems...)));
@@ -466,7 +466,7 @@ public:
                 SupportType::rank() == (0 + ... + DElems::size()),
                 "Invalid number of dimensions");
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
-        assert(this->m_domain.is_inside(delems...));
+        assert(this->m_domain.contains(delems...));
         return DDC_MDSPAN_ACCESS_OP(
                 this->m_allocation_mdspan,
                 detail::array(this->m_domain.distance_from_front(delems...)));

--- a/include/ddc/chunk.hpp
+++ b/include/ddc/chunk.hpp
@@ -424,19 +424,19 @@ public:
         return *this;
     }
 
-    // /// Slice out some dimensions
-    // template <class... QueryDDims>
-    // auto operator[](DiscreteElement<QueryDDims...> const& slice_spec) const
-    // {
-    //     return view_type(*this)[slice_spec];
-    // }
+    /// Slice out some dimensions
+    template <class... QueryDDims>
+    auto operator[](DiscreteElement<QueryDDims...> const& slice_spec) const
+    {
+        return view_type(*this)[slice_spec];
+    }
 
-    // /// Slice out some dimensions
-    // template <class... QueryDDims>
-    // auto operator[](DiscreteElement<QueryDDims...> const& slice_spec)
-    // {
-    //     return span_view()[slice_spec];
-    // }
+    /// Slice out some dimensions
+    template <class... QueryDDims>
+    auto operator[](DiscreteElement<QueryDDims...> const& slice_spec)
+    {
+        return span_view()[slice_spec];
+    }
 
     /** Element access using a list of DiscreteElement
      * @param delems discrete coordinates

--- a/include/ddc/chunk.hpp
+++ b/include/ddc/chunk.hpp
@@ -24,6 +24,283 @@ class Chunk;
 template <class ElementType, class SupportType, class Allocator>
 inline constexpr bool enable_chunk<Chunk<ElementType, SupportType, Allocator>> = true;
 
+template <class ElementType, class... DDims, class Allocator>
+class Chunk<ElementType, DiscreteDomain<DDims...>, Allocator>
+    : public ChunkCommon<ElementType, DiscreteDomain<DDims...>, Kokkos::layout_right>
+{
+protected:
+    using base_type = ChunkCommon<ElementType, DiscreteDomain<DDims...>, Kokkos::layout_right>;
+
+    /// ND memory view
+    using internal_mdspan_type = typename base_type::internal_mdspan_type;
+
+public:
+    /// type of a span of this full chunk
+    using span_type = ChunkSpan<
+            ElementType,
+            DiscreteDomain<DDims...>,
+            Kokkos::layout_right,
+            typename Allocator::memory_space>;
+
+    /// type of a view of this full chunk
+    using view_type = ChunkSpan<
+            ElementType const,
+            DiscreteDomain<DDims...>,
+            Kokkos::layout_right,
+            typename Allocator::memory_space>;
+
+    /// The dereferenceable part of the co-domain but with indexing starting at 0
+    using allocation_mdspan_type = typename base_type::allocation_mdspan_type;
+
+    using const_allocation_mdspan_type = typename base_type::const_allocation_mdspan_type;
+
+    using discrete_domain_type = typename base_type::discrete_domain_type;
+
+    using memory_space = typename Allocator::memory_space;
+
+    using discrete_element_type = typename base_type::discrete_element_type;
+
+    using extents_type = typename base_type::extents_type;
+
+    using layout_type = typename base_type::layout_type;
+
+    using mapping_type = typename base_type::mapping_type;
+
+    using element_type = typename base_type::element_type;
+
+    using value_type = typename base_type::value_type;
+
+    using size_type = typename base_type::size_type;
+
+    using data_handle_type = typename base_type::data_handle_type;
+
+    using reference = typename base_type::reference;
+
+    template <class, class, class>
+    friend class Chunk;
+
+private:
+    Allocator m_allocator;
+
+    std::string m_label;
+
+public:
+    /// Empty Chunk
+    Chunk() = default;
+
+    /// Construct a labeled Chunk on a domain with uninitialized values
+    explicit Chunk(
+            std::string const& label,
+            discrete_domain_type const& domain,
+            Allocator allocator = Allocator())
+        : base_type(allocator.allocate(label, domain.size()), domain)
+        , m_allocator(std::move(allocator))
+        , m_label(label)
+    {
+    }
+
+    /// Construct a Chunk on a domain with uninitialized values
+    explicit Chunk(discrete_domain_type const& domain, Allocator allocator = Allocator())
+        : Chunk("no-label", domain, std::move(allocator))
+    {
+    }
+
+    /// Deleted: use deepcopy instead
+    Chunk(Chunk const& other) = delete;
+
+    /** Constructs a new Chunk by move
+     * @param other the Chunk to move
+     */
+    Chunk(Chunk&& other) noexcept
+        : base_type(std::move(static_cast<base_type&>(other)))
+        , m_allocator(std::move(other.m_allocator))
+        , m_label(std::move(other.m_label))
+    {
+        other.m_internal_mdspan = internal_mdspan_type(nullptr, other.m_internal_mdspan.mapping());
+    }
+
+    ~Chunk() noexcept
+    {
+        if (this->m_internal_mdspan.data_handle()) {
+            m_allocator.deallocate(this->data_handle(), this->size());
+        }
+    }
+
+    /// Deleted: use deepcopy instead
+    Chunk& operator=(Chunk const& other) = delete;
+
+    /** Move-assigns a new value to this field
+     * @param other the Chunk to move
+     * @return *this
+     */
+    Chunk& operator=(Chunk&& other) noexcept
+    {
+        if (this == &other) {
+            return *this;
+        }
+        if (this->m_internal_mdspan.data_handle()) {
+            m_allocator.deallocate(this->data_handle(), this->size());
+        }
+        static_cast<base_type&>(*this) = std::move(static_cast<base_type&>(other));
+        m_allocator = std::move(other.m_allocator);
+        m_label = std::move(other.m_label);
+        other.m_internal_mdspan = internal_mdspan_type(nullptr, other.m_internal_mdspan.mapping());
+
+        return *this;
+    }
+
+    /// Slice out some dimensions
+    template <class... QueryDDims>
+    auto operator[](DiscreteElement<QueryDDims...> const& slice_spec) const
+    {
+        return view_type(*this)[slice_spec];
+    }
+
+    /// Slice out some dimensions
+    template <class... QueryDDims>
+    auto operator[](DiscreteElement<QueryDDims...> const& slice_spec)
+    {
+        return span_view()[slice_spec];
+    }
+
+    /// Slice out some dimensions
+    template <class... QueryDDims>
+    auto operator[](DiscreteDomain<QueryDDims...> const& odomain) const
+    {
+        return span_view()[odomain];
+    }
+
+    /// Slice out some dimensions
+    template <class... QueryDDims>
+    auto operator[](DiscreteDomain<QueryDDims...> const& odomain)
+    {
+        return span_view()[odomain];
+    }
+
+    /** Element access using a list of DiscreteElement
+     * @param delems discrete coordinates
+     * @return const-reference to this element
+     */
+    template <class... DElems>
+    element_type const& operator()(DElems const&... delems) const noexcept
+    {
+        static_assert(
+                sizeof...(DDims) == (0 + ... + DElems::size()),
+                "Invalid number of dimensions");
+        static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
+        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain))
+                && ...));
+        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain))
+                && ...));
+        return DDC_MDSPAN_ACCESS_OP(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
+    }
+
+    /** Element access using a list of DiscreteElement
+     * @param delems discrete coordinates
+     * @return reference to this element
+     */
+    template <class... DElems>
+    element_type& operator()(DElems const&... delems) noexcept
+    {
+        static_assert(
+                sizeof...(DDims) == (0 + ... + DElems::size()),
+                "Invalid number of dimensions");
+        static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
+        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain))
+                && ...));
+        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain))
+                && ...));
+        return DDC_MDSPAN_ACCESS_OP(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
+    }
+
+    /** Returns the label of the Chunk
+     * @return c-string
+     */
+    char const* label() const
+    {
+        return m_label.c_str();
+    }
+
+    /** Access to the underlying allocation pointer
+     * @return read-only allocation pointer
+     */
+    ElementType const* data_handle() const
+    {
+        return base_type::data_handle();
+    }
+
+    /** Access to the underlying allocation pointer
+     * @return allocation pointer
+     */
+    ElementType* data_handle()
+    {
+        return base_type::data_handle();
+    }
+
+    /** Provide a mdspan on the memory allocation
+     * @return read-only allocation mdspan
+     */
+    const_allocation_mdspan_type allocation_mdspan() const
+    {
+        return base_type::allocation_mdspan();
+    }
+
+    /** Provide a mdspan on the memory allocation
+     * @return allocation mdspan
+     */
+    allocation_mdspan_type allocation_mdspan()
+    {
+        return base_type::allocation_mdspan();
+    }
+
+    /** Provide an unmanaged `Kokkos::View` on the memory allocation
+     * @return allocation `Kokkos::View`
+     */
+    auto allocation_kokkos_view()
+    {
+        auto s = this->allocation_mdspan();
+        auto kokkos_layout = detail::build_kokkos_layout(
+                s.extents(),
+                s.mapping(),
+                std::make_index_sequence<sizeof...(DDims)> {});
+        return Kokkos::View<
+                detail::mdspan_to_kokkos_element_t<ElementType, sizeof...(DDims)>,
+                decltype(kokkos_layout),
+                typename Allocator::memory_space>(s.data_handle(), kokkos_layout);
+    }
+
+    /** Provide an unmanaged `Kokkos::View` on the memory allocation
+     * @return read-only allocation `Kokkos::View`
+     */
+    auto allocation_kokkos_view() const
+    {
+        auto s = this->allocation_mdspan();
+        auto kokkos_layout = detail::build_kokkos_layout(
+                s.extents(),
+                s.mapping(),
+                std::make_index_sequence<sizeof...(DDims)> {});
+        return Kokkos::View<
+                detail::mdspan_to_kokkos_element_t<const ElementType, sizeof...(DDims)>,
+                decltype(kokkos_layout),
+                typename Allocator::memory_space>(s.data_handle(), kokkos_layout);
+    }
+
+    view_type span_cview() const
+    {
+        return view_type(*this);
+    }
+
+    view_type span_view() const
+    {
+        return view_type(*this);
+    }
+
+    span_type span_view()
+    {
+        return span_type(*this);
+    }
+};
+
 template <class ElementType, class SupportType, class Allocator>
 class Chunk : public ChunkCommon<ElementType, SupportType, Kokkos::layout_right>
 {
@@ -159,20 +436,6 @@ public:
     // auto operator[](DiscreteElement<QueryDDims...> const& slice_spec)
     // {
     //     return span_view()[slice_spec];
-    // }
-
-    // /// Slice out some dimensions
-    // template <class... QueryDDims>
-    // auto operator[](DiscreteDomain<QueryDDims...> const& odomain) const
-    // {
-    //     return span_view()[odomain];
-    // }
-
-    // /// Slice out some dimensions
-    // template <class... QueryDDims>
-    // auto operator[](DiscreteDomain<QueryDDims...> const& odomain)
-    // {
-    //     return span_view()[odomain];
     // }
 
     /** Element access using a list of DiscreteElement

--- a/include/ddc/chunk_common.hpp
+++ b/include/ddc/chunk_common.hpp
@@ -173,8 +173,7 @@ public:
     template <class QueryDDim>
     KOKKOS_FUNCTION constexpr size_type stride() const
     {
-        return m_allocation_mdspan.stride(
-                type_seq_rank_v<QueryDDim, detail::ToTypeSeq<SupportType>>);
+        return m_allocation_mdspan.stride(type_seq_rank_v<QueryDDim, to_type_seq_t<SupportType>>);
     }
 
     /** Provide access to the domain on which this chunk is defined

--- a/include/ddc/chunk_common.hpp
+++ b/include/ddc/chunk_common.hpp
@@ -134,7 +134,7 @@ public:
         return m_allocation_mdspan.accessor();
     }
 
-    KOKKOS_FUNCTION constexpr SupportType::discrete_vector_type extents() const noexcept
+    KOKKOS_FUNCTION constexpr typename SupportType::discrete_vector_type extents() const noexcept
     {
         return m_domain.extents();
     }

--- a/include/ddc/chunk_common.hpp
+++ b/include/ddc/chunk_common.hpp
@@ -32,6 +32,278 @@ KOKKOS_FUNCTION auto get_domain(ChunkType const& chunk) noexcept
 template <class ElementType, class SupportType, class LayoutStridedPolicy>
 class ChunkCommon;
 
+template <class ElementType, class... DDims, class LayoutStridedPolicy>
+class ChunkCommon<ElementType, DiscreteDomain<DDims...>, LayoutStridedPolicy>
+{
+protected:
+    /// the raw mdspan underlying this, with the same indexing (0 might no be dereferenceable)
+    using internal_mdspan_type = Kokkos::mdspan<
+            ElementType,
+            Kokkos::dextents<std::size_t, sizeof...(DDims)>,
+            Kokkos::layout_stride>;
+
+public:
+    using discrete_domain_type = DiscreteDomain<DDims...>;
+
+    /// The dereferenceable part of the co-domain but with a different domain, starting at 0
+    using allocation_mdspan_type = Kokkos::mdspan<
+            ElementType,
+            Kokkos::dextents<std::size_t, sizeof...(DDims)>,
+            LayoutStridedPolicy>;
+
+    using const_allocation_mdspan_type = Kokkos::mdspan<
+            const ElementType,
+            Kokkos::dextents<std::size_t, sizeof...(DDims)>,
+            LayoutStridedPolicy>;
+
+    using discrete_element_type = typename discrete_domain_type::discrete_element_type;
+
+    using extents_type = typename allocation_mdspan_type::extents_type;
+
+    using layout_type = typename allocation_mdspan_type::layout_type;
+
+    using accessor_type = typename allocation_mdspan_type::accessor_type;
+
+    using mapping_type = typename allocation_mdspan_type::mapping_type;
+
+    using element_type = typename allocation_mdspan_type::element_type;
+
+    using value_type = typename allocation_mdspan_type::value_type;
+
+    using size_type = typename allocation_mdspan_type::size_type;
+
+    using data_handle_type = typename allocation_mdspan_type::data_handle_type;
+
+    using reference = typename allocation_mdspan_type::reference;
+
+    // ChunkCommon, ChunkSpan and Chunk need to access to m_internal_mdspan and m_domain of other template versions
+    template <class, class, class>
+    friend class ChunkCommon;
+
+    template <class, class, class, class>
+    friend class ChunkSpan;
+
+    template <class, class, class>
+    friend class Chunk;
+
+    static_assert(mapping_type::is_always_strided());
+
+protected:
+    /// The raw view of the data
+    internal_mdspan_type m_internal_mdspan;
+
+    /// The mesh on which this chunk is defined
+    discrete_domain_type m_domain;
+
+public:
+    static KOKKOS_FUNCTION constexpr int rank() noexcept
+    {
+        return extents_type::rank();
+    }
+
+    static KOKKOS_FUNCTION constexpr int rank_dynamic() noexcept
+    {
+        return extents_type::rank_dynamic();
+    }
+
+    static KOKKOS_FUNCTION constexpr size_type static_extent(std::size_t r) noexcept
+    {
+        return extents_type::static_extent(r);
+    }
+
+    static KOKKOS_FUNCTION constexpr bool is_always_unique() noexcept
+    {
+        return mapping_type::is_always_unique();
+    }
+
+    static KOKKOS_FUNCTION constexpr bool is_always_exhaustive() noexcept
+    {
+        return mapping_type::is_always_exhaustive();
+    }
+
+    static KOKKOS_FUNCTION constexpr bool is_always_strided() noexcept
+    {
+        return mapping_type::is_always_strided();
+    }
+
+private:
+    template <class Mapping = mapping_type>
+    static KOKKOS_FUNCTION constexpr std::
+            enable_if_t<std::is_constructible_v<Mapping, extents_type>, internal_mdspan_type>
+            make_internal_mdspan(ElementType* ptr, discrete_domain_type const& domain)
+    {
+        if (domain.empty()) {
+            return internal_mdspan_type(ptr, Kokkos::layout_stride::mapping<extents_type>());
+        }
+        extents_type const extents_r(::ddc::extents<DDims>(domain).value()...);
+        mapping_type const mapping_r(extents_r);
+
+        extents_type const extents_s((front<DDims>(domain) + ddc::extents<DDims>(domain)).uid()...);
+        std::array<std::size_t, sizeof...(DDims)> const strides_s {
+                mapping_r.stride(type_seq_rank_v<DDims, detail::TypeSeq<DDims...>>)...};
+        Kokkos::layout_stride::mapping<extents_type> const mapping_s(extents_s, strides_s);
+        return internal_mdspan_type(ptr - mapping_s(front<DDims>(domain).uid()...), mapping_s);
+    }
+
+public:
+    KOKKOS_FUNCTION constexpr accessor_type accessor() const
+    {
+        return m_internal_mdspan.accessor();
+    }
+
+    KOKKOS_FUNCTION constexpr DiscreteVector<DDims...> extents() const noexcept
+    {
+        return m_domain.extents();
+    }
+
+    template <class QueryDDim>
+    KOKKOS_FUNCTION constexpr size_type extent() const noexcept
+    {
+        return m_domain.template extent<QueryDDim>();
+    }
+
+    KOKKOS_FUNCTION constexpr size_type size() const noexcept
+    {
+        return allocation_mdspan().size();
+    }
+
+    KOKKOS_FUNCTION constexpr mapping_type mapping() const noexcept
+    {
+        return allocation_mdspan().mapping();
+    }
+
+    KOKKOS_FUNCTION constexpr bool is_unique() const noexcept
+    {
+        return allocation_mdspan().is_unique();
+    }
+
+    KOKKOS_FUNCTION constexpr bool is_exhaustive() const noexcept
+    {
+        return allocation_mdspan().is_exhaustive();
+    }
+
+    KOKKOS_FUNCTION constexpr bool is_strided() const noexcept
+    {
+        return allocation_mdspan().is_strided();
+    }
+
+    template <class QueryDDim>
+    KOKKOS_FUNCTION constexpr size_type stride() const
+    {
+        return m_internal_mdspan.stride(type_seq_rank_v<QueryDDim, detail::TypeSeq<DDims...>>);
+    }
+
+    /** Provide access to the domain on which this chunk is defined
+     * @return the domain on which this chunk is defined
+     */
+    KOKKOS_FUNCTION constexpr discrete_domain_type domain() const noexcept
+    {
+        return m_domain;
+    }
+
+    /** Provide access to the domain on which this chunk is defined
+     * @return the domain on which this chunk is defined
+     */
+    template <class... QueryDDims>
+    KOKKOS_FUNCTION constexpr DiscreteDomain<QueryDDims...> domain() const noexcept
+    {
+        return DiscreteDomain<QueryDDims...>(domain());
+    }
+
+protected:
+    /// Empty ChunkCommon
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkCommon() = default;
+
+    /** Constructs a new ChunkCommon from scratch
+     * @param internal_mdspan
+     * @param domain
+     */
+    KOKKOS_FUNCTION constexpr ChunkCommon(
+            internal_mdspan_type internal_mdspan,
+            discrete_domain_type const& domain) noexcept
+        : m_internal_mdspan(std::move(internal_mdspan))
+        , m_domain(domain)
+    {
+    }
+
+    /** Constructs a new ChunkCommon from scratch
+     * @param ptr the allocation pointer to the data
+     * @param domain the domain that sustains the view
+     */
+    template <
+            class Mapping = mapping_type,
+            std::enable_if_t<std::is_constructible_v<Mapping, extents_type>, int> = 0>
+    KOKKOS_FUNCTION constexpr ChunkCommon(ElementType* ptr, discrete_domain_type const& domain)
+        : m_internal_mdspan(make_internal_mdspan(ptr, domain))
+        , m_domain(domain)
+    {
+        // Handle the case where an allocation of size 0 returns a nullptr.
+        assert(domain.empty() || ((ptr != nullptr) && !domain.empty()));
+    }
+
+    /** Constructs a new ChunkCommon by copy, yields a new view to the same data
+     * @param other the ChunkCommon to copy
+     */
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkCommon(ChunkCommon const& other) = default;
+
+    /** Constructs a new ChunkCommon by move
+     * @param other the ChunkCommon to move
+     */
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkCommon(ChunkCommon&& other) noexcept = default;
+
+    KOKKOS_DEFAULTED_FUNCTION ~ChunkCommon() noexcept = default;
+
+    /** Copy-assigns a new value to this ChunkCommon, yields a new view to the same data
+     * @param other the ChunkCommon to copy
+     * @return *this
+     */
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkCommon& operator=(ChunkCommon const& other) = default;
+
+    /** Move-assigns a new value to this ChunkCommon
+     * @param other the ChunkCommon to move
+     * @return *this
+     */
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkCommon& operator=(ChunkCommon&& other) noexcept
+            = default;
+
+    /** Access to the underlying allocation pointer
+     * @return allocation pointer
+     */
+    KOKKOS_FUNCTION constexpr ElementType* data_handle() const
+    {
+        ElementType* ptr = m_internal_mdspan.data_handle();
+        if (!m_domain.empty()) {
+            ptr += m_internal_mdspan.mapping()(front<DDims>(m_domain).uid()...);
+        }
+        return ptr;
+    }
+
+    /** Provide a modifiable view of the data
+     * @return a modifiable view of the data
+     */
+    KOKKOS_FUNCTION constexpr internal_mdspan_type internal_mdspan() const
+    {
+        return m_internal_mdspan;
+    }
+
+    /** Provide a modifiable view of the data
+     * @return a modifiable view of the data
+     */
+    KOKKOS_FUNCTION constexpr allocation_mdspan_type allocation_mdspan() const
+    {
+        DDC_IF_NVCC_THEN_PUSH_AND_SUPPRESS(implicit_return_from_non_void_function)
+        extents_type const extents_s(::ddc::extents<DDims>(m_domain).value()...);
+        if constexpr (std::is_same_v<LayoutStridedPolicy, Kokkos::layout_stride>) {
+            mapping_type const map(extents_s, m_internal_mdspan.mapping().strides());
+            return allocation_mdspan_type(data_handle(), map);
+        } else {
+            mapping_type const map(extents_s);
+            return allocation_mdspan_type(data_handle(), map);
+        }
+        DDC_IF_NVCC_THEN_POP
+    }
+};
+
 template <class ElementType, class SupportType, class LayoutStridedPolicy>
 class ChunkCommon
 {

--- a/include/ddc/chunk_span.hpp
+++ b/include/ddc/chunk_span.hpp
@@ -39,6 +39,348 @@ inline constexpr bool
         enable_borrowed_chunk<ChunkSpan<ElementType, SupportType, LayoutStridedPolicy, MemorySpace>>
         = true;
 
+template <class ElementType, class... DDims, class LayoutStridedPolicy, class MemorySpace>
+class ChunkSpan<ElementType, DiscreteDomain<DDims...>, LayoutStridedPolicy, MemorySpace>
+    : public ChunkCommon<ElementType, DiscreteDomain<DDims...>, LayoutStridedPolicy>
+{
+    static_assert(
+            std::is_same_v<LayoutStridedPolicy, Kokkos::layout_left>
+                    || std::is_same_v<LayoutStridedPolicy, Kokkos::layout_right>
+                    || std::is_same_v<LayoutStridedPolicy, Kokkos::layout_stride>,
+            "ChunkSpan only supports layout_left, layout_right or layout_stride");
+
+protected:
+    using base_type = ChunkCommon<ElementType, DiscreteDomain<DDims...>, LayoutStridedPolicy>;
+
+    /// the raw mdspan underlying this, with the same indexing (0 might no be dereferenceable)
+    using typename base_type::internal_mdspan_type;
+
+public:
+    /// type of a span of this full chunk
+    using span_type
+            = ChunkSpan<ElementType, DiscreteDomain<DDims...>, LayoutStridedPolicy, MemorySpace>;
+
+    /// type of a view of this full chunk
+    using view_type = ChunkSpan<
+            ElementType const,
+            DiscreteDomain<DDims...>,
+            LayoutStridedPolicy,
+            MemorySpace>;
+
+    using discrete_domain_type = typename base_type::discrete_domain_type;
+
+    using memory_space = MemorySpace;
+
+    /// The dereferenceable part of the co-domain but with a different domain, starting at 0
+    using allocation_mdspan_type = typename base_type::allocation_mdspan_type;
+
+    using const_allocation_mdspan_type = typename base_type::const_allocation_mdspan_type;
+
+    using discrete_element_type = typename discrete_domain_type::discrete_element_type;
+
+    using extents_type = typename base_type::extents_type;
+
+    using layout_type = typename base_type::layout_type;
+
+    using accessor_type = typename base_type::accessor_type;
+
+    using mapping_type = typename base_type::mapping_type;
+
+    using element_type = typename base_type::element_type;
+
+    using value_type = typename base_type::value_type;
+
+    using size_type = typename base_type::size_type;
+
+    using data_handle_type = typename base_type::data_handle_type;
+
+    using reference = typename base_type::reference;
+
+    template <class, class, class, class>
+    friend class ChunkSpan;
+
+protected:
+    static KOKKOS_FUNCTION internal_mdspan_type build_internal_mdspan(
+            allocation_mdspan_type const& allocation_mdspan,
+            discrete_domain_type const& domain)
+    {
+        if (!domain.empty()) {
+            extents_type const extents_s((front<DDims>(domain) + extents<DDims>(domain)).uid()...);
+            std::array<std::size_t, sizeof...(DDims)> const strides_s {
+                    allocation_mdspan.mapping().stride(
+                            type_seq_rank_v<DDims, detail::TypeSeq<DDims...>>)...};
+            Kokkos::layout_stride::mapping<extents_type> const mapping_s(extents_s, strides_s);
+            return internal_mdspan_type(
+                    allocation_mdspan.data_handle() - mapping_s(front<DDims>(domain).uid()...),
+                    mapping_s);
+        }
+
+        return internal_mdspan_type(allocation_mdspan);
+    }
+
+    template <class QueryDDim, class... ODDims>
+    KOKKOS_FUNCTION constexpr auto get_slicer_for(DiscreteElement<ODDims...> const& c) const
+    {
+        DDC_IF_NVCC_THEN_PUSH_AND_SUPPRESS(implicit_return_from_non_void_function)
+        if constexpr (in_tags_v<QueryDDim, detail::TypeSeq<ODDims...>>) {
+            return (uid<QueryDDim>(c) - front<QueryDDim>(this->m_domain).uid());
+        } else {
+            return Kokkos::full_extent;
+        }
+        DDC_IF_NVCC_THEN_POP
+    }
+
+    template <class QueryDDim, class... ODDims>
+    KOKKOS_FUNCTION constexpr auto get_slicer_for(DiscreteDomain<ODDims...> const& c) const
+    {
+        DDC_IF_NVCC_THEN_PUSH_AND_SUPPRESS(implicit_return_from_non_void_function)
+        if constexpr (in_tags_v<QueryDDim, detail::TypeSeq<ODDims...>>) {
+            return std::pair<std::size_t, std::size_t>(
+                    front<QueryDDim>(c) - front<QueryDDim>(this->m_domain),
+                    back<QueryDDim>(c) + 1 - front<QueryDDim>(this->m_domain));
+        } else {
+            return Kokkos::full_extent;
+        }
+        DDC_IF_NVCC_THEN_POP
+    }
+
+public:
+    /// Empty ChunkSpan
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkSpan() = default;
+
+    /** Constructs a new ChunkSpan by copy, yields a new view to the same data
+     * @param other the ChunkSpan to copy
+     */
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkSpan(ChunkSpan const& other) = default;
+
+    /** Constructs a new ChunkSpan by move
+     * @param other the ChunkSpan to move
+     */
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkSpan(ChunkSpan&& other) noexcept = default;
+
+    /** Forbids to construct a ChunkSpan from a rvalue of type Chunk.
+     */
+    template <
+            class OElementType,
+            class Allocator,
+            class = std::enable_if_t<std::is_same_v<typename Allocator::memory_space, MemorySpace>>>
+    ChunkSpan(Chunk<OElementType, discrete_domain_type, Allocator>&& other) noexcept = delete;
+
+    /** Constructs a new ChunkSpan from a Chunk, yields a new view to the same data
+     * @param other the Chunk to view
+     */
+    template <
+            class OElementType,
+            class Allocator,
+            class = std::enable_if_t<std::is_same_v<typename Allocator::memory_space, MemorySpace>>>
+    KOKKOS_FUNCTION constexpr explicit ChunkSpan(
+            Chunk<OElementType, discrete_domain_type, Allocator>& other) noexcept
+        : base_type(other.m_internal_mdspan, other.m_domain)
+    {
+    }
+
+    /** Constructs a new ChunkSpan from a Chunk, yields a new view to the same data
+     * @param other the Chunk to view
+     */
+    // Disabled by SFINAE in the case of `ElementType` is not `const` to avoid write access
+    template <
+            class OElementType,
+            class SFINAEElementType = ElementType,
+            class = std::enable_if_t<std::is_const_v<SFINAEElementType>>,
+            class Allocator,
+            class = std::enable_if_t<std::is_same_v<typename Allocator::memory_space, MemorySpace>>>
+    KOKKOS_FUNCTION constexpr explicit ChunkSpan(
+            Chunk<OElementType, discrete_domain_type, Allocator> const& other) noexcept
+        : base_type(other.m_internal_mdspan, other.m_domain)
+    {
+    }
+
+    /** Constructs a new ChunkSpan by copy of a chunk, yields a new view to the same data
+     * @param other the ChunkSpan to move
+     */
+    template <class OElementType>
+    KOKKOS_FUNCTION constexpr explicit ChunkSpan(
+            ChunkSpan<OElementType, discrete_domain_type, layout_type, MemorySpace> const&
+                    other) noexcept
+        : base_type(other.m_internal_mdspan, other.m_domain)
+    {
+    }
+
+    /** Constructs a new ChunkSpan from scratch
+     * @param ptr the allocation pointer to the data
+     * @param domain the domain that sustains the view
+     */
+    template <
+            class Mapping = mapping_type,
+            std::enable_if_t<std::is_constructible_v<Mapping, extents_type>, int> = 0>
+    KOKKOS_FUNCTION constexpr ChunkSpan(ElementType* const ptr, discrete_domain_type const& domain)
+        : base_type(ptr, domain)
+    {
+    }
+
+    /** Constructs a new ChunkSpan from scratch
+     * @param allocation_mdspan the allocation mdspan to the data
+     * @param domain the domain that sustains the view
+     */
+    KOKKOS_FUNCTION constexpr ChunkSpan(
+            allocation_mdspan_type allocation_mdspan,
+            discrete_domain_type const& domain)
+        : base_type(build_internal_mdspan(allocation_mdspan, domain), domain)
+    {
+        assert(((allocation_mdspan.extent(type_seq_rank_v<DDims, detail::TypeSeq<DDims...>>)
+                 == static_cast<std::size_t>(domain.template extent<DDims>().value()))
+                && ...));
+    }
+
+    /** Constructs a new ChunkSpan from scratch
+     * @param view the Kokkos view
+     * @param domain the domain that sustains the view
+     */
+    template <class KokkosView, class = std::enable_if_t<Kokkos::is_view_v<KokkosView>>>
+    KOKKOS_FUNCTION constexpr ChunkSpan(
+            KokkosView const& view,
+            discrete_domain_type const& domain) noexcept
+        : ChunkSpan(
+                  detail::build_mdspan(view, std::make_index_sequence<sizeof...(DDims)> {}),
+                  domain)
+    {
+    }
+
+    KOKKOS_DEFAULTED_FUNCTION ~ChunkSpan() noexcept = default;
+
+    /** Copy-assigns a new value to this ChunkSpan, yields a new view to the same data
+     * @param other the ChunkSpan to copy
+     * @return *this
+     */
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkSpan& operator=(ChunkSpan const& other) = default;
+
+    /** Move-assigns a new value to this ChunkSpan
+     * @param other the ChunkSpan to move
+     * @return *this
+     */
+    KOKKOS_DEFAULTED_FUNCTION constexpr ChunkSpan& operator=(ChunkSpan&& other) noexcept = default;
+
+    /** Slice out some dimensions
+     */
+    template <class... QueryDDims>
+    KOKKOS_FUNCTION constexpr auto operator[](
+            DiscreteElement<QueryDDims...> const& slice_spec) const
+    {
+        auto subview = Kokkos::submdspan(allocation_mdspan(), get_slicer_for<DDims>(slice_spec)...);
+        using layout_type = typename decltype(subview)::layout_type;
+        using extents_type = typename decltype(subview)::extents_type;
+        using detail::TypeSeq;
+        using OutTypeSeqDDims = type_seq_remove_t<TypeSeq<DDims...>, TypeSeq<QueryDDims...>>;
+        using OutDDom = detail::convert_type_seq_to_discrete_domain_t<OutTypeSeqDDims>;
+        if constexpr (
+                std::is_same_v<layout_type, Kokkos::Experimental::layout_left_padded<>>
+                || std::is_same_v<layout_type, Kokkos::Experimental::layout_right_padded<>>) {
+            Kokkos::layout_stride::mapping<extents_type> const mapping_stride(subview.mapping());
+            Kokkos::mdspan<ElementType, extents_type, Kokkos::layout_stride> const
+                    a(subview.data_handle(), mapping_stride);
+            return ChunkSpan<
+                    ElementType,
+                    OutDDom,
+                    Kokkos::layout_stride,
+                    memory_space>(a, OutDDom(this->m_domain));
+        } else {
+            return ChunkSpan<
+                    ElementType,
+                    OutDDom,
+                    layout_type,
+                    memory_space>(subview, OutDDom(this->m_domain));
+        }
+    }
+
+    /** Restrict to a subdomain
+     */
+    template <class... QueryDDims>
+    KOKKOS_FUNCTION constexpr auto operator[](DiscreteDomain<QueryDDims...> const& odomain) const
+    {
+        auto subview = Kokkos::submdspan(allocation_mdspan(), get_slicer_for<DDims>(odomain)...);
+        using layout_type = typename decltype(subview)::layout_type;
+        using extents_type = typename decltype(subview)::extents_type;
+        if constexpr (
+                std::is_same_v<layout_type, Kokkos::Experimental::layout_left_padded<>>
+                || std::is_same_v<layout_type, Kokkos::Experimental::layout_right_padded<>>) {
+            Kokkos::layout_stride::mapping<extents_type> const mapping_stride(subview.mapping());
+            Kokkos::mdspan<ElementType, extents_type, Kokkos::layout_stride> const
+                    a(subview.data_handle(), mapping_stride);
+            return ChunkSpan<
+                    ElementType,
+                    decltype(this->m_domain.restrict_with(odomain)),
+                    Kokkos::layout_stride,
+                    memory_space>(a, this->m_domain.restrict_with(odomain));
+        } else {
+            return ChunkSpan<
+                    ElementType,
+                    decltype(this->m_domain.restrict_with(odomain)),
+                    layout_type,
+                    memory_space>(subview, this->m_domain.restrict_with(odomain));
+        }
+    }
+
+    /** Element access using a list of DiscreteElement
+     * @param delems discrete elements
+     * @return reference to this element
+     */
+    template <class... DElems>
+    KOKKOS_FUNCTION constexpr reference operator()(DElems const&... delems) const noexcept
+    {
+        static_assert(
+                sizeof...(DDims) == (0 + ... + DElems::size()),
+                "Invalid number of dimensions");
+        static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
+        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain))
+                && ...));
+        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain))
+                && ...));
+        return DDC_MDSPAN_ACCESS_OP(this->m_internal_mdspan, uid<DDims>(take<DDims>(delems...))...);
+    }
+
+    /** Access to the underlying allocation pointer
+     * @return allocation pointer
+     */
+    KOKKOS_FUNCTION constexpr ElementType* data_handle() const
+    {
+        return base_type::data_handle();
+    }
+
+    /** Provide a mdspan on the memory allocation
+     * @return allocation mdspan
+     */
+    KOKKOS_FUNCTION constexpr allocation_mdspan_type allocation_mdspan() const
+    {
+        return base_type::allocation_mdspan();
+    }
+
+    /** Provide a mdspan on the memory allocation
+     * @return allocation mdspan
+     */
+    KOKKOS_FUNCTION constexpr auto allocation_kokkos_view() const
+    {
+        auto s = this->allocation_mdspan();
+        auto kokkos_layout = detail::build_kokkos_layout(
+                s.extents(),
+                s.mapping(),
+                std::make_index_sequence<sizeof...(DDims)> {});
+        return Kokkos::View<
+                detail::mdspan_to_kokkos_element_t<ElementType, sizeof...(DDims)>,
+                decltype(kokkos_layout),
+                MemorySpace>(s.data_handle(), kokkos_layout);
+    }
+
+    KOKKOS_FUNCTION constexpr view_type span_cview() const
+    {
+        return view_type(*this);
+    }
+
+    KOKKOS_FUNCTION constexpr span_type span_view() const
+    {
+        return *this;
+    }
+};
+
 template <class ElementType, class SupportType, class LayoutStridedPolicy, class MemorySpace>
 class ChunkSpan : public ChunkCommon<ElementType, SupportType, LayoutStridedPolicy>
 {
@@ -97,20 +439,6 @@ protected:
         DDC_IF_NVCC_THEN_PUSH_AND_SUPPRESS(implicit_return_from_non_void_function)
         if constexpr (in_tags_v<QueryDDim, detail::TypeSeq<ODDims...>>) {
             return (uid<QueryDDim>(c) - front<QueryDDim>(this->m_domain).uid());
-        } else {
-            return Kokkos::full_extent;
-        }
-        DDC_IF_NVCC_THEN_POP
-    }
-
-    template <class QueryDDim, class... ODDims>
-    KOKKOS_FUNCTION constexpr auto get_slicer_for(DiscreteDomain<ODDims...> const& c) const
-    {
-        DDC_IF_NVCC_THEN_PUSH_AND_SUPPRESS(implicit_return_from_non_void_function)
-        if constexpr (in_tags_v<QueryDDim, detail::TypeSeq<ODDims...>>) {
-            return std::pair<std::size_t, std::size_t>(
-                    front<QueryDDim>(c) - front<QueryDDim>(this->m_domain),
-                    back<QueryDDim>(c) + 1 - front<QueryDDim>(this->m_domain));
         } else {
             return Kokkos::full_extent;
         }
@@ -264,34 +592,6 @@ public:
     //     }
     // }
 
-    // /** Restrict to a subdomain
-    //  */
-    // template <class... QueryDDims>
-    // KOKKOS_FUNCTION constexpr auto operator[](DiscreteDomain<QueryDDims...> const& odomain) const
-    // {
-    //     auto subview = Kokkos::submdspan(allocation_mdspan(), get_slicer_for<DDims>(odomain)...);
-    //     using layout_type = typename decltype(subview)::layout_type;
-    //     using extents_type = typename decltype(subview)::extents_type;
-    //     if constexpr (
-    //             std::is_same_v<layout_type, Kokkos::Experimental::layout_left_padded<>>
-    //             || std::is_same_v<layout_type, Kokkos::Experimental::layout_right_padded<>>) {
-    //         Kokkos::layout_stride::mapping<extents_type> const mapping_stride(subview.mapping());
-    //         Kokkos::mdspan<ElementType, extents_type, Kokkos::layout_stride> const
-    //                 a(subview.data_handle(), mapping_stride);
-    //         return ChunkSpan<
-    //                 ElementType,
-    //                 decltype(this->m_domain.restrict_with(odomain)),
-    //                 Kokkos::layout_stride,
-    //                 memory_space>(a, this->m_domain.restrict_with(odomain));
-    //     } else {
-    //         return ChunkSpan<
-    //                 ElementType,
-    //                 decltype(this->m_domain.restrict_with(odomain)),
-    //                 layout_type,
-    //                 memory_space>(subview, this->m_domain.restrict_with(odomain));
-    //     }
-    // }
-
     /** Element access using a list of DiscreteElement
      * @param delems discrete elements
      * @return reference to this element
@@ -365,18 +665,20 @@ KOKKOS_DEDUCTION_GUIDE ChunkSpan(
                 typename Kokkos::View<DataType, Properties...>::memory_space>;
 
 template <class ElementType, class SupportType, class Allocator>
-ChunkSpan(Chunk<ElementType, SupportType, Allocator>& other) -> ChunkSpan<
-        ElementType,
-        SupportType,
-        Kokkos::layout_right,
-        typename Allocator::memory_space>;
+ChunkSpan(Chunk<ElementType, SupportType, Allocator>& other)
+        -> ChunkSpan<
+                ElementType,
+                SupportType,
+                Kokkos::layout_right,
+                typename Allocator::memory_space>;
 
 template <class ElementType, class SupportType, class Allocator>
-ChunkSpan(Chunk<ElementType, SupportType, Allocator> const& other) -> ChunkSpan<
-        const ElementType,
-        SupportType,
-        Kokkos::layout_right,
-        typename Allocator::memory_space>;
+ChunkSpan(Chunk<ElementType, SupportType, Allocator> const& other)
+        -> ChunkSpan<
+                const ElementType,
+                SupportType,
+                Kokkos::layout_right,
+                typename Allocator::memory_space>;
 
 template <
         class ElementType,

--- a/include/ddc/chunk_span.hpp
+++ b/include/ddc/chunk_span.hpp
@@ -603,7 +603,7 @@ public:
                 SupportType::rank() == (0 + ... + DElems::size()),
                 "Invalid number of dimensions");
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
-        assert(this->m_domain.is_inside(delems...));
+        assert(this->m_domain.contains(delems...));
         return DDC_MDSPAN_ACCESS_OP(
                 this->m_allocation_mdspan,
                 detail::array(this->m_domain.distance_from_front(delems...)));

--- a/include/ddc/chunk_span.hpp
+++ b/include/ddc/chunk_span.hpp
@@ -310,13 +310,10 @@ public:
                 sizeof...(DDims) == (0 + ... + DElems::size()),
                 "Invalid number of dimensions");
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
-        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) >= front<DDims>(this->m_domain))
-                && ...));
-        assert(((DiscreteElement<DDims>(take<DDims>(delems...)) <= back<DDims>(this->m_domain))
-                && ...));
+        assert(this->m_domain.is_inside(delems...));
         return DDC_MDSPAN_ACCESS_OP(
                 this->m_allocation_mdspan,
-                (DiscreteElement<DDims>(take<DDims>(delems...)) - front<DDims>(this->m_domain))...);
+                detail::array(this->m_domain.distance_from_front(delems...)));
     }
 
     /** Access to the underlying allocation pointer

--- a/include/ddc/ddc.hpp
+++ b/include/ddc/ddc.hpp
@@ -31,6 +31,7 @@ namespace ddc {
 #include "ddc/discrete_vector.hpp"
 #include "ddc/non_uniform_point_sampling.hpp"
 #include "ddc/periodic_sampling.hpp"
+#include "ddc/storage_discrete_domain.hpp"
 #include "ddc/strided_discrete_domain.hpp"
 #include "ddc/uniform_point_sampling.hpp"
 

--- a/include/ddc/ddc.hpp
+++ b/include/ddc/ddc.hpp
@@ -31,6 +31,7 @@ namespace ddc {
 #include "ddc/discrete_vector.hpp"
 #include "ddc/non_uniform_point_sampling.hpp"
 #include "ddc/periodic_sampling.hpp"
+#include "ddc/strided_discrete_domain.hpp"
 #include "ddc/uniform_point_sampling.hpp"
 
 // Algorithms

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -174,6 +174,12 @@ public:
         return DiscreteDomain(front() + n1, extents() - n1 - n2);
     }
 
+    KOKKOS_FUNCTION constexpr DiscreteElement<DDims...> operator()(
+            DiscreteVector<DDims...> const& dvect) const noexcept
+    {
+        return m_element_begin + dvect;
+    }
+
     template <class... ODDims>
     KOKKOS_FUNCTION constexpr auto restrict_with(DiscreteDomain<ODDims...> const& odomain) const
     {

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -390,7 +390,7 @@ public:
     KOKKOS_FUNCTION constexpr DiscreteElement<> operator()(
             DiscreteVector<> const& /* dvect */) const noexcept
     {
-        return DiscreteElement<>();
+        return {};
     }
 
     template <class... ODims>
@@ -412,12 +412,12 @@ public:
 
     static DiscreteVector<> distance_from_front() noexcept
     {
-        return DiscreteVector<>();
+        return {};
     }
 
     static DiscreteVector<> distance_from_front(DiscreteElement<>) noexcept
     {
-        return DiscreteVector<>();
+        return {};
     }
 
     static KOKKOS_FUNCTION constexpr bool empty() noexcept

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -507,10 +507,10 @@ KOKKOS_FUNCTION constexpr auto remove_dims_of(
 //! Remove the dimensions DDimsB from DDom_a
 //! @param[in] DDom_a The discrete domain on which to remove dimensions
 //! @return The discrete domain without DDimsB dimensions
-template <class... DDimsB, class DDomA>
-KOKKOS_FUNCTION constexpr auto remove_dims_of(DDomA const& DDom_a) noexcept
+template <class... DDimsB, class... DDimsA>
+KOKKOS_FUNCTION constexpr auto remove_dims_of(DiscreteDomain<DDimsA...> const& DDom_a) noexcept
 {
-    using TagSeqA = typename detail::ToTypeSeq<DDomA>::type;
+    using TagSeqA = detail::TypeSeq<DDimsA...>;
     using TagSeqB = detail::TypeSeq<DDimsB...>;
 
     using type_seq_r = type_seq_remove_t<TagSeqA, TagSeqB>;
@@ -564,10 +564,9 @@ KOKKOS_FUNCTION constexpr auto replace_dim_of(
 
 // Replace dimensions from a domain type
 template <typename DDom, typename DDim1, typename DDim2>
-using replace_dim_of_t
-        = decltype(replace_dim_of<
-                   DDim1,
-                   DDim2>(std::declval<DDom>(), std::declval<DiscreteDomain<DDim2>>()));
+using replace_dim_of_t = decltype(replace_dim_of<DDim1, DDim2>(
+        std::declval<DDom>(),
+        std::declval<typename detail::RebindDomain<DDom, detail::TypeSeq<DDim2>>::type>()));
 
 
 template <class... QueryDDims, class... DDims>

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -387,6 +387,12 @@ public:
         return *this;
     }
 
+    KOKKOS_FUNCTION constexpr DiscreteElement<> operator()(
+            DiscreteVector<> const& /* dvect */) const noexcept
+    {
+        return DiscreteElement<>();
+    }
+
     template <class... ODims>
     KOKKOS_FUNCTION constexpr DiscreteDomain restrict_with(
             DiscreteDomain<ODims...> const& /* odomain */) const

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -194,7 +194,7 @@ public:
     }
 
     template <class... DElems>
-    bool is_inside(DElems const&... delems) const noexcept
+    bool contains(DElems const&... delems) const noexcept
     {
         static_assert(
                 sizeof...(DDims) == (0 + ... + DElems::size()),
@@ -400,12 +400,12 @@ public:
         return *this;
     }
 
-    static bool is_inside() noexcept
+    static bool contains() noexcept
     {
         return true;
     }
 
-    static bool is_inside(DiscreteElement<>) noexcept
+    static bool contains(DiscreteElement<>) noexcept
     {
         return true;
     }

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -46,6 +46,15 @@ struct ToTypeSeq<DiscreteDomain<Tags...>>
     using type = TypeSeq<Tags...>;
 };
 
+template <class T, class U>
+struct RebindDomain;
+
+template <class... DDims, class... ODDims>
+struct RebindDomain<DiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
+{
+    using type = DiscreteDomain<ODDims...>;
+};
+
 } // namespace detail
 
 template <class... DDims>

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -187,6 +187,33 @@ public:
                 DiscreteVector<DDims...>((get_or<DDims>(oextents, get<DDims>(myextents)))...));
     }
 
+    template <class... DElems>
+    bool is_inside(DElems const&... delems) const noexcept
+    {
+        static_assert(
+                sizeof...(DDims) == (0 + ... + DElems::size()),
+                "Invalid number of dimensions");
+        static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
+        return (((DiscreteElement<DDims>(take<DDims>(delems...))
+                  >= DiscreteElement<DDims>(m_element_begin))
+                 && ...)
+                && ((DiscreteElement<DDims>(take<DDims>(delems...))
+                     < DiscreteElement<DDims>(m_element_end))
+                    && ...));
+    }
+
+    template <class... DElems>
+    DiscreteVector<DDims...> distance_from_front(DElems const&... delems) const noexcept
+    {
+        static_assert(
+                sizeof...(DDims) == (0 + ... + DElems::size()),
+                "Invalid number of dimensions");
+        static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
+        return DiscreteVector<DDims...>(
+                (DiscreteElement<DDims>(take<DDims>(delems...))
+                 - DiscreteElement<DDims>(m_element_begin))...);
+    }
+
     KOKKOS_FUNCTION constexpr bool empty() const noexcept
     {
         return size() == 0;
@@ -359,6 +386,26 @@ public:
             DiscreteDomain<ODims...> const& /* odomain */) const
     {
         return *this;
+    }
+
+    static bool is_inside() noexcept
+    {
+        return true;
+    }
+
+    static bool is_inside(DiscreteElement<>) noexcept
+    {
+        return true;
+    }
+
+    static DiscreteVector<> distance_from_front() noexcept
+    {
+        return DiscreteVector<>();
+    }
+
+    static DiscreteVector<> distance_from_front(DiscreteElement<>) noexcept
+    {
+        return DiscreteVector<>();
     }
 
     static KOKKOS_FUNCTION constexpr bool empty() noexcept

--- a/include/ddc/parallel_for_each.hpp
+++ b/include/ddc/parallel_for_each.hpp
@@ -20,41 +20,53 @@ namespace ddc {
 
 namespace detail {
 
-template <class F, class... DDims>
-class ForEachKokkosLambdaAdapter
+template <class F, class Support, class IndexSequence>
+class ForEachKokkosLambdaAdapter;
+
+template <class F, class Support, std::size_t... Idx>
+class ForEachKokkosLambdaAdapter<F, Support, std::index_sequence<Idx...>>
 {
-    template <class T>
+    template <std::size_t I>
     using index_type = DiscreteElementType;
 
     F m_f;
 
-public:
-    explicit ForEachKokkosLambdaAdapter(F const& f) : m_f(f) {}
+    Support m_support;
 
-    template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N == 0), bool> = true>
-    KOKKOS_FUNCTION void operator()([[maybe_unused]] index_type<void> unused_id) const
+public:
+    explicit ForEachKokkosLambdaAdapter(F const& f, Support const& support)
+        : m_f(f)
+        , m_support(support)
+    {
+    }
+
+    template <std::size_t N = sizeof...(Idx), std::enable_if_t<(N == 0), bool> = true>
+    KOKKOS_FUNCTION void operator()([[maybe_unused]] index_type<0> unused_id) const
     {
         m_f(DiscreteElement<>());
     }
 
-    template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N > 0), bool> = true>
-    KOKKOS_FUNCTION void operator()(index_type<DDims>... ids) const
+    template <std::size_t N = sizeof...(Idx), std::enable_if_t<(N > 0), bool> = true>
+    KOKKOS_FUNCTION void operator()(index_type<Idx>... ids) const
     {
-        m_f(DiscreteElement<DDims...>(ids...));
+        m_f(m_support(typename Support::discrete_vector_type(ids...)));
     }
 };
 
-template <class ExecSpace, class Functor, class... DDims>
+template <class ExecSpace, class Support, class Functor>
 void for_each_kokkos(
         std::string const& label,
         ExecSpace const& execution_space,
-        DiscreteDomain<DDims...> const& domain,
+        Support const& domain,
         Functor const& f) noexcept
 {
     Kokkos::parallel_for(
             label,
             ddc_to_kokkos_execution_policy(execution_space, domain),
-            ForEachKokkosLambdaAdapter<Functor, DDims...>(f));
+            ForEachKokkosLambdaAdapter<
+                    Functor,
+                    Support,
+                    std::make_index_sequence<Support::rank()>>(f, domain));
 }
 
 } // namespace detail
@@ -65,11 +77,11 @@ void for_each_kokkos(
  * @param[in] domain the domain over which to iterate
  * @param[in] f      a functor taking an index as parameter
  */
-template <class ExecSpace, class... DDims, class Functor>
+template <class ExecSpace, class Support, class Functor>
 void parallel_for_each(
         std::string const& label,
         ExecSpace const& execution_space,
-        DiscreteDomain<DDims...> const& domain,
+        Support const& domain,
         Functor&& f) noexcept
 {
     detail::for_each_kokkos(label, execution_space, domain, std::forward<Functor>(f));
@@ -80,10 +92,10 @@ void parallel_for_each(
  * @param[in] domain the domain over which to iterate
  * @param[in] f      a functor taking an index as parameter
  */
-template <class ExecSpace, class... DDims, class Functor>
+template <class ExecSpace, class Support, class Functor>
 std::enable_if_t<Kokkos::is_execution_space_v<ExecSpace>> parallel_for_each(
         ExecSpace const& execution_space,
-        DiscreteDomain<DDims...> const& domain,
+        Support const& domain,
         Functor&& f) noexcept
 {
     detail::for_each_kokkos(
@@ -98,11 +110,8 @@ std::enable_if_t<Kokkos::is_execution_space_v<ExecSpace>> parallel_for_each(
  * @param[in] domain the domain over which to iterate
  * @param[in] f      a functor taking an index as parameter
  */
-template <class... DDims, class Functor>
-void parallel_for_each(
-        std::string const& label,
-        DiscreteDomain<DDims...> const& domain,
-        Functor&& f) noexcept
+template <class Support, class Functor>
+void parallel_for_each(std::string const& label, Support const& domain, Functor&& f) noexcept
 {
     parallel_for_each(label, Kokkos::DefaultExecutionSpace(), domain, std::forward<Functor>(f));
 }
@@ -111,8 +120,8 @@ void parallel_for_each(
  * @param[in] domain the domain over which to iterate
  * @param[in] f      a functor taking an index as parameter
  */
-template <class... DDims, class Functor>
-void parallel_for_each(DiscreteDomain<DDims...> const& domain, Functor&& f) noexcept
+template <class Support, class Functor>
+void parallel_for_each(Support const& domain, Functor&& f) noexcept
 {
     parallel_for_each(
             "ddc_for_each_default",

--- a/include/ddc/storage_discrete_domain.hpp
+++ b/include/ddc/storage_discrete_domain.hpp
@@ -274,7 +274,7 @@ public:
     // }
 
     template <class... DElems>
-    KOKKOS_FUNCTION bool is_inside(DElems const&... delems) const noexcept
+    KOKKOS_FUNCTION bool contains(DElems const&... delems) const noexcept
     {
         static_assert(
                 sizeof...(DDims) == (0 + ... + DElems::size()),
@@ -296,7 +296,7 @@ public:
                 sizeof...(DDims) == (0 + ... + DElems::size()),
                 "Invalid number of dimensions");
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
-        assert(is_inside(delems...));
+        assert(contains(delems...));
         return DiscreteVector<DDims...>(
                 (detail::lower_bound(
                          get<DDims>(m_views).data(),
@@ -502,12 +502,12 @@ public:
 //         return *this;
 //     }
 
-//     static bool is_inside() noexcept
+//     static bool contains() noexcept
 //     {
 //         return true;
 //     }
 
-//     static bool is_inside(DiscreteElement<>) noexcept
+//     static bool contains(DiscreteElement<>) noexcept
 //     {
 //         return true;
 //     }

--- a/include/ddc/storage_discrete_domain.hpp
+++ b/include/ddc/storage_discrete_domain.hpp
@@ -543,6 +543,20 @@ KOKKOS_FUNCTION constexpr auto remove_dims_of(
     return detail::convert_type_seq_to_storage_discrete_domain_t<type_seq_r>(DDom_a);
 }
 
+//! Remove the dimensions DDimsB from DDom_a
+//! @param[in] DDom_a The discrete domain on which to remove dimensions
+//! @return The discrete domain without DDimsB dimensions
+template <class... DDimsB, class... DDimsA>
+KOKKOS_FUNCTION constexpr auto remove_dims_of(
+        StorageDiscreteDomain<DDimsA...> const& DDom_a) noexcept
+{
+    using TagSeqA = detail::TypeSeq<DDimsA...>;
+    using TagSeqB = detail::TypeSeq<DDimsB...>;
+
+    using type_seq_r = type_seq_remove_t<TagSeqA, TagSeqB>;
+    return detail::convert_type_seq_to_storage_discrete_domain_t<type_seq_r>(DDom_a);
+}
+
 namespace detail {
 
 // Checks if dimension of DDom_a is DDim1. If not, returns restriction to DDim2 of DDom_b. May not be useful in its own, it helps for replace_dim_of

--- a/include/ddc/storage_discrete_domain.hpp
+++ b/include/ddc/storage_discrete_domain.hpp
@@ -1,0 +1,784 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <iterator>
+#include <tuple>
+#include <type_traits>
+
+#include <Kokkos_Core.hpp>
+#include <Kokkos_StdAlgorithms.hpp>
+
+#include "ddc/detail/kokkos.hpp"
+#include "ddc/detail/tagged_vector.hpp"
+#include "ddc/detail/type_seq.hpp"
+#include "ddc/discrete_element.hpp"
+#include "ddc/discrete_vector.hpp"
+
+namespace ddc {
+
+template <class DDim>
+struct StorageDiscreteDomainIterator;
+
+template <class... DDims>
+class StorageDiscreteDomain;
+
+template <class T>
+struct is_storage_discrete_domain : std::false_type
+{
+};
+
+template <class... Tags>
+struct is_storage_discrete_domain<StorageDiscreteDomain<Tags...>> : std::true_type
+{
+};
+
+template <class T>
+inline constexpr bool is_storage_discrete_domain_v = is_storage_discrete_domain<T>::value;
+
+
+namespace detail {
+
+template <class... Tags>
+struct ToTypeSeq<StorageDiscreteDomain<Tags...>>
+{
+    using type = TypeSeq<Tags...>;
+};
+
+template <class InputIt1, class InputIt2>
+KOKKOS_FUNCTION bool equal(InputIt1 first1, InputIt1 last1, InputIt2 first2)
+{
+    for (; first1 != last1; ++first1, ++first2) {
+        if (!(*first1 == *first2)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+template <
+        class ForwardIt,
+        class T = typename std::iterator_traits<ForwardIt>::value_type,
+        class Compare>
+KOKKOS_FUNCTION ForwardIt lower_bound(ForwardIt first, ForwardIt last, const T& value, Compare comp)
+{
+    ForwardIt it;
+    typename std::iterator_traits<ForwardIt>::difference_type count = last - first;
+    while (count > 0) {
+        it = first;
+        typename std::iterator_traits<ForwardIt>::difference_type step = count / 2;
+        it += step;
+
+        if (comp(*it, value)) {
+            first = ++it;
+            count -= step + 1;
+        } else {
+            count = step;
+        }
+    }
+
+    return first;
+}
+
+template <
+        class ForwardIt,
+        class T = typename std::iterator_traits<ForwardIt>::value_type,
+        class Compare>
+bool binary_search(ForwardIt first, ForwardIt last, const T& value, Compare comp)
+{
+    first = ::ddc::detail::lower_bound(first, last, value, comp);
+    return (!(first == last) && !(comp(value, *first)));
+}
+
+} // namespace detail
+
+template <class... DDims>
+class StorageDiscreteDomain
+{
+    template <class...>
+    friend class StorageDiscreteDomain;
+
+public:
+    using discrete_element_type = DiscreteElement<DDims...>;
+
+    using discrete_vector_type = DiscreteVector<DDims...>;
+
+private:
+    detail::TaggedVector<Kokkos::View<DiscreteElementType*, Kokkos::SharedSpace>, DDims...> m_views;
+
+public:
+    static KOKKOS_FUNCTION constexpr std::size_t rank()
+    {
+        return sizeof...(DDims);
+    }
+
+    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain() = default;
+
+    /// Construct a StorageDiscreteDomain by copies and merge of domains
+    template <
+            class... DDoms,
+            class = std::enable_if_t<(is_storage_discrete_domain_v<DDoms> && ...)>>
+    KOKKOS_FUNCTION constexpr explicit StorageDiscreteDomain(DDoms const&... domains)
+        : m_views(domains...)
+    {
+    }
+
+    /** Construct a StridedDiscreteDomain starting from element_begin with size points.
+     * @param element_begin the lower bound in each direction
+     * @param size the number of points in each direction
+     */
+    KOKKOS_FUNCTION explicit constexpr StorageDiscreteDomain(
+            Kokkos::View<DiscreteElement<DDims>*, Kokkos::SharedSpace> const&... views)
+    {
+        ((m_views[type_seq_rank_v<DDims, detail::TypeSeq<DDims...>>]
+          = Kokkos::View<DiscreteElementType*, Kokkos::SharedSpace>(views.label(), views.size())),
+         ...);
+        ((Kokkos::Experimental::transform(
+                 "StorageDiscreteDomainCtor",
+                 Kokkos::DefaultExecutionSpace(),
+                 views,
+                 m_views[type_seq_rank_v<DDims, detail::TypeSeq<DDims...>>],
+                 KOKKOS_LAMBDA(DiscreteElement<DDims> const& delem) { return delem.uid(); })),
+         ...);
+        Kokkos::fence("StorageDiscreteDomainCtor");
+    }
+
+    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain(StorageDiscreteDomain const& x) = default;
+
+    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain(StorageDiscreteDomain&& x) = default;
+
+    KOKKOS_DEFAULTED_FUNCTION ~StorageDiscreteDomain() = default;
+
+    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain& operator=(StorageDiscreteDomain const& x)
+            = default;
+
+    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain& operator=(StorageDiscreteDomain&& x) = default;
+
+    template <class... ODims>
+    KOKKOS_FUNCTION constexpr bool operator==(StorageDiscreteDomain<ODims...> const& other) const
+    {
+        if (empty() && other.empty()) {
+            return true;
+        }
+        if (m_views.size() != other.m_views.size()) {
+            return false;
+        }
+        for (std::size_t i = 0; i < m_views.size(); ++i) {
+            if (m_views[i].size() != other.m_views[i].size()) {
+                return false;
+            }
+            if (!detail::
+                        equal(m_views[i].data(),
+                              m_views[i].data() + m_views[i].size(),
+                              other.m_views[i].data())) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+#if !defined(__cpp_impl_three_way_comparison) || __cpp_impl_three_way_comparison < 201902L
+    // In C++20, `a!=b` shall be automatically translated by the compiler to `!(a==b)`
+    template <class... ODims>
+    KOKKOS_FUNCTION constexpr bool operator!=(StorageDiscreteDomain<ODims...> const& other) const
+    {
+        return !(*this == other);
+    }
+#endif
+
+    KOKKOS_FUNCTION constexpr std::size_t size() const
+    {
+        return (1UL * ... * get<DDims>(m_views).size());
+    }
+
+    KOKKOS_FUNCTION constexpr discrete_vector_type extents() const noexcept
+    {
+        return discrete_vector_type(get<DDims>(m_views).size()...);
+    }
+
+    template <class QueryDDim>
+    KOKKOS_FUNCTION constexpr DiscreteVector<QueryDDim> extent() const noexcept
+    {
+        return DiscreteVector<QueryDDim>(get<QueryDDim>(m_views).size());
+    }
+
+    KOKKOS_FUNCTION constexpr discrete_element_type front() const noexcept
+    {
+        return discrete_element_type(get<DDims>(m_views)(0)...);
+    }
+
+    KOKKOS_FUNCTION constexpr discrete_element_type back() const noexcept
+    {
+        return discrete_element_type(get<DDims>(m_views)(get<DDims>(m_views).size() - 1)...);
+    }
+
+    KOKKOS_FUNCTION constexpr StorageDiscreteDomain take_first(discrete_vector_type n) const
+    {
+        return StorageDiscreteDomain(front(), n);
+    }
+
+    KOKKOS_FUNCTION constexpr StorageDiscreteDomain take_last(discrete_vector_type n) const
+    {
+        return StorageDiscreteDomain(front() + prod(extents() - n), n);
+    }
+
+    KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove_first(discrete_vector_type n) const
+    {
+        return StorageDiscreteDomain(front() + prod(n), extents() - n);
+    }
+
+    KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove_last(discrete_vector_type n) const
+    {
+        return StorageDiscreteDomain(front(), extents() - n);
+    }
+
+    KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove(
+            discrete_vector_type n1,
+            discrete_vector_type n2) const
+    {
+        return StorageDiscreteDomain(front() + prod(n1), extents() - n1 - n2);
+    }
+
+    KOKKOS_FUNCTION constexpr DiscreteElement<DDims...> operator()(
+            DiscreteVector<DDims...> const& dvect) const noexcept
+    {
+        return m_views(get<DDims>(dvect)...);
+    }
+
+    // template <class... ODDims>
+    // KOKKOS_FUNCTION constexpr auto restrict_with(
+    //         StorageDiscreteDomain<ODDims...> const& odomain) const
+    // {
+    //     assert(((uid<ODDims>(m_element_begin) <= uid<ODDims>(odomain.m_element_begin)) && ...));
+    //     assert(((uid<ODDims>(m_element_end) >= uid<ODDims>(odomain.m_element_end)) && ...));
+    //     const DiscreteVector<DDims...> myextents = extents();
+    //     const DiscreteVector<ODDims...> oextents = odomain.extents();
+    //     return StorageDiscreteDomain(
+    //             DiscreteElement<DDims...>(
+    //                     (uid_or<DDims>(odomain.m_element_begin, uid<DDims>(m_element_begin)))...),
+    //             DiscreteVector<DDims...>((get_or<DDims>(oextents, get<DDims>(myextents)))...));
+    // }
+
+    template <class... DElems>
+    KOKKOS_FUNCTION bool is_inside(DElems const&... delems) const noexcept
+    {
+        static_assert(
+                sizeof...(DDims) == (0 + ... + DElems::size()),
+                "Invalid number of dimensions");
+        static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
+        return (detail::binary_search(
+                        get<DDims>(m_views).data(),
+                        get<DDims>(m_views).data() + get<DDims>(m_views).size(),
+                        uid<DDims>(take<DDims>(delems...)),
+                        std::less {})
+                && ...);
+    }
+
+    template <class... DElems>
+    KOKKOS_FUNCTION DiscreteVector<DDims...> distance_from_front(
+            DElems const&... delems) const noexcept
+    {
+        static_assert(
+                sizeof...(DDims) == (0 + ... + DElems::size()),
+                "Invalid number of dimensions");
+        static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
+        assert(is_inside(delems...));
+        return DiscreteVector<DDims...>(
+                (detail::lower_bound(
+                         get<DDims>(m_views).data(),
+                         get<DDims>(m_views).data() + get<DDims>(m_views).size(),
+                         uid<DDims>(take<DDims>(delems...)),
+                         std::less {})
+                 - get<DDims>(m_views).data())...);
+    }
+
+    KOKKOS_FUNCTION constexpr bool empty() const noexcept
+    {
+        return size() == 0;
+    }
+
+    KOKKOS_FUNCTION constexpr explicit operator bool()
+    {
+        return !empty();
+    }
+
+    // template <
+    //         std::size_t N = sizeof...(DDims),
+    //         class DDim0 = std::enable_if_t<N == 1, std::tuple_element_t<0, std::tuple<DDims...>>>>
+    // KOKKOS_FUNCTION auto begin() const
+    // {
+    //     return StorageDiscreteDomainIterator<DDim0>(front(), m_strides);
+    // }
+
+    // template <
+    //         std::size_t N = sizeof...(DDims),
+    //         class DDim0 = std::enable_if_t<N == 1, std::tuple_element_t<0, std::tuple<DDims...>>>>
+    // KOKKOS_FUNCTION auto end() const
+    // {
+    //     return StorageDiscreteDomainIterator<
+    //             DDim0>(m_element_begin + m_extents * m_strides, m_strides);
+    // }
+
+    // template <
+    //         std::size_t N = sizeof...(DDims),
+    //         class DDim0 = std::enable_if_t<N == 1, std::tuple_element_t<0, std::tuple<DDims...>>>>
+    // KOKKOS_FUNCTION auto cbegin() const
+    // {
+    //     return StorageDiscreteDomainIterator<DDim0>(front() s);
+    // }
+
+    // template <
+    //         std::size_t N = sizeof...(DDims),
+    //         class DDim0 = std::enable_if_t<N == 1, std::tuple_element_t<0, std::tuple<DDims...>>>>
+    // KOKKOS_FUNCTION auto cend() const
+    // {
+    //     return StorageDiscreteDomainIterator<DDim0>(m_element_begin);
+    // }
+
+    // template <
+    //         std::size_t N = sizeof...(DDims),
+    //         class = std::enable_if_t<N == 1, std::tuple_element_t<0, std::tuple<DDims...>>>>
+    // KOKKOS_FUNCTION constexpr decltype(auto) operator[](std::size_t n)
+    // {
+    //     return begin()[n];
+    // }
+
+    // template <
+    //         std::size_t N = sizeof...(DDims),
+    //         class = std::enable_if_t<N == 1, std::tuple_element_t<0, std::tuple<DDims...>>>>
+    // KOKKOS_FUNCTION constexpr decltype(auto) operator[](std::size_t n) const
+    // {
+    //     return begin()[n];
+    // }
+};
+
+// template <>
+// class StorageDiscreteDomain<>
+// {
+//     template <class...>
+//     friend class StorageDiscreteDomain;
+
+// public:
+//     using discrete_element_type = DiscreteElement<>;
+
+//     using discrete_vector_type = DiscreteVector<>;
+
+//     static KOKKOS_FUNCTION constexpr std::size_t rank()
+//     {
+//         return 0;
+//     }
+
+//     KOKKOS_DEFAULTED_FUNCTION constexpr StorageDiscreteDomain() = default;
+
+//     // Construct a StorageDiscreteDomain from a reordered copy of `domain`
+//     template <class... ODDims>
+//     KOKKOS_FUNCTION constexpr explicit StorageDiscreteDomain(
+//             [[maybe_unused]] StorageDiscreteDomain<ODDims...> const& domain)
+//     {
+//     }
+
+//     /** Construct a StorageDiscreteDomain starting from element_begin with size points.
+//      * @param element_begin the lower bound in each direction
+//      * @param size the number of points in each direction
+//      */
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomain(
+//             [[maybe_unused]] discrete_element_type const& element_begin,
+//             [[maybe_unused]] discrete_vector_type const& size)
+//     {
+//     }
+
+//     KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain(StorageDiscreteDomain const& x) = default;
+
+//     KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain(StorageDiscreteDomain&& x) = default;
+
+//     KOKKOS_DEFAULTED_FUNCTION ~StorageDiscreteDomain() = default;
+
+//     KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain& operator=(StorageDiscreteDomain const& x)
+//             = default;
+
+//     KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain& operator=(StorageDiscreteDomain&& x) = default;
+
+//     KOKKOS_FUNCTION constexpr bool operator==(
+//             [[maybe_unused]] StorageDiscreteDomain const& other) const
+//     {
+//         return true;
+//     }
+
+// #if !defined(__cpp_impl_three_way_comparison) || __cpp_impl_three_way_comparison < 201902L
+//     // In C++20, `a!=b` shall be automatically translated by the compiler to `!(a==b)`
+//     KOKKOS_FUNCTION constexpr bool operator!=(StorageDiscreteDomain const& other) const
+//     {
+//         return !(*this == other);
+//     }
+// #endif
+
+//     static KOKKOS_FUNCTION constexpr std::size_t size()
+//     {
+//         return 1;
+//     }
+
+//     static KOKKOS_FUNCTION constexpr discrete_vector_type extents() noexcept
+//     {
+//         return {};
+//     }
+
+//     static KOKKOS_FUNCTION constexpr discrete_element_type front() noexcept
+//     {
+//         return {};
+//     }
+
+//     static KOKKOS_FUNCTION constexpr discrete_element_type back() noexcept
+//     {
+//         return {};
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomain take_first(
+//             [[maybe_unused]] discrete_vector_type n) const
+//     {
+//         return *this;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomain take_last(
+//             [[maybe_unused]] discrete_vector_type n) const
+//     {
+//         return *this;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove_first(
+//             [[maybe_unused]] discrete_vector_type n) const
+//     {
+//         return *this;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove_last(
+//             [[maybe_unused]] discrete_vector_type n) const
+//     {
+//         return *this;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove(
+//             [[maybe_unused]] discrete_vector_type n1,
+//             [[maybe_unused]] discrete_vector_type n2) const
+//     {
+//         return *this;
+//     }
+
+//     KOKKOS_FUNCTION constexpr DiscreteElement<> operator()(
+//             DiscreteVector<> const& /* dvect */) const noexcept
+//     {
+//         return DiscreteElement<>();
+//     }
+
+// #if defined(DDC_BUILD_DEPRECATED_CODE)
+//     template <class... ODims>
+//     [[deprecated(
+//             "Use `restrict_with` "
+//             "instead")]] KOKKOS_FUNCTION constexpr StorageDiscreteDomain restrict(StorageDiscreteDomain<ODims...> const&
+//                                                                                           odomain)
+//             const
+//     {
+//         return restrict_with(odomain);
+//     }
+// #endif
+
+//     template <class... ODims>
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomain restrict_with(
+//             StorageDiscreteDomain<ODims...> const& /* odomain */) const
+//     {
+//         return *this;
+//     }
+
+//     static bool is_inside() noexcept
+//     {
+//         return true;
+//     }
+
+//     static bool is_inside(DiscreteElement<>) noexcept
+//     {
+//         return true;
+//     }
+
+//     static DiscreteVector<> distance_from_front() noexcept
+//     {
+//         return DiscreteVector<>();
+//     }
+
+//     static DiscreteVector<> distance_from_front(DiscreteElement<>) noexcept
+//     {
+//         return DiscreteVector<>();
+//     }
+
+//     static KOKKOS_FUNCTION constexpr bool empty() noexcept
+//     {
+//         return false;
+//     }
+
+//     KOKKOS_FUNCTION constexpr explicit operator bool()
+//     {
+//         return true;
+//     }
+// };
+
+template <class... QueryDDims, class... DDims>
+KOKKOS_FUNCTION constexpr StorageDiscreteDomain<QueryDDims...> select(
+        StorageDiscreteDomain<DDims...> const& domain)
+{
+    return StorageDiscreteDomain<QueryDDims...>(
+            DiscreteElement<QueryDDims...>(domain.front()),
+            DiscreteElement<QueryDDims...>(domain.extents()));
+}
+
+namespace detail {
+
+template <class T>
+struct ConvertTypeSeqToStorageDiscreteDomain;
+
+template <class... DDims>
+struct ConvertTypeSeqToStorageDiscreteDomain<detail::TypeSeq<DDims...>>
+{
+    using type = StorageDiscreteDomain<DDims...>;
+};
+
+template <class T>
+using convert_type_seq_to_storage_discrete_domain_t =
+        typename ConvertTypeSeqToStorageDiscreteDomain<T>::type;
+
+} // namespace detail
+
+// Computes the substraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
+template <class... DDimsA, class... DDimsB>
+KOKKOS_FUNCTION constexpr auto remove_dims_of(
+        StorageDiscreteDomain<DDimsA...> const& DDom_a,
+        [[maybe_unused]] StorageDiscreteDomain<DDimsB...> const& DDom_b) noexcept
+{
+    using TagSeqA = detail::TypeSeq<DDimsA...>;
+    using TagSeqB = detail::TypeSeq<DDimsB...>;
+
+    using type_seq_r = type_seq_remove_t<TagSeqA, TagSeqB>;
+    return detail::convert_type_seq_to_storage_discrete_domain_t<type_seq_r>(DDom_a);
+}
+
+namespace detail {
+
+// Checks if dimension of DDom_a is DDim1. If not, returns restriction to DDim2 of DDom_b. May not be usefull in its own, it helps for replace_dim_of
+template <typename DDim1, typename DDim2, typename DDimA, typename... DDimsB>
+KOKKOS_FUNCTION constexpr std::conditional_t<
+        std::is_same_v<DDimA, DDim1>,
+        ddc::StorageDiscreteDomain<DDim2>,
+        ddc::StorageDiscreteDomain<DDimA>>
+replace_dim_of_1d(
+        StorageDiscreteDomain<DDimA> const& DDom_a,
+        [[maybe_unused]] StorageDiscreteDomain<DDimsB...> const& DDom_b) noexcept
+{
+    if constexpr (std::is_same_v<DDimA, DDim1>) {
+        return ddc::StorageDiscreteDomain<DDim2>(DDom_b);
+    } else {
+        return DDom_a;
+    }
+}
+
+} // namespace detail
+
+// Replace in DDom_a the dimension Dim1 by the dimension Dim2 of DDom_b
+template <typename DDim1, typename DDim2, typename... DDimsA, typename... DDimsB>
+KOKKOS_FUNCTION constexpr auto replace_dim_of(
+        StorageDiscreteDomain<DDimsA...> const& DDom_a,
+        [[maybe_unused]] StorageDiscreteDomain<DDimsB...> const& DDom_b) noexcept
+{
+    // TODO : static_asserts
+    using TagSeqA = detail::TypeSeq<DDimsA...>;
+    using TagSeqB = detail::TypeSeq<DDim1>;
+    using TagSeqC = detail::TypeSeq<DDim2>;
+
+    using type_seq_r = ddc::type_seq_replace_t<TagSeqA, TagSeqB, TagSeqC>;
+    return ddc::detail::convert_type_seq_to_storage_discrete_domain_t<type_seq_r>(
+            detail::replace_dim_of_1d<
+                    DDim1,
+                    DDim2,
+                    DDimsA,
+                    DDimsB...>(ddc::StorageDiscreteDomain<DDimsA>(DDom_a), DDom_b)...);
+}
+
+template <class... QueryDDims, class... DDims>
+KOKKOS_FUNCTION constexpr DiscreteVector<QueryDDims...> extents(
+        StorageDiscreteDomain<DDims...> const& domain) noexcept
+{
+    return DiscreteVector<QueryDDims...>(StorageDiscreteDomain<QueryDDims>(domain).size()...);
+}
+
+template <class... QueryDDims, class... DDims>
+KOKKOS_FUNCTION constexpr DiscreteElement<QueryDDims...> front(
+        StorageDiscreteDomain<DDims...> const& domain) noexcept
+{
+    return DiscreteElement<QueryDDims...>(StorageDiscreteDomain<QueryDDims>(domain).front()...);
+}
+
+template <class... QueryDDims, class... DDims>
+KOKKOS_FUNCTION constexpr DiscreteElement<QueryDDims...> back(
+        StorageDiscreteDomain<DDims...> const& domain) noexcept
+{
+    return DiscreteElement<QueryDDims...>(StorageDiscreteDomain<QueryDDims>(domain).back()...);
+}
+
+// template <class DDim>
+// struct StorageDiscreteDomainIterator
+// {
+// private:
+//     DiscreteElement<DDim> m_value = DiscreteElement<DDim>();
+
+//     DiscreteVector<DDim> m_stride = DiscreteVector<DDim>();
+
+// public:
+//     using iterator_category = std::random_access_iterator_tag;
+
+//     using value_type = DiscreteElement<DDim>;
+
+//     using difference_type = std::ptrdiff_t;
+
+//     KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomainIterator() = default;
+
+//     KOKKOS_FUNCTION constexpr explicit StorageDiscreteDomainIterator(
+//             DiscreteElement<DDim> value,
+//             DiscreteVector<DDim> stride)
+//         : m_value(value)
+//         , m_stride(stride)
+//     {
+//     }
+
+//     KOKKOS_FUNCTION constexpr DiscreteElement<DDim> operator*() const noexcept
+//     {
+//         return m_value;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomainIterator& operator++()
+//     {
+//         m_value.uid() += m_stride.value();
+//         return *this;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomainIterator operator++(int)
+//     {
+//         auto tmp = *this;
+//         ++*this;
+//         return tmp;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomainIterator& operator--()
+//     {
+//         m_value.uid() -= m_stride.value();
+//         return *this;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomainIterator operator--(int)
+//     {
+//         auto tmp = *this;
+//         --*this;
+//         return tmp;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomainIterator& operator+=(difference_type n)
+//     {
+//         if (n >= difference_type(0)) {
+//             m_value.uid() += static_cast<DiscreteElementType>(n) * m_stride.value();
+//         } else {
+//             m_value.uid() -= static_cast<DiscreteElementType>(-n) * m_stride.value();
+//         }
+//         return *this;
+//     }
+
+//     KOKKOS_FUNCTION constexpr StorageDiscreteDomainIterator& operator-=(difference_type n)
+//     {
+//         if (n >= difference_type(0)) {
+//             m_value.uid() -= static_cast<DiscreteElementType>(n) * m_stride.value();
+//         } else {
+//             m_value.uid() += static_cast<DiscreteElementType>(-n) * m_stride.value();
+//         }
+//         return *this;
+//     }
+
+//     KOKKOS_FUNCTION constexpr DiscreteElement<DDim> operator[](difference_type n) const
+//     {
+//         return m_value + n * m_stride.value();
+//     }
+
+//     friend KOKKOS_FUNCTION constexpr bool operator==(
+//             StorageDiscreteDomainIterator const& xx,
+//             StorageDiscreteDomainIterator const& yy)
+//     {
+//         return xx.m_value == yy.m_value;
+//     }
+
+// #if !defined(__cpp_impl_three_way_comparison) || __cpp_impl_three_way_comparison < 201902L
+//     // In C++20, `a!=b` shall be automatically translated by the compiler to `!(a==b)`
+//     friend KOKKOS_FUNCTION constexpr bool operator!=(
+//             StorageDiscreteDomainIterator const& xx,
+//             StorageDiscreteDomainIterator const& yy)
+//     {
+//         return xx.m_value != yy.m_value;
+//     }
+// #endif
+
+//     friend KOKKOS_FUNCTION constexpr bool operator<(
+//             StorageDiscreteDomainIterator const& xx,
+//             StorageDiscreteDomainIterator const& yy)
+//     {
+//         return xx.m_value < yy.m_value;
+//     }
+
+//     friend KOKKOS_FUNCTION constexpr bool operator>(
+//             StorageDiscreteDomainIterator const& xx,
+//             StorageDiscreteDomainIterator const& yy)
+//     {
+//         return yy < xx;
+//     }
+
+//     friend KOKKOS_FUNCTION constexpr bool operator<=(
+//             StorageDiscreteDomainIterator const& xx,
+//             StorageDiscreteDomainIterator const& yy)
+//     {
+//         return !(yy < xx);
+//     }
+
+//     friend KOKKOS_FUNCTION constexpr bool operator>=(
+//             StorageDiscreteDomainIterator const& xx,
+//             StorageDiscreteDomainIterator const& yy)
+//     {
+//         return !(xx < yy);
+//     }
+
+//     friend KOKKOS_FUNCTION constexpr StorageDiscreteDomainIterator operator+(
+//             StorageDiscreteDomainIterator i,
+//             difference_type n)
+//     {
+//         return i += n;
+//     }
+
+//     friend KOKKOS_FUNCTION constexpr StorageDiscreteDomainIterator operator+(
+//             difference_type n,
+//             StorageDiscreteDomainIterator i)
+//     {
+//         return i += n;
+//     }
+
+//     friend KOKKOS_FUNCTION constexpr StorageDiscreteDomainIterator operator-(
+//             StorageDiscreteDomainIterator i,
+//             difference_type n)
+//     {
+//         return i -= n;
+//     }
+
+//     friend KOKKOS_FUNCTION constexpr difference_type operator-(
+//             StorageDiscreteDomainIterator const& xx,
+//             StorageDiscreteDomainIterator const& yy)
+//     {
+//         return (yy.m_value > xx.m_value) ? (-static_cast<difference_type>(yy.m_value - xx.m_value))
+//                                          : (xx.m_value - yy.m_value);
+//     }
+// };
+
+} // namespace ddc

--- a/include/ddc/storage_discrete_domain.hpp
+++ b/include/ddc/storage_discrete_domain.hpp
@@ -49,6 +49,15 @@ struct ToTypeSeq<StorageDiscreteDomain<Tags...>>
     using type = TypeSeq<Tags...>;
 };
 
+template <class T, class U>
+struct RebindDomain;
+
+template <class... DDims, class... ODDims>
+struct RebindDomain<StorageDiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
+{
+    using type = StorageDiscreteDomain<ODDims...>;
+};
+
 template <class InputIt1, class InputIt2>
 KOKKOS_FUNCTION bool equal(InputIt1 first1, InputIt1 last1, InputIt2 first2)
 {
@@ -134,7 +143,7 @@ public:
             class... DDoms,
             class = std::enable_if_t<(is_storage_discrete_domain_v<DDoms> && ...)>>
     KOKKOS_FUNCTION constexpr explicit StorageDiscreteDomain(DDoms const&... domains)
-        : m_views(domains...)
+        : m_views(domains.m_views...)
     {
     }
 

--- a/include/ddc/strided_discrete_domain.hpp
+++ b/include/ddc/strided_discrete_domain.hpp
@@ -219,7 +219,7 @@ public:
     // }
 
     template <class... DElems>
-    KOKKOS_FUNCTION bool is_inside(DElems const&... delems) const noexcept
+    KOKKOS_FUNCTION bool contains(DElems const&... delems) const noexcept
     {
         static_assert(
                 sizeof...(DDims) == (0 + ... + DElems::size()),
@@ -251,7 +251,7 @@ public:
                 sizeof...(DDims) == (0 + ... + DElems::size()),
                 "Invalid number of dimensions");
         static_assert((is_discrete_element_v<DElems> && ...), "Expected DiscreteElements");
-        assert(is_inside(delems...));
+        assert(contains(delems...));
         return DiscreteVector<DDims...>(
                 ((DiscreteElement<DDims>(take<DDims>(delems...))
                   - DiscreteElement<DDims>(m_element_begin))
@@ -455,12 +455,12 @@ public:
         return *this;
     }
 
-    static bool is_inside() noexcept
+    static bool contains() noexcept
     {
         return true;
     }
 
-    static bool is_inside(DiscreteElement<>) noexcept
+    static bool contains(DiscreteElement<>) noexcept
     {
         return true;
     }

--- a/include/ddc/strided_discrete_domain.hpp
+++ b/include/ddc/strided_discrete_domain.hpp
@@ -428,6 +428,12 @@ public:
         return *this;
     }
 
+    KOKKOS_FUNCTION constexpr DiscreteElement<> operator()(
+            DiscreteVector<> const& dvect) const noexcept
+    {
+        return DiscreteElement<>();
+    }
+
 #if defined(DDC_BUILD_DEPRECATED_CODE)
     template <class... ODims>
     [[deprecated(

--- a/include/ddc/strided_discrete_domain.hpp
+++ b/include/ddc/strided_discrete_domain.hpp
@@ -204,20 +204,6 @@ public:
         return m_element_begin + prod(dvect, m_strides);
     }
 
-    // template <class... ODDims>
-    // KOKKOS_FUNCTION constexpr auto restrict_with(
-    //         StridedDiscreteDomain<ODDims...> const& odomain) const
-    // {
-    //     assert(((uid<ODDims>(m_element_begin) <= uid<ODDims>(odomain.m_element_begin)) && ...));
-    //     assert(((uid<ODDims>(m_element_end) >= uid<ODDims>(odomain.m_element_end)) && ...));
-    //     const DiscreteVector<DDims...> myextents = extents();
-    //     const DiscreteVector<ODDims...> oextents = odomain.extents();
-    //     return StridedDiscreteDomain(
-    //             DiscreteElement<DDims...>(
-    //                     (uid_or<DDims>(odomain.m_element_begin, uid<DDims>(m_element_begin)))...),
-    //             DiscreteVector<DDims...>((get_or<DDims>(oextents, get<DDims>(myextents)))...));
-    // }
-
     template <class... DElems>
     KOKKOS_FUNCTION bool contains(DElems const&... delems) const noexcept
     {
@@ -347,10 +333,12 @@ public:
     /** Construct a StridedDiscreteDomain starting from element_begin with size points.
      * @param element_begin the lower bound in each direction
      * @param size the number of points in each direction
+     * @param strides the step between two elements
      */
     KOKKOS_FUNCTION constexpr StridedDiscreteDomain(
             [[maybe_unused]] discrete_element_type const& element_begin,
-            [[maybe_unused]] discrete_vector_type const& size)
+            [[maybe_unused]] discrete_vector_type const& size,
+            [[maybe_unused]] discrete_vector_type const& strides)
     {
     }
 
@@ -436,25 +424,6 @@ public:
         return {};
     }
 
-#if defined(DDC_BUILD_DEPRECATED_CODE)
-    template <class... ODims>
-    [[deprecated(
-            "Use `restrict_with` "
-            "instead")]] KOKKOS_FUNCTION constexpr StridedDiscreteDomain restrict(StridedDiscreteDomain<ODims...> const&
-                                                                                          odomain)
-            const
-    {
-        return restrict_with(odomain);
-    }
-#endif
-
-    template <class... ODims>
-    KOKKOS_FUNCTION constexpr StridedDiscreteDomain restrict_with(
-            StridedDiscreteDomain<ODims...> const& /* odomain */) const
-    {
-        return *this;
-    }
-
     static bool contains() noexcept
     {
         return true;
@@ -492,7 +461,8 @@ KOKKOS_FUNCTION constexpr StridedDiscreteDomain<QueryDDims...> select(
 {
     return StridedDiscreteDomain<QueryDDims...>(
             DiscreteElement<QueryDDims...>(domain.front()),
-            DiscreteElement<QueryDDims...>(domain.extents()));
+            DiscreteVector<QueryDDims...>(domain.extents()),
+            DiscreteVector<QueryDDims...>(domain.strides()));
 }
 
 namespace detail {

--- a/include/ddc/strided_discrete_domain.hpp
+++ b/include/ddc/strided_discrete_domain.hpp
@@ -46,6 +46,15 @@ struct ToTypeSeq<StridedDiscreteDomain<Tags...>>
     using type = TypeSeq<Tags...>;
 };
 
+template <class T, class U>
+struct RebindDomain;
+
+template <class... DDims, class... ODDims>
+struct RebindDomain<StridedDiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
+{
+    using type = StridedDiscreteDomain<ODDims...>;
+};
+
 } // namespace detail
 
 template <class... ODDims>

--- a/include/ddc/strided_discrete_domain.hpp
+++ b/include/ddc/strided_discrete_domain.hpp
@@ -504,6 +504,20 @@ KOKKOS_FUNCTION constexpr auto remove_dims_of(
     return detail::convert_type_seq_to_strided_discrete_domain_t<type_seq_r>(DDom_a);
 }
 
+//! Remove the dimensions DDimsB from DDom_a
+//! @param[in] DDom_a The discrete domain on which to remove dimensions
+//! @return The discrete domain without DDimsB dimensions
+template <class... DDimsB, class... DDimsA>
+KOKKOS_FUNCTION constexpr auto remove_dims_of(
+        StridedDiscreteDomain<DDimsA...> const& DDom_a) noexcept
+{
+    using TagSeqA = detail::TypeSeq<DDimsA...>;
+    using TagSeqB = detail::TypeSeq<DDimsB...>;
+
+    using type_seq_r = type_seq_remove_t<TagSeqA, TagSeqB>;
+    return detail::convert_type_seq_to_strided_discrete_domain_t<type_seq_r>(DDom_a);
+}
+
 namespace detail {
 
 // Checks if dimension of DDom_a is DDim1. If not, returns restriction to DDim2 of DDom_b. May not be useful in its own, it helps for replace_dim_of

--- a/include/ddc/strided_discrete_domain.hpp
+++ b/include/ddc/strided_discrete_domain.hpp
@@ -49,7 +49,7 @@ struct ToTypeSeq<StridedDiscreteDomain<Tags...>>
 } // namespace detail
 
 template <class... ODDims>
-DiscreteVector<ODDims...> prod(
+KOKKOS_FUNCTION DiscreteVector<ODDims...> prod(
         DiscreteVector<ODDims...> const& lhs,
         DiscreteVector<ODDims...> const& rhs) noexcept
 {
@@ -95,7 +95,8 @@ public:
 
     /** Construct a StridedDiscreteDomain starting from element_begin with size points.
      * @param element_begin the lower bound in each direction
-     * @param size the number of points in each direction
+     * @param extents the number of points in each direction
+     * @param strides the step between two elements
      */
     KOKKOS_FUNCTION constexpr StridedDiscreteDomain(
             discrete_element_type const& element_begin,
@@ -218,7 +219,7 @@ public:
     // }
 
     template <class... DElems>
-    bool is_inside(DElems const&... delems) const noexcept
+    KOKKOS_FUNCTION bool is_inside(DElems const&... delems) const noexcept
     {
         static_assert(
                 sizeof...(DDims) == (0 + ... + DElems::size()),
@@ -243,7 +244,8 @@ public:
     }
 
     template <class... DElems>
-    DiscreteVector<DDims...> distance_from_front(DElems const&... delems) const noexcept
+    KOKKOS_FUNCTION DiscreteVector<DDims...> distance_from_front(
+            DElems const&... delems) const noexcept
     {
         static_assert(
                 sizeof...(DDims) == (0 + ... + DElems::size()),
@@ -429,9 +431,9 @@ public:
     }
 
     KOKKOS_FUNCTION constexpr DiscreteElement<> operator()(
-            DiscreteVector<> const& dvect) const noexcept
+            DiscreteVector<> const& /* dvect */) const noexcept
     {
-        return DiscreteElement<>();
+        return {};
     }
 
 #if defined(DDC_BUILD_DEPRECATED_CODE)
@@ -465,12 +467,12 @@ public:
 
     static DiscreteVector<> distance_from_front() noexcept
     {
-        return DiscreteVector<>();
+        return {};
     }
 
     static DiscreteVector<> distance_from_front(DiscreteElement<>) noexcept
     {
-        return DiscreteVector<>();
+        return {};
     }
 
     static KOKKOS_FUNCTION constexpr bool empty() noexcept
@@ -510,7 +512,7 @@ using convert_type_seq_to_strided_discrete_domain_t =
 
 } // namespace detail
 
-// Computes the substraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
+// Computes the subtraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
 template <class... DDimsA, class... DDimsB>
 KOKKOS_FUNCTION constexpr auto remove_dims_of(
         StridedDiscreteDomain<DDimsA...> const& DDom_a,
@@ -525,7 +527,7 @@ KOKKOS_FUNCTION constexpr auto remove_dims_of(
 
 namespace detail {
 
-// Checks if dimension of DDom_a is DDim1. If not, returns restriction to DDim2 of DDom_b. May not be usefull in its own, it helps for replace_dim_of
+// Checks if dimension of DDom_a is DDim1. If not, returns restriction to DDim2 of DDom_b. May not be useful in its own, it helps for replace_dim_of
 template <typename DDim1, typename DDim2, typename DDimA, typename... DDimsB>
 KOKKOS_FUNCTION constexpr std::conditional_t<
         std::is_same_v<DDimA, DDim1>,

--- a/include/ddc/transform_reduce.hpp
+++ b/include/ddc/transform_reduce.hpp
@@ -9,7 +9,6 @@
 #include "ddc/detail/macros.hpp"
 #include "ddc/discrete_domain.hpp"
 #include "ddc/discrete_element.hpp"
-#include "ddc/strided_discrete_domain.hpp"
 
 namespace ddc {
 

--- a/include/ddc/transform_reduce.hpp
+++ b/include/ddc/transform_reduce.hpp
@@ -9,6 +9,7 @@
 #include "ddc/detail/macros.hpp"
 #include "ddc/discrete_domain.hpp"
 #include "ddc/discrete_element.hpp"
+#include "ddc/strided_discrete_domain.hpp"
 
 namespace ddc {
 
@@ -23,24 +24,19 @@ namespace detail {
  *            range. The return type must be acceptable as input to reduce
  * @param[in] dcoords discrete elements from dimensions already in a loop
  */
-template <
-        class... DDims,
-        class T,
-        class BinaryReductionOp,
-        class UnaryTransformOp,
-        class... DCoords>
+template <class Support, class T, class BinaryReductionOp, class UnaryTransformOp, class... DCoords>
 T transform_reduce_serial(
-        DiscreteDomain<DDims...> const& domain,
+        Support const& domain,
         [[maybe_unused]] T const neutral,
         BinaryReductionOp const& reduce,
         UnaryTransformOp const& transform,
         DCoords const&... dcoords) noexcept
 {
     DDC_IF_NVCC_THEN_PUSH_AND_SUPPRESS(implicit_return_from_non_void_function)
-    if constexpr (sizeof...(DCoords) == sizeof...(DDims)) {
-        return transform(DiscreteElement<DDims...>(dcoords...));
+    if constexpr (sizeof...(DCoords) == Support::rank()) {
+        return transform(typename Support::discrete_element_type(dcoords...));
     } else {
-        using CurrentDDim = type_seq_element_t<sizeof...(DCoords), detail::TypeSeq<DDims...>>;
+        using CurrentDDim = type_seq_element_t<sizeof...(DCoords), to_type_seq_t<Support>>;
         T result = neutral;
         for (DiscreteElement<CurrentDDim> const ii : DiscreteDomain<CurrentDDim>(domain)) {
             result = reduce(
@@ -62,9 +58,9 @@ T transform_reduce_serial(
  * @param[in] transform a unary FunctionObject that will be applied to each element of the input
  *            range. The return type must be acceptable as input to reduce
  */
-template <class... DDims, class T, class BinaryReductionOp, class UnaryTransformOp>
+template <class Support, class T, class BinaryReductionOp, class UnaryTransformOp>
 T transform_reduce(
-        DiscreteDomain<DDims...> const& domain,
+        Support const& domain,
         T neutral,
         BinaryReductionOp&& reduce,
         UnaryTransformOp&& transform) noexcept

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
     relocatable_device_code.cpp
     relocatable_device_code_initialization.cpp
     single_discretization.cpp
+    strided_discrete_domain.cpp
     tagged_vector.cpp
     transform_reduce.cpp
     type_seq.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(
     relocatable_device_code.cpp
     relocatable_device_code_initialization.cpp
     single_discretization.cpp
+    storage_discrete_domain.cpp
     strided_discrete_domain.cpp
     tagged_vector.cpp
     transform_reduce.cpp

--- a/tests/chunk.cpp
+++ b/tests/chunk.cpp
@@ -634,3 +634,12 @@ TEST(Chunk2DTest, Mirror)
         }
     }
 }
+
+TEST(ChunkStridedDiscreteDomain, Constructor)
+{
+    ddc::StridedDiscreteDomain<DDimX, DDimY> dom(lbound_x_y, nelems_x_y, DVectXY(10, 10));
+    ddc::Chunk chk("", dom, ddc::HostAllocator<int>());
+    ddc::parallel_fill(chk.span_view(), 2);
+    EXPECT_EQ(chk(lbound_x_y), 2);
+    EXPECT_EQ(chk(lbound_x_y + DVectXY(10, 10)), 2);
+}

--- a/tests/chunk.cpp
+++ b/tests/chunk.cpp
@@ -468,101 +468,101 @@ TEST(Chunk2DTest, Cview)
     }
 }
 
-// TEST(Chunk2DTest, SliceCoordX)
-// {
-//     DElemX const slice_x_val(lbound_x + 1);
+TEST(Chunk2DTest, SliceCoordX)
+{
+    DElemX const slice_x_val(lbound_x + 1);
 
-//     ChunkXY<double> chunk(dom_x_y);
-//     ChunkXY<double> const& chunk_cref = chunk;
-//     for (DElemX const ix : chunk.domain<DDimX>()) {
-//         for (DElemY const iy : chunk.domain<DDimY>()) {
-//             chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
-//         }
-//     }
+    ChunkXY<double> chunk(dom_x_y);
+    ChunkXY<double> const& chunk_cref = chunk;
+    for (DElemX const ix : chunk.domain<DDimX>()) {
+        for (DElemY const iy : chunk.domain<DDimY>()) {
+            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+        }
+    }
 
-//     ddc::ChunkSpan const chunk_y = chunk_cref[slice_x_val];
-//     EXPECT_TRUE(
-//             (std::is_same_v<std::decay_t<decltype(chunk_y)>::layout_type, Kokkos::layout_right>));
-//     EXPECT_EQ(chunk_y.extent<DDimY>(), chunk.extent<DDimY>());
-//     for (DElemY const iy : chunk_cref.domain<DDimY>()) {
-//         // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
-//         EXPECT_EQ(chunk_y(iy), chunk_cref(slice_x_val, iy));
-//     }
-// }
+    ddc::ChunkSpan const chunk_y = chunk_cref[slice_x_val];
+    EXPECT_TRUE(
+            (std::is_same_v<std::decay_t<decltype(chunk_y)>::layout_type, Kokkos::layout_right>));
+    EXPECT_EQ(chunk_y.extent<DDimY>(), chunk.extent<DDimY>());
+    for (DElemY const iy : chunk_cref.domain<DDimY>()) {
+        // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
+        EXPECT_EQ(chunk_y(iy), chunk_cref(slice_x_val, iy));
+    }
+}
 
-// TEST(Chunk2DTest, SliceCoordY)
-// {
-//     DElemY const slice_y_val(lbound_y + 1);
+TEST(Chunk2DTest, SliceCoordY)
+{
+    DElemY const slice_y_val(lbound_y + 1);
 
-//     ChunkXY<double> chunk(dom_x_y);
-//     ChunkXY<double> const& chunk_cref = chunk;
-//     for (DElemX const ix : chunk.domain<DDimX>()) {
-//         for (DElemY const iy : chunk.domain<DDimY>()) {
-//             chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
-//         }
-//     }
+    ChunkXY<double> chunk(dom_x_y);
+    ChunkXY<double> const& chunk_cref = chunk;
+    for (DElemX const ix : chunk.domain<DDimX>()) {
+        for (DElemY const iy : chunk.domain<DDimY>()) {
+            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+        }
+    }
 
-//     ddc::ChunkSpan const chunk_x = chunk_cref[slice_y_val];
-//     EXPECT_TRUE(
-//             (std::is_same_v<std::decay_t<decltype(chunk_x)>::layout_type, Kokkos::layout_stride>));
-//     EXPECT_EQ(chunk_x.extent<DDimX>(), chunk.extent<DDimX>());
-//     for (DElemX const ix : chunk_cref.domain<DDimX>()) {
-//         // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
-//         EXPECT_EQ(chunk_x(ix), chunk_cref(ix, slice_y_val));
-//     }
-// }
+    ddc::ChunkSpan const chunk_x = chunk_cref[slice_y_val];
+    EXPECT_TRUE(
+            (std::is_same_v<std::decay_t<decltype(chunk_x)>::layout_type, Kokkos::layout_stride>));
+    EXPECT_EQ(chunk_x.extent<DDimX>(), chunk.extent<DDimX>());
+    for (DElemX const ix : chunk_cref.domain<DDimX>()) {
+        // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
+        EXPECT_EQ(chunk_x(ix), chunk_cref(ix, slice_y_val));
+    }
+}
 
-// TEST(Chunk2DTest, SliceDomainX)
-// {
-//     DDomX const subdomain_x(lbound_x + 1, nelems_x - 2);
+TEST(Chunk2DTest, SliceDomainX)
+{
+    DDomX const subdomain_x(lbound_x + 1, nelems_x - 2);
 
-//     ChunkXY<double> chunk(dom_x_y);
-//     ChunkXY<double> const& chunk_cref = chunk;
-//     for (DElemX const ix : chunk.domain<DDimX>()) {
-//         for (DElemY const iy : chunk.domain<DDimY>()) {
-//             chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
-//         }
-//     }
+    ChunkXY<double> chunk(dom_x_y);
+    ChunkXY<double> const& chunk_cref = chunk;
+    for (DElemX const ix : chunk.domain<DDimX>()) {
+        for (DElemY const iy : chunk.domain<DDimY>()) {
+            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+        }
+    }
 
-//     ddc::ChunkSpan const subchunk_x = chunk_cref[subdomain_x];
-//     EXPECT_TRUE((
-//             std::is_same_v<std::decay_t<decltype(subchunk_x)>::layout_type, Kokkos::layout_right>));
+    ddc::ChunkSpan const subchunk_x = chunk_cref[subdomain_x];
+    EXPECT_TRUE((
+            std::is_same_v<std::decay_t<decltype(subchunk_x)>::layout_type, Kokkos::layout_right>));
 
-//     EXPECT_EQ(subchunk_x.extent<DDimX>(), subdomain_x.size());
-//     EXPECT_EQ(subchunk_x.extent<DDimY>(), chunk.domain<DDimY>().size());
-//     for (DElemX const ix : subchunk_x.domain<DDimX>()) {
-//         for (DElemY const iy : subchunk_x.domain<DDimY>()) {
-//             // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
-//             EXPECT_EQ(subchunk_x(ix, iy), chunk_cref(ix, iy));
-//         }
-//     }
-// }
+    EXPECT_EQ(subchunk_x.extent<DDimX>(), subdomain_x.size());
+    EXPECT_EQ(subchunk_x.extent<DDimY>(), chunk.domain<DDimY>().size());
+    for (DElemX const ix : subchunk_x.domain<DDimX>()) {
+        for (DElemY const iy : subchunk_x.domain<DDimY>()) {
+            // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
+            EXPECT_EQ(subchunk_x(ix, iy), chunk_cref(ix, iy));
+        }
+    }
+}
 
-// TEST(Chunk2DTest, SliceDomainY)
-// {
-//     DDomY const subdomain_y(lbound_y + 1, nelems_y - 2);
+TEST(Chunk2DTest, SliceDomainY)
+{
+    DDomY const subdomain_y(lbound_y + 1, nelems_y - 2);
 
-//     ChunkXY<double> chunk(dom_x_y);
-//     ChunkXY<double> const& chunk_cref = chunk;
-//     for (DElemX const ix : chunk.domain<DDimX>()) {
-//         for (DElemY const iy : chunk.domain<DDimY>()) {
-//             chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
-//         }
-//     }
-//     ddc::ChunkSpan const subchunk_y = chunk_cref[subdomain_y];
-//     EXPECT_TRUE((std::is_same_v<
-//                  std::decay_t<decltype(subchunk_y)>::layout_type,
-//                  Kokkos::layout_stride>));
+    ChunkXY<double> chunk(dom_x_y);
+    ChunkXY<double> const& chunk_cref = chunk;
+    for (DElemX const ix : chunk.domain<DDimX>()) {
+        for (DElemY const iy : chunk.domain<DDimY>()) {
+            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+        }
+    }
+    ddc::ChunkSpan const subchunk_y = chunk_cref[subdomain_y];
+    EXPECT_TRUE((std::is_same_v<
+                 std::decay_t<decltype(subchunk_y)>::layout_type,
+                 Kokkos::layout_stride>));
 
-//     EXPECT_EQ(subchunk_y.extent<DDimX>(), chunk.domain<DDimX>().size());
-//     EXPECT_EQ(subchunk_y.extent<DDimY>(), subdomain_y.size());
-//     for (DElemX const ix : subchunk_y.domain<DDimX>()) {
-//         for (DElemY const iy : subchunk_y.domain<DDimY>()) {
-//             // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
-//             EXPECT_EQ(subchunk_y(ix, iy), chunk_cref(ix, iy));
-//         }
-//     }
-// }
+    EXPECT_EQ(subchunk_y.extent<DDimX>(), chunk.domain<DDimX>().size());
+    EXPECT_EQ(subchunk_y.extent<DDimY>(), subdomain_y.size());
+    for (DElemX const ix : subchunk_y.domain<DDimX>()) {
+        for (DElemY const iy : subchunk_y.domain<DDimY>()) {
+            // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
+            EXPECT_EQ(subchunk_y(ix, iy), chunk_cref(ix, iy));
+        }
+    }
+}
 
 TEST(Chunk2DTest, Deepcopy)
 {
@@ -637,7 +637,7 @@ TEST(Chunk2DTest, Mirror)
 
 TEST(ChunkStridedDiscreteDomain, Constructor)
 {
-    ddc::StridedDiscreteDomain<DDimX, DDimY> dom(lbound_x_y, nelems_x_y, DVectXY(10, 10));
+    ddc::StridedDiscreteDomain<DDimX, DDimY> const dom(lbound_x_y, nelems_x_y, DVectXY(10, 10));
     ddc::Chunk chk("", dom, ddc::HostAllocator<int>());
     ddc::parallel_fill(chk.span_view(), 2);
     EXPECT_EQ(chk(lbound_x_y), 2);

--- a/tests/chunk.cpp
+++ b/tests/chunk.cpp
@@ -468,101 +468,101 @@ TEST(Chunk2DTest, Cview)
     }
 }
 
-TEST(Chunk2DTest, SliceCoordX)
-{
-    DElemX const slice_x_val(lbound_x + 1);
+// TEST(Chunk2DTest, SliceCoordX)
+// {
+//     DElemX const slice_x_val(lbound_x + 1);
 
-    ChunkXY<double> chunk(dom_x_y);
-    ChunkXY<double> const& chunk_cref = chunk;
-    for (DElemX const ix : chunk.domain<DDimX>()) {
-        for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
-        }
-    }
+//     ChunkXY<double> chunk(dom_x_y);
+//     ChunkXY<double> const& chunk_cref = chunk;
+//     for (DElemX const ix : chunk.domain<DDimX>()) {
+//         for (DElemY const iy : chunk.domain<DDimY>()) {
+//             chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+//         }
+//     }
 
-    ddc::ChunkSpan const chunk_y = chunk_cref[slice_x_val];
-    EXPECT_TRUE(
-            (std::is_same_v<std::decay_t<decltype(chunk_y)>::layout_type, Kokkos::layout_right>));
-    EXPECT_EQ(chunk_y.extent<DDimY>(), chunk.extent<DDimY>());
-    for (DElemY const iy : chunk_cref.domain<DDimY>()) {
-        // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
-        EXPECT_EQ(chunk_y(iy), chunk_cref(slice_x_val, iy));
-    }
-}
+//     ddc::ChunkSpan const chunk_y = chunk_cref[slice_x_val];
+//     EXPECT_TRUE(
+//             (std::is_same_v<std::decay_t<decltype(chunk_y)>::layout_type, Kokkos::layout_right>));
+//     EXPECT_EQ(chunk_y.extent<DDimY>(), chunk.extent<DDimY>());
+//     for (DElemY const iy : chunk_cref.domain<DDimY>()) {
+//         // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
+//         EXPECT_EQ(chunk_y(iy), chunk_cref(slice_x_val, iy));
+//     }
+// }
 
-TEST(Chunk2DTest, SliceCoordY)
-{
-    DElemY const slice_y_val(lbound_y + 1);
+// TEST(Chunk2DTest, SliceCoordY)
+// {
+//     DElemY const slice_y_val(lbound_y + 1);
 
-    ChunkXY<double> chunk(dom_x_y);
-    ChunkXY<double> const& chunk_cref = chunk;
-    for (DElemX const ix : chunk.domain<DDimX>()) {
-        for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
-        }
-    }
+//     ChunkXY<double> chunk(dom_x_y);
+//     ChunkXY<double> const& chunk_cref = chunk;
+//     for (DElemX const ix : chunk.domain<DDimX>()) {
+//         for (DElemY const iy : chunk.domain<DDimY>()) {
+//             chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+//         }
+//     }
 
-    ddc::ChunkSpan const chunk_x = chunk_cref[slice_y_val];
-    EXPECT_TRUE(
-            (std::is_same_v<std::decay_t<decltype(chunk_x)>::layout_type, Kokkos::layout_stride>));
-    EXPECT_EQ(chunk_x.extent<DDimX>(), chunk.extent<DDimX>());
-    for (DElemX const ix : chunk_cref.domain<DDimX>()) {
-        // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
-        EXPECT_EQ(chunk_x(ix), chunk_cref(ix, slice_y_val));
-    }
-}
+//     ddc::ChunkSpan const chunk_x = chunk_cref[slice_y_val];
+//     EXPECT_TRUE(
+//             (std::is_same_v<std::decay_t<decltype(chunk_x)>::layout_type, Kokkos::layout_stride>));
+//     EXPECT_EQ(chunk_x.extent<DDimX>(), chunk.extent<DDimX>());
+//     for (DElemX const ix : chunk_cref.domain<DDimX>()) {
+//         // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
+//         EXPECT_EQ(chunk_x(ix), chunk_cref(ix, slice_y_val));
+//     }
+// }
 
-TEST(Chunk2DTest, SliceDomainX)
-{
-    DDomX const subdomain_x(lbound_x + 1, nelems_x - 2);
+// TEST(Chunk2DTest, SliceDomainX)
+// {
+//     DDomX const subdomain_x(lbound_x + 1, nelems_x - 2);
 
-    ChunkXY<double> chunk(dom_x_y);
-    ChunkXY<double> const& chunk_cref = chunk;
-    for (DElemX const ix : chunk.domain<DDimX>()) {
-        for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
-        }
-    }
+//     ChunkXY<double> chunk(dom_x_y);
+//     ChunkXY<double> const& chunk_cref = chunk;
+//     for (DElemX const ix : chunk.domain<DDimX>()) {
+//         for (DElemY const iy : chunk.domain<DDimY>()) {
+//             chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+//         }
+//     }
 
-    ddc::ChunkSpan const subchunk_x = chunk_cref[subdomain_x];
-    EXPECT_TRUE((
-            std::is_same_v<std::decay_t<decltype(subchunk_x)>::layout_type, Kokkos::layout_right>));
+//     ddc::ChunkSpan const subchunk_x = chunk_cref[subdomain_x];
+//     EXPECT_TRUE((
+//             std::is_same_v<std::decay_t<decltype(subchunk_x)>::layout_type, Kokkos::layout_right>));
 
-    EXPECT_EQ(subchunk_x.extent<DDimX>(), subdomain_x.size());
-    EXPECT_EQ(subchunk_x.extent<DDimY>(), chunk.domain<DDimY>().size());
-    for (DElemX const ix : subchunk_x.domain<DDimX>()) {
-        for (DElemY const iy : subchunk_x.domain<DDimY>()) {
-            // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
-            EXPECT_EQ(subchunk_x(ix, iy), chunk_cref(ix, iy));
-        }
-    }
-}
+//     EXPECT_EQ(subchunk_x.extent<DDimX>(), subdomain_x.size());
+//     EXPECT_EQ(subchunk_x.extent<DDimY>(), chunk.domain<DDimY>().size());
+//     for (DElemX const ix : subchunk_x.domain<DDimX>()) {
+//         for (DElemY const iy : subchunk_x.domain<DDimY>()) {
+//             // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
+//             EXPECT_EQ(subchunk_x(ix, iy), chunk_cref(ix, iy));
+//         }
+//     }
+// }
 
-TEST(Chunk2DTest, SliceDomainY)
-{
-    DDomY const subdomain_y(lbound_y + 1, nelems_y - 2);
+// TEST(Chunk2DTest, SliceDomainY)
+// {
+//     DDomY const subdomain_y(lbound_y + 1, nelems_y - 2);
 
-    ChunkXY<double> chunk(dom_x_y);
-    ChunkXY<double> const& chunk_cref = chunk;
-    for (DElemX const ix : chunk.domain<DDimX>()) {
-        for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
-        }
-    }
-    ddc::ChunkSpan const subchunk_y = chunk_cref[subdomain_y];
-    EXPECT_TRUE((std::is_same_v<
-                 std::decay_t<decltype(subchunk_y)>::layout_type,
-                 Kokkos::layout_stride>));
+//     ChunkXY<double> chunk(dom_x_y);
+//     ChunkXY<double> const& chunk_cref = chunk;
+//     for (DElemX const ix : chunk.domain<DDimX>()) {
+//         for (DElemY const iy : chunk.domain<DDimY>()) {
+//             chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+//         }
+//     }
+//     ddc::ChunkSpan const subchunk_y = chunk_cref[subdomain_y];
+//     EXPECT_TRUE((std::is_same_v<
+//                  std::decay_t<decltype(subchunk_y)>::layout_type,
+//                  Kokkos::layout_stride>));
 
-    EXPECT_EQ(subchunk_y.extent<DDimX>(), chunk.domain<DDimX>().size());
-    EXPECT_EQ(subchunk_y.extent<DDimY>(), subdomain_y.size());
-    for (DElemX const ix : subchunk_y.domain<DDimX>()) {
-        for (DElemY const iy : subchunk_y.domain<DDimY>()) {
-            // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
-            EXPECT_EQ(subchunk_y(ix, iy), chunk_cref(ix, iy));
-        }
-    }
-}
+//     EXPECT_EQ(subchunk_y.extent<DDimX>(), chunk.domain<DDimX>().size());
+//     EXPECT_EQ(subchunk_y.extent<DDimY>(), subdomain_y.size());
+//     for (DElemX const ix : subchunk_y.domain<DDimX>()) {
+//         for (DElemY const iy : subchunk_y.domain<DDimY>()) {
+//             // we expect complete equality, not EXPECT_DOUBLE_EQ: these are copy
+//             EXPECT_EQ(subchunk_y(ix, iy), chunk_cref(ix, iy));
+//         }
+//     }
+// }
 
 TEST(Chunk2DTest, Deepcopy)
 {

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -245,6 +245,19 @@ TEST(DiscreteDomainTest, Remove)
             DDomXY(dom_x_y.front() + DVectXY(1, 4), dom_x_y.extents() - DVectXY(2, 5)));
 }
 
+TEST(DiscreteDomainTest, IsInside)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+    EXPECT_TRUE(dom_x_y.is_inside(lbound_x_y));
+    EXPECT_FALSE(dom_x_y.is_inside(lbound_x_y + nelems_x_y));
+}
+
+TEST(DiscreteDomainTest, DistanceFromFront)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+    EXPECT_EQ(dom_x_y.distance_from_front(lbound_x_y), DVectXY(0, 0));
+}
+
 TEST(DiscreteDomainTest, SliceDomainXTooearly)
 {
 #ifndef NDEBUG // The assertion is only checked if NDEBUG isn't defined

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -245,11 +245,11 @@ TEST(DiscreteDomainTest, Remove)
             DDomXY(dom_x_y.front() + DVectXY(1, 4), dom_x_y.extents() - DVectXY(2, 5)));
 }
 
-TEST(DiscreteDomainTest, IsInside)
+TEST(DiscreteDomainTest, Contains)
 {
     DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
-    EXPECT_TRUE(dom_x_y.is_inside(lbound_x_y));
-    EXPECT_FALSE(dom_x_y.is_inside(lbound_x_y + nelems_x_y));
+    EXPECT_TRUE(dom_x_y.contains(lbound_x_y));
+    EXPECT_FALSE(dom_x_y.contains(lbound_x_y + nelems_x_y));
 }
 
 TEST(DiscreteDomainTest, DistanceFromFront)

--- a/tests/storage_discrete_domain.cpp
+++ b/tests/storage_discrete_domain.cpp
@@ -97,5 +97,5 @@ TEST(StorageDiscreteDomainTest, Constructor)
     EXPECT_EQ(dom_xy.distance_from_front(lbound_x + 2, lbound_y + 0), DVectXY(1, 0));
     EXPECT_EQ(dom_xy.distance_from_front(lbound_x + 2, lbound_y + 2), DVectXY(1, 1));
     EXPECT_EQ(dom_xy.distance_from_front(lbound_x + 2, lbound_y + 5), DVectXY(1, 2));
-    EXPECT_FALSE(dom_xy.is_inside(lbound_x + 1, lbound_y + 0));
+    EXPECT_FALSE(dom_xy.contains(lbound_x + 1, lbound_y + 0));
 }

--- a/tests/storage_discrete_domain.cpp
+++ b/tests/storage_discrete_domain.cpp
@@ -1,0 +1,101 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP) {
+
+struct DDimX
+{
+};
+using DElemX = ddc::DiscreteElement<DDimX>;
+using DVectX = ddc::DiscreteVector<DDimX>;
+using DDomX = ddc::StorageDiscreteDomain<DDimX>;
+
+
+struct DDimY
+{
+};
+using DElemY = ddc::DiscreteElement<DDimY>;
+using DVectY = ddc::DiscreteVector<DDimY>;
+using DDomY = ddc::StorageDiscreteDomain<DDimY>;
+
+
+struct DDimZ
+{
+};
+using DElemZ = ddc::DiscreteElement<DDimZ>;
+using DVectZ = ddc::DiscreteVector<DDimZ>;
+using DDomZ = ddc::StorageDiscreteDomain<DDimZ>;
+
+
+using DElemXY = ddc::DiscreteElement<DDimX, DDimY>;
+using DVectXY = ddc::DiscreteVector<DDimX, DDimY>;
+using DDomXY = ddc::StorageDiscreteDomain<DDimX, DDimY>;
+
+
+using DElemYX = ddc::DiscreteElement<DDimY, DDimX>;
+using DVectYX = ddc::DiscreteVector<DDimY, DDimX>;
+using DDomYX = ddc::StorageDiscreteDomain<DDimY, DDimX>;
+
+using DElemXZ = ddc::DiscreteElement<DDimX, DDimZ>;
+using DVectXZ = ddc::DiscreteVector<DDimX, DDimZ>;
+using DDomXZ = ddc::StorageDiscreteDomain<DDimX, DDimZ>;
+
+using DElemZY = ddc::DiscreteElement<DDimZ, DDimY>;
+using DVectZY = ddc::DiscreteVector<DDimZ, DDimY>;
+using DDomZY = ddc::StorageDiscreteDomain<DDimZ, DDimY>;
+
+
+using DElemXYZ = ddc::DiscreteElement<DDimX, DDimY, DDimZ>;
+using DVectXYZ = ddc::DiscreteVector<DDimX, DDimY, DDimZ>;
+using DDomXYZ = ddc::StorageDiscreteDomain<DDimX, DDimY, DDimZ>;
+
+using DElemZYX = ddc::DiscreteElement<DDimZ, DDimY, DDimX>;
+using DVectZYX = ddc::DiscreteVector<DDimZ, DDimY, DDimX>;
+using DDomZYX = ddc::StorageDiscreteDomain<DDimZ, DDimY, DDimX>;
+
+DElemX constexpr lbound_x(50);
+DVectX constexpr nelems_x(3);
+DElemX constexpr sentinel_x(lbound_x + nelems_x);
+DElemX constexpr ubound_x(sentinel_x - 1);
+
+
+DElemY constexpr lbound_y(4);
+DVectY constexpr nelems_y(10);
+DElemY constexpr sentinel_y(lbound_y);
+DElemY constexpr ubound_y(sentinel_y - 1);
+
+DElemZ constexpr lbound_z(7);
+DVectZ constexpr nelems_z(15);
+
+DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
+DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
+DElemXY constexpr ubound_x_y(ubound_x, ubound_y);
+
+DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
+DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
+
+} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP)
+
+TEST(StorageDiscreteDomainTest, Constructor)
+{
+    Kokkos::View<DElemX*, Kokkos::SharedSpace> const view_x("view_x", 2);
+    view_x(0) = lbound_x + 0;
+    view_x(1) = lbound_x + 2;
+    Kokkos::View<DElemY*, Kokkos::SharedSpace> const view_y("view_y", 3);
+    view_y(0) = lbound_y + 0;
+    view_y(1) = lbound_y + 2;
+    view_y(2) = lbound_y + 5;
+    DDomXY const dom_xy(view_x, view_y);
+    EXPECT_EQ(dom_xy.distance_from_front(lbound_x + 0, lbound_y + 0), DVectXY(0, 0));
+    EXPECT_EQ(dom_xy.distance_from_front(lbound_x + 0, lbound_y + 2), DVectXY(0, 1));
+    EXPECT_EQ(dom_xy.distance_from_front(lbound_x + 0, lbound_y + 5), DVectXY(0, 2));
+    EXPECT_EQ(dom_xy.distance_from_front(lbound_x + 2, lbound_y + 0), DVectXY(1, 0));
+    EXPECT_EQ(dom_xy.distance_from_front(lbound_x + 2, lbound_y + 2), DVectXY(1, 1));
+    EXPECT_EQ(dom_xy.distance_from_front(lbound_x + 2, lbound_y + 5), DVectXY(1, 2));
+    EXPECT_FALSE(dom_xy.is_inside(lbound_x + 1, lbound_y + 0));
+}

--- a/tests/storage_discrete_domain.cpp
+++ b/tests/storage_discrete_domain.cpp
@@ -59,25 +59,25 @@ using DVectZYX = ddc::DiscreteVector<DDimZ, DDimY, DDimX>;
 using DDomZYX = ddc::StorageDiscreteDomain<DDimZ, DDimY, DDimX>;
 
 DElemX constexpr lbound_x(50);
-DVectX constexpr nelems_x(3);
-DElemX constexpr sentinel_x(lbound_x + nelems_x);
-DElemX constexpr ubound_x(sentinel_x - 1);
+// DVectX constexpr nelems_x(3);
+// DElemX constexpr sentinel_x(lbound_x + nelems_x);
+// DElemX constexpr ubound_x(sentinel_x - 1);
 
 
 DElemY constexpr lbound_y(4);
-DVectY constexpr nelems_y(10);
-DElemY constexpr sentinel_y(lbound_y);
-DElemY constexpr ubound_y(sentinel_y - 1);
+// DVectY constexpr nelems_y(10);
+// DElemY constexpr sentinel_y(lbound_y);
+// DElemY constexpr ubound_y(sentinel_y - 1);
 
-DElemZ constexpr lbound_z(7);
-DVectZ constexpr nelems_z(15);
+// DElemZ constexpr lbound_z(7);
+// DVectZ constexpr nelems_z(15);
 
-DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
-DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
-DElemXY constexpr ubound_x_y(ubound_x, ubound_y);
+// DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
+// DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
+// DElemXY constexpr ubound_x_y(ubound_x, ubound_y);
 
-DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
-DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
+// DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
+// DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
 
 } // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP)
 

--- a/tests/strided_discrete_domain.cpp
+++ b/tests/strided_discrete_domain.cpp
@@ -80,8 +80,9 @@ DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
 DVectXY constexpr strides_x_y(strides_x, strides_y);
 DElemXY constexpr ubound_x_y(ubound_x, ubound_y);
 
-// DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
-// DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
+DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
+DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
+DVectXZ constexpr strides_x_z(strides_x, strides_z);
 
 } // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP)
 
@@ -178,37 +179,37 @@ TEST(StridedDiscreteDomainTest, RangeFor)
     }
 }
 
-// TEST(StridedDiscreteDomainTest, DiffEmpty)
-// {
-//     DDomX const dom_x = DDomX();
-//     ddc::remove_dims_of_t<DDomX, DDimX> const subdomain1 = ddc::remove_dims_of(dom_x, dom_x);
-//     ddc::remove_dims_of_t<DDomX, DDimX> const subdomain2 = ddc::remove_dims_of<DDimX>(dom_x);
-//     EXPECT_EQ(subdomain1, ddc::DiscreteDomain<>());
-//     EXPECT_EQ(subdomain2, ddc::DiscreteDomain<>());
-// }
+TEST(StridedDiscreteDomainTest, DiffEmpty)
+{
+    DDomX const dom_x = DDomX();
+    ddc::remove_dims_of_t<DDomX, DDimX> const subdomain1 = ddc::remove_dims_of(dom_x, dom_x);
+    ddc::remove_dims_of_t<DDomX, DDimX> const subdomain2 = ddc::remove_dims_of<DDimX>(dom_x);
+    EXPECT_EQ(subdomain1, ddc::StridedDiscreteDomain<>());
+    EXPECT_EQ(subdomain2, ddc::StridedDiscreteDomain<>());
+}
 
-// TEST(StridedDiscreteDomainTest, Diff)
-// {
-//     DDomX const dom_x = DDomX();
-//     DDomXY const dom_x_y = DDomXY();
-//     DDomZY const dom_z_y = DDomZY();
-//     ddc::remove_dims_of_t<DDomX, DDimZ, DDimY> const subdomain1
-//             = ddc::remove_dims_of(dom_x_y, dom_z_y);
-//     ddc::remove_dims_of_t<DDomX, DDimZ, DDimY> const subdomain2
-//             = ddc::remove_dims_of<DDimZ, DDimY>(dom_x_y);
-//     EXPECT_EQ(subdomain1, dom_x);
-//     EXPECT_EQ(subdomain2, dom_x);
-// }
+TEST(StridedDiscreteDomainTest, Diff)
+{
+    DDomX const dom_x = DDomX();
+    DDomXY const dom_x_y = DDomXY();
+    DDomZY const dom_z_y = DDomZY();
+    ddc::remove_dims_of_t<DDomX, DDimZ, DDimY> const subdomain1
+            = ddc::remove_dims_of(dom_x_y, dom_z_y);
+    ddc::remove_dims_of_t<DDomX, DDimZ, DDimY> const subdomain2
+            = ddc::remove_dims_of<DDimZ, DDimY>(dom_x_y);
+    EXPECT_EQ(subdomain1, dom_x);
+    EXPECT_EQ(subdomain2, dom_x);
+}
 
-// TEST(StridedDiscreteDomainTest, Replace)
-// {
-//     DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
-//     DDomZ const dom_z(lbound_z, nelems_z);
-//     DDomXZ const dom_x_z(lbound_x_z, nelems_x_z);
-//     ddc::replace_dim_of_t<DDomXY, DDimY, DDimZ> const subdomain
-//             = ddc::replace_dim_of<DDimY, DDimZ>(dom_x_y, dom_z);
-//     EXPECT_EQ(subdomain, dom_x_z);
-// }
+TEST(StridedDiscreteDomainTest, Replace)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    DDomZ const dom_z(lbound_z, nelems_z, strides_z);
+    DDomXZ const dom_x_z(lbound_x_z, nelems_x_z, strides_x_z);
+    ddc::replace_dim_of_t<DDomXY, DDimY, DDimZ> const subdomain
+            = ddc::replace_dim_of<DDimY, DDimZ>(dom_x_y, dom_z);
+    EXPECT_EQ(subdomain, dom_x_z);
+}
 
 
 TEST(StridedDiscreteDomainTest, TakeFirst)

--- a/tests/strided_discrete_domain.cpp
+++ b/tests/strided_discrete_domain.cpp
@@ -1,0 +1,322 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <ddc/ddc.hpp>
+
+#include <gtest/gtest.h>
+
+namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP) {
+
+struct DDimX
+{
+};
+using DElemX = ddc::DiscreteElement<DDimX>;
+using DVectX = ddc::DiscreteVector<DDimX>;
+using DDomX = ddc::StridedDiscreteDomain<DDimX>;
+
+
+struct DDimY
+{
+};
+using DElemY = ddc::DiscreteElement<DDimY>;
+using DVectY = ddc::DiscreteVector<DDimY>;
+using DDomY = ddc::StridedDiscreteDomain<DDimY>;
+
+
+struct DDimZ
+{
+};
+using DElemZ = ddc::DiscreteElement<DDimZ>;
+using DVectZ = ddc::DiscreteVector<DDimZ>;
+using DDomZ = ddc::StridedDiscreteDomain<DDimZ>;
+
+
+using DElemXY = ddc::DiscreteElement<DDimX, DDimY>;
+using DVectXY = ddc::DiscreteVector<DDimX, DDimY>;
+using DDomXY = ddc::StridedDiscreteDomain<DDimX, DDimY>;
+
+
+using DElemYX = ddc::DiscreteElement<DDimY, DDimX>;
+using DVectYX = ddc::DiscreteVector<DDimY, DDimX>;
+using DDomYX = ddc::StridedDiscreteDomain<DDimY, DDimX>;
+
+using DElemXZ = ddc::DiscreteElement<DDimX, DDimZ>;
+using DVectXZ = ddc::DiscreteVector<DDimX, DDimZ>;
+using DDomXZ = ddc::StridedDiscreteDomain<DDimX, DDimZ>;
+
+using DElemZY = ddc::DiscreteElement<DDimZ, DDimY>;
+using DVectZY = ddc::DiscreteVector<DDimZ, DDimY>;
+using DDomZY = ddc::StridedDiscreteDomain<DDimZ, DDimY>;
+
+
+using DElemXYZ = ddc::DiscreteElement<DDimX, DDimY, DDimZ>;
+using DVectXYZ = ddc::DiscreteVector<DDimX, DDimY, DDimZ>;
+using DDomXYZ = ddc::StridedDiscreteDomain<DDimX, DDimY, DDimZ>;
+
+using DElemZYX = ddc::DiscreteElement<DDimZ, DDimY, DDimX>;
+using DVectZYX = ddc::DiscreteVector<DDimZ, DDimY, DDimX>;
+using DDomZYX = ddc::StridedDiscreteDomain<DDimZ, DDimY, DDimX>;
+
+DElemX constexpr lbound_x(50);
+DVectX constexpr nelems_x(3);
+DVectX constexpr strides_x(10);
+DElemX constexpr sentinel_x(lbound_x + nelems_x * strides_x);
+DElemX constexpr ubound_x(sentinel_x - strides_x);
+
+
+DElemY constexpr lbound_y(4);
+DVectY constexpr nelems_y(12);
+DVectY constexpr strides_y(10);
+DElemY constexpr sentinel_y(lbound_y + nelems_y * strides_y);
+DElemY constexpr ubound_y(sentinel_y - strides_y);
+
+DElemZ constexpr lbound_z(7);
+DVectZ constexpr nelems_z(15);
+DVectZ constexpr strides_z(3);
+
+DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
+DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
+DVectXY constexpr strides_x_y(strides_x, strides_y);
+DElemXY constexpr ubound_x_y(ubound_x, ubound_y);
+
+DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
+DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
+
+} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP)
+
+TEST(StridedDiscreteDomainTest, Constructor)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    EXPECT_EQ(dom_x_y.extents(), nelems_x_y);
+    EXPECT_EQ(dom_x_y.front(), lbound_x_y);
+    EXPECT_EQ(dom_x_y.back(), ubound_x_y);
+    EXPECT_EQ(dom_x_y.size(), nelems_x.value() * nelems_y.value());
+
+    DDomX const dom_x(lbound_x, nelems_x, strides_x);
+    EXPECT_EQ(dom_x.size(), nelems_x);
+    EXPECT_EQ(dom_x.empty(), false);
+    EXPECT_EQ(dom_x[0], lbound_x);
+    EXPECT_EQ(dom_x.front(), lbound_x);
+    EXPECT_EQ(dom_x.back(), ubound_x);
+
+    DDomX const empty_domain(lbound_x, DVectX(0), DVectX(0));
+    EXPECT_EQ(empty_domain.size(), 0);
+    EXPECT_EQ(empty_domain.empty(), true);
+    EXPECT_EQ(empty_domain[0], lbound_x);
+}
+
+TEST(StridedDiscreteDomainTest, ConstructorFromStridedDiscreteDomains)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    DDomZ const dom_z(lbound_z, nelems_z, strides_z);
+    DDomXYZ const dom_x_y_z(dom_z, dom_x_y);
+    EXPECT_EQ(dom_x_y_z.front(), DElemXYZ(lbound_x, lbound_y, lbound_z));
+    EXPECT_EQ(dom_x_y_z.extents(), DVectXYZ(nelems_x, nelems_y, nelems_z));
+}
+
+TEST(StridedDiscreteDomainTest, EmptyDomain)
+{
+    DDomXY const dom_x_y = DDomXY();
+    EXPECT_EQ(dom_x_y.extents(), DVectXY(0, 0));
+    EXPECT_EQ(dom_x_y.size(), 0);
+    EXPECT_TRUE(dom_x_y.empty());
+}
+
+TEST(StridedDiscreteDomainTest, CompareSameDomains)
+{
+    DDomXY const dom_x_y_1(lbound_x_y, nelems_x_y, strides_x_y);
+    DDomXY const dom_x_y_2(dom_x_y_1);
+    EXPECT_TRUE(dom_x_y_1 == dom_x_y_2);
+    EXPECT_TRUE(dom_x_y_1 == DDomYX(dom_x_y_2));
+    EXPECT_FALSE(dom_x_y_1 != dom_x_y_2);
+    EXPECT_FALSE(dom_x_y_1 != DDomYX(dom_x_y_2));
+}
+
+TEST(StridedDiscreteDomainTest, CompareDifferentDomains)
+{
+    DDomXY const dom_x_y_1(DElemXY(0, 1), DVectXY(1, 2), strides_x_y);
+    DDomXY const dom_x_y_2(DElemXY(2, 3), DVectXY(3, 4), strides_x_y);
+    EXPECT_FALSE(dom_x_y_1 == dom_x_y_2);
+    EXPECT_FALSE(dom_x_y_1 == DDomYX(dom_x_y_2));
+    EXPECT_TRUE(dom_x_y_1 != dom_x_y_2);
+    EXPECT_TRUE(dom_x_y_1 != DDomYX(dom_x_y_2));
+}
+
+TEST(StridedDiscreteDomainTest, CompareEmptyDomains)
+{
+    DDomXY const dom_x_y_1(DElemXY(4, 1), DVectXY(0, 0), strides_x_y);
+    DDomXY const dom_x_y_2(DElemXY(3, 9), DVectXY(0, 0), strides_x_y);
+    EXPECT_TRUE(dom_x_y_1.empty());
+    EXPECT_TRUE(dom_x_y_2.empty());
+    EXPECT_TRUE(dom_x_y_1 == dom_x_y_2);
+    EXPECT_FALSE(dom_x_y_1 != dom_x_y_2);
+}
+
+// TEST(StridedDiscreteDomainTest, Subdomain)
+// {
+//     DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+//     ddc::DiscreteElement<DDimX> const lbound_subdomain_x(lbound_x + 1);
+//     ddc::DiscreteVector<DDimX> const npoints_subdomain_x(nelems_x - 2);
+//     DDomX const subdomain_x(lbound_subdomain_x, npoints_subdomain_x);
+//     DDomXY const subdomain = dom_x_y.restrict_with(subdomain_x);
+//     EXPECT_EQ(
+//             subdomain,
+//             DDomXY(ddc::DiscreteElement<DDimX, DDimY>(lbound_subdomain_x, lbound_y),
+//                    ddc::DiscreteVector<DDimX, DDimY>(npoints_subdomain_x, nelems_y)));
+// }
+
+TEST(StridedDiscreteDomainTest, RangeFor)
+{
+    DDomX const dom(lbound_x, nelems_x, strides_x);
+    DElemX ii = lbound_x;
+    for (DElemX const ix : dom) {
+        EXPECT_LE(lbound_x, ix);
+        EXPECT_EQ(ix, ii);
+        EXPECT_LE(ix, ubound_x);
+        ii.uid<DDimX>() += strides_x.value();
+    }
+}
+
+// TEST(StridedDiscreteDomainTest, DiffEmpty)
+// {
+//     DDomX const dom_x = DDomX();
+//     ddc::remove_dims_of_t<DDomX, DDimX> const subdomain1 = ddc::remove_dims_of(dom_x, dom_x);
+//     ddc::remove_dims_of_t<DDomX, DDimX> const subdomain2 = ddc::remove_dims_of<DDimX>(dom_x);
+//     EXPECT_EQ(subdomain1, ddc::DiscreteDomain<>());
+//     EXPECT_EQ(subdomain2, ddc::DiscreteDomain<>());
+// }
+
+// TEST(StridedDiscreteDomainTest, Diff)
+// {
+//     DDomX const dom_x = DDomX();
+//     DDomXY const dom_x_y = DDomXY();
+//     DDomZY const dom_z_y = DDomZY();
+//     ddc::remove_dims_of_t<DDomX, DDimZ, DDimY> const subdomain1
+//             = ddc::remove_dims_of(dom_x_y, dom_z_y);
+//     ddc::remove_dims_of_t<DDomX, DDimZ, DDimY> const subdomain2
+//             = ddc::remove_dims_of<DDimZ, DDimY>(dom_x_y);
+//     EXPECT_EQ(subdomain1, dom_x);
+//     EXPECT_EQ(subdomain2, dom_x);
+// }
+
+// TEST(StridedDiscreteDomainTest, Replace)
+// {
+//     DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+//     DDomZ const dom_z(lbound_z, nelems_z);
+//     DDomXZ const dom_x_z(lbound_x_z, nelems_x_z);
+//     ddc::replace_dim_of_t<DDomXY, DDimY, DDimZ> const subdomain
+//             = ddc::replace_dim_of<DDimY, DDimZ>(dom_x_y, dom_z);
+//     EXPECT_EQ(subdomain, dom_x_z);
+// }
+
+
+TEST(StridedDiscreteDomainTest, TakeFirst)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    EXPECT_EQ(
+            dom_x_y.take_first(DVectXY(1, 4)),
+            DDomXY(dom_x_y.front(), DVectXY(1, 4), strides_x_y));
+}
+
+TEST(StridedDiscreteDomainTest, TakeLast)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    EXPECT_EQ(
+            dom_x_y.take_last(DVectXY(1, 4)),
+            DDomXY(dom_x_y.front() + ddc::prod(dom_x_y.extents() - DVectXY(1, 4), strides_x_y),
+                   DVectXY(1, 4),
+                   strides_x_y));
+}
+
+TEST(StridedDiscreteDomainTest, RemoveFirst)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    EXPECT_EQ(
+            dom_x_y.remove_first(DVectXY(1, 4)),
+            DDomXY(dom_x_y.front() + ddc::prod(DVectXY(1, 4), strides_x_y),
+                   dom_x_y.extents() - DVectXY(1, 4),
+                   strides_x_y));
+}
+
+TEST(StridedDiscreteDomainTest, RemoveLast)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    EXPECT_EQ(
+            dom_x_y.remove_last(DVectXY(1, 4)),
+            DDomXY(dom_x_y.front(), dom_x_y.extents() - DVectXY(1, 4), strides_x_y));
+}
+
+TEST(StridedDiscreteDomainTest, Remove)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    EXPECT_EQ(
+            dom_x_y.remove(DVectXY(1, 4), DVectXY(1, 1)),
+            DDomXY(dom_x_y.front() + prod(DVectXY(1, 4), strides_x_y),
+                   dom_x_y.extents() - DVectXY(2, 5),
+                   strides_x_y));
+}
+
+TEST(StridedDiscreteDomainTest, IsInside)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    EXPECT_TRUE(dom_x_y.is_inside(lbound_x_y));
+    EXPECT_FALSE(dom_x_y.is_inside(lbound_x_y + DVectXY(1, 1)));
+}
+
+TEST(StridedDiscreteDomainTest, DistanceFromFront)
+{
+    DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
+    EXPECT_EQ(dom_x_y.distance_from_front(lbound_x_y), DVectXY(0, 0));
+}
+
+// TEST(StridedDiscreteDomainTest, SliceDomainXTooearly)
+// {
+// #ifndef NDEBUG // The assertion is only checked if NDEBUG isn't defined
+//     DDomX const subdomain_x(lbound_x - 1, nelems_x);
+//     DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+//     // the error message is checked with clang & gcc only
+//     EXPECT_DEATH(
+//             dom_x_y.restrict_with(subdomain_x),
+//             R"rgx([Aa]ssert.*uid<ODDims>\(m_element_begin\).*uid<ODDims>\(odomain\.m_element_begin\))rgx");
+// #else
+//     GTEST_SKIP();
+// #endif
+// }
+
+// TEST(StridedDiscreteDomainTest, SliceDomainXToolate)
+// {
+// #ifndef NDEBUG // The assertion is only checked if NDEBUG isn't defined
+//     DDomX const subdomain_x(lbound_x, nelems_x + 1);
+//     DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+//     // the error message is checked with clang & gcc only
+//     EXPECT_DEATH(
+//             dom_x_y.restrict_with(subdomain_x),
+//             R"rgx([Aa]ssert.*uid<ODDims>\(m_element_end\).*uid<ODDims>\(odomain\.m_element_end\).*)rgx");
+// #else
+//     GTEST_SKIP();
+// #endif
+// }
+
+TEST(StridedDiscreteDomainTest, Transpose3DConstructor)
+{
+    DDomX const dom_x(lbound_x, nelems_x, strides_x);
+    DDomY const dom_y(lbound_y, nelems_y, strides_y);
+    DDomZ const dom_z(lbound_z, nelems_z, strides_z);
+    DDomXYZ const dom_x_y_z(dom_x, dom_y, dom_z);
+    DDomZYX const dom_z_y_x(dom_x_y_z);
+    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.front()), ddc::select<DDimX>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.front()), ddc::select<DDimY>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.front()), ddc::select<DDimZ>(dom_z_y_x.front()));
+    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.back()), ddc::select<DDimX>(dom_z_y_x.back()));
+    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.back()), ddc::select<DDimY>(dom_z_y_x.back()));
+    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.back()), ddc::select<DDimZ>(dom_z_y_x.back()));
+}
+
+// TEST(StridedDiscreteDomainTest, CartesianProduct)
+// {
+//     EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<>, ddc::DiscreteDomain<>>));
+//     EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<DDomX>, DDomX>));
+//     EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<DDomX, DDomY, DDomZ>, DDomXYZ>));
+//     EXPECT_TRUE((std::is_same_v<ddc::cartesian_prod_t<DDomZY, DDomX>, DDomZYX>));
+// }

--- a/tests/strided_discrete_domain.cpp
+++ b/tests/strided_discrete_domain.cpp
@@ -257,11 +257,11 @@ TEST(StridedDiscreteDomainTest, Remove)
                    strides_x_y));
 }
 
-TEST(StridedDiscreteDomainTest, IsInside)
+TEST(StridedDiscreteDomainTest, Contains)
 {
     DDomXY const dom_x_y(lbound_x_y, nelems_x_y, strides_x_y);
-    EXPECT_TRUE(dom_x_y.is_inside(lbound_x_y));
-    EXPECT_FALSE(dom_x_y.is_inside(lbound_x_y + DVectXY(1, 1)));
+    EXPECT_TRUE(dom_x_y.contains(lbound_x_y));
+    EXPECT_FALSE(dom_x_y.contains(lbound_x_y + DVectXY(1, 1)));
 }
 
 TEST(StridedDiscreteDomainTest, DistanceFromFront)

--- a/tests/strided_discrete_domain.cpp
+++ b/tests/strided_discrete_domain.cpp
@@ -305,12 +305,12 @@ TEST(StridedDiscreteDomainTest, Transpose3DConstructor)
     DDomZ const dom_z(lbound_z, nelems_z, strides_z);
     DDomXYZ const dom_x_y_z(dom_x, dom_y, dom_z);
     DDomZYX const dom_z_y_x(dom_x_y_z);
-    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.front()), ddc::select<DDimX>(dom_z_y_x.front()));
-    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.front()), ddc::select<DDimY>(dom_z_y_x.front()));
-    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.front()), ddc::select<DDimZ>(dom_z_y_x.front()));
-    EXPECT_EQ(ddc::select<DDimX>(dom_x_y_z.back()), ddc::select<DDimX>(dom_z_y_x.back()));
-    EXPECT_EQ(ddc::select<DDimY>(dom_x_y_z.back()), ddc::select<DDimY>(dom_z_y_x.back()));
-    EXPECT_EQ(ddc::select<DDimZ>(dom_x_y_z.back()), ddc::select<DDimZ>(dom_z_y_x.back()));
+    EXPECT_EQ(DElemX(dom_x_y_z.front()), DElemX(dom_z_y_x.front()));
+    EXPECT_EQ(DElemY(dom_x_y_z.front()), DElemY(dom_z_y_x.front()));
+    EXPECT_EQ(DElemZ(dom_x_y_z.front()), DElemZ(dom_z_y_x.front()));
+    EXPECT_EQ(DElemX(dom_x_y_z.back()), DElemX(dom_z_y_x.back()));
+    EXPECT_EQ(DElemY(dom_x_y_z.back()), DElemY(dom_z_y_x.back()));
+    EXPECT_EQ(DElemZ(dom_x_y_z.back()), DElemZ(dom_z_y_x.back()));
 }
 
 // TEST(StridedDiscreteDomainTest, CartesianProduct)

--- a/tests/strided_discrete_domain.cpp
+++ b/tests/strided_discrete_domain.cpp
@@ -80,8 +80,8 @@ DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
 DVectXY constexpr strides_x_y(strides_x, strides_y);
 DElemXY constexpr ubound_x_y(ubound_x, ubound_y);
 
-DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
-DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
+// DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
+// DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
 
 } // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP)
 


### PR DESCRIPTION
PoC for #438 

Steps:
- [x] remove internal_mdspan
- [x] implement `Chunk` and `ChunkSpan` with `SupportType` being a customization point
- [x] implement a `StridedDiscreteDomain`
- [x] implement a `StorageDiscreteDomain` 
- [x] update algorithms

Not clear if we should define an equivalent of the slice operator taking a `DiscreteDomain`

cc @science-enthusiast