### PR TITLE
Improve cmake workaround for rocm <6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,9 +171,6 @@ jobs:
           'hip')
             export CC=hipcc
             export CXX=hipcc
-            # We extend the CMAKE_PREFIX_PATH with the content of _ROOT variables to support
-            # rocm 5.7. (likely due to a cmake_minimum_required(VERSION 3.3))
-            export CMAKE_PREFIX_PATH="/opt/rocm:$benchmark_ROOT:$DDC_ROOT:$GTest_ROOT:$Kokkos_ROOT:$KokkosFFT_ROOT:$KokkosKernels_ROOT"
             EXTRA_CMAKE_FLAGS="-DKokkos_ENABLE_HIP=ON -DKokkos_ENABLE_HIP_RELOCATABLE_DEVICE_CODE=ON -DKokkos_ENABLE_ROCTHRUST=OFF -DKokkos_ARCH_AMD_GFX90A=ON"
           ;;
           'cpu-clang')

--- a/cmake/DDCConfig.cmake.in
+++ b/cmake/DDCConfig.cmake.in
@@ -4,29 +4,35 @@
 
 @PACKAGE_INIT@
 
-include(CMakeFindDependencyMacro)
+# Workaround for rocm <6 setting a cmake_minimum_required <3.12.
+# When redefining `find_dependency` we get a better chance
+# to use the NEW policy for CMP0074.
+macro(ddc_find_dependency)
+   include(CMakeFindDependencyMacro)
+   find_dependency(${ARGN})
+endmacro()
 
 set(DDC_BUILD_DOUBLE_PRECISION @DDC_BUILD_DOUBLE_PRECISION@)
 
-find_package(Kokkos 4.4...4.5)
+ddc_find_dependency(Kokkos 4.4...4.5)
 
 if(@DDC_BUILD_KERNELS_FFT@)
-   find_dependency(KokkosFFT 0.2.1...<1)
+   ddc_find_dependency(KokkosFFT 0.2.1...<1)
 endif()
 
 if(@DDC_BUILD_KERNELS_SPLINES@)
-   find_dependency(Ginkgo 1.8.0 EXACT)
+   ddc_find_dependency(Ginkgo 1.8.0 EXACT)
    # DDC installs a FindLAPACKE.cmake file.
    # We choose to rely on it by prepending to CMAKE_MODULE_PATH
-   # only the time of calling find_dependency.
+   # only the time of calling ddc_find_dependency.
    list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR})
-   find_dependency(LAPACKE)
+   ddc_find_dependency(LAPACKE)
    list(POP_FRONT CMAKE_MODULE_PATH)
-   find_dependency(KokkosKernels)
+   ddc_find_dependency(KokkosKernels)
 endif()
 
 if(@DDC_BUILD_PDI_WRAPPER@)
-   find_dependency(PDI COMPONENTS C)
+   ddc_find_dependency(PDI COMPONENTS C)
 endif()
 
 include(${CMAKE_CURRENT_LIST_DIR}/DDCTargets.cmake)


### PR DESCRIPTION
The call to `cmake_minimum_required(VERSION 3.3)` inside `hip-config.cmake` along with `include(CMakeFindDependencyMacro)` redefines the macro `find_dependency` with a behavior following the `OLD` policy `CMP0074`.

The trick in the PR is to redefine the macro each time we plan to use it. It slightly improve the situation.