### PR TITLE
Make `parallel_deepcopy` safer

### DIFF
--- a/examples/heat_equation.cpp
+++ b/examples/heat_equation.cpp
@@ -286,18 +286,26 @@ int main(int argc, char** argv)
 
         //! [boundary conditions]
         // Periodic boundary conditions
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[x_pre_ghost][y_domain],
-                ghosted_last_temp[y_domain][x_domain_end]);
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[y_domain][x_post_ghost],
-                ghosted_last_temp[y_domain][x_domain_begin]);
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[x_domain][y_pre_ghost],
-                ghosted_last_temp[x_domain][y_domain_end]);
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[x_domain][y_post_ghost],
-                ghosted_last_temp[x_domain][y_domain_begin]);
+        for (ddc::DiscreteElement<DDimX> const ix : x_pre_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[ix][y_domain],
+                    ghosted_last_temp[ix + nb_x_points][y_domain]);
+        }
+        for (ddc::DiscreteElement<DDimX> const ix : x_post_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[ix][y_domain],
+                    ghosted_last_temp[ix - nb_x_points][y_domain]);
+        }
+        for (ddc::DiscreteElement<DDimY> const iy : y_pre_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[x_domain][iy],
+                    ghosted_last_temp[x_domain][iy + nb_y_points]);
+        }
+        for (ddc::DiscreteElement<DDimY> const iy : y_post_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[x_domain][iy],
+                    ghosted_last_temp[x_domain][iy - nb_y_points]);
+        }
         //! [boundary conditions]
 
         //! [manipulated views]

--- a/examples/non_uniform_heat_equation.cpp
+++ b/examples/non_uniform_heat_equation.cpp
@@ -311,34 +311,26 @@ int main(int argc, char** argv)
         //! [time iteration]
 
         //! [boundary conditions]
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_pre_ghost, y_domain)],
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(y_domain, x_domain_end)]);
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(y_domain, x_post_ghost)],
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(y_domain, x_domain_begin)]);
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_domain, y_pre_ghost)],
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_domain, y_domain_end)]);
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_domain, y_post_ghost)],
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_domain, y_domain_begin)]);
+        for (ddc::DiscreteElement<DDimX> const ix : x_pre_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[ix][y_domain],
+                    ghosted_last_temp[ix + nb_x_points][y_domain]);
+        }
+        for (ddc::DiscreteElement<DDimX> const ix : x_post_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[ix][y_domain],
+                    ghosted_last_temp[ix - nb_x_points][y_domain]);
+        }
+        for (ddc::DiscreteElement<DDimY> const iy : y_pre_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[x_domain][iy],
+                    ghosted_last_temp[x_domain][iy + nb_y_points]);
+        }
+        for (ddc::DiscreteElement<DDimY> const iy : y_post_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[x_domain][iy],
+                    ghosted_last_temp[x_domain][iy - nb_y_points]);
+        }
         //! [boundary conditions]
 
         //! [manipulated views]

--- a/examples/uniform_heat_equation.cpp
+++ b/examples/uniform_heat_equation.cpp
@@ -231,34 +231,26 @@ int main(int argc, char** argv)
         //! [time iteration]
 
         //! [boundary conditions]
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_pre_ghost, y_domain)],
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(y_domain, x_domain_end)]);
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(y_domain, x_post_ghost)],
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(y_domain, x_domain_begin)]);
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_domain, y_pre_ghost)],
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_domain, y_domain_end)]);
-        ddc::parallel_deepcopy(
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_domain, y_post_ghost)],
-                ghosted_last_temp[ddc::DiscreteDomain<
-                        DDimX,
-                        DDimY>(x_domain, y_domain_begin)]);
+        for (ddc::DiscreteElement<DDimX> const ix : x_pre_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[ix][y_domain],
+                    ghosted_last_temp[ix + nb_x_points][y_domain]);
+        }
+        for (ddc::DiscreteElement<DDimX> const ix : x_post_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[ix][y_domain],
+                    ghosted_last_temp[ix - nb_x_points][y_domain]);
+        }
+        for (ddc::DiscreteElement<DDimY> const iy : y_pre_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[x_domain][iy],
+                    ghosted_last_temp[x_domain][iy + nb_y_points]);
+        }
+        for (ddc::DiscreteElement<DDimY> const iy : y_post_ghost) {
+            ddc::parallel_deepcopy(
+                    ghosted_last_temp[x_domain][iy],
+                    ghosted_last_temp[x_domain][iy - nb_y_points]);
+        }
         //! [boundary conditions]
 
         //! [manipulated views]

--- a/include/ddc/parallel_deepcopy.hpp
+++ b/include/ddc/parallel_deepcopy.hpp
@@ -26,7 +26,8 @@ auto parallel_deepcopy(ChunkDst&& dst, ChunkSrc&& src)
     static_assert(
             std::is_assignable_v<chunk_reference_t<ChunkDst>, chunk_reference_t<ChunkSrc>>,
             "Not assignable");
-    assert(dst.domain().extents() == src.domain().extents());
+    static_assert(std::is_same_v<decltype(dst.domain()), decltype(src.domain())>);
+    assert(dst.domain() == src.domain());
     Kokkos::deep_copy(dst.allocation_kokkos_view(), src.allocation_kokkos_view());
     return dst.span_view();
 }
@@ -45,7 +46,10 @@ auto parallel_deepcopy(ExecSpace const& execution_space, ChunkDst&& dst, ChunkSr
     static_assert(
             std::is_assignable_v<chunk_reference_t<ChunkDst>, chunk_reference_t<ChunkSrc>>,
             "Not assignable");
-    assert(dst.domain().extents() == src.domain().extents());
+    static_assert(
+            std::is_same_v<decltype(dst.domain()), decltype(src.domain())>,
+            "ddc::parallel_deepcopy only supports domains whose dimensions are of the same order");
+    assert(dst.domain() == src.domain());
     Kokkos::deep_copy(execution_space, dst.allocation_kokkos_view(), src.allocation_kokkos_view());
     return dst.span_view();
 }


### PR DESCRIPTION
The PR makes the `parallel_deepcopy` safer with two more checks:
- ensure the dimensions of the supports have the same order (to be able to call `.kokkos_view()`)
- ensure the supports start on the same `DiscreteElement`