### PR TITLE
Remove use_annotated_operator

### DIFF
--- a/include/ddc/ddc_to_kokkos_execution_policy.hpp
+++ b/include/ddc/ddc_to_kokkos_execution_policy.hpp
@@ -20,8 +20,7 @@ auto ddc_to_kokkos_execution_policy(
         ExecSpace const& execution_space,
         DiscreteDomain<DDims...> const& domain)
 {
-    using work_tag = std::
-            conditional_t<need_annotated_operator<ExecSpace>(), use_annotated_operator, void>;
+    using work_tag = void;
     using index_type = Kokkos::IndexType<DiscreteElementType>;
     if constexpr (sizeof...(DDims) == 0) {
         return Kokkos::RangePolicy<ExecSpace, work_tag, index_type>(execution_space, 0, 1);

--- a/include/ddc/detail/kokkos.hpp
+++ b/include/ddc/detail/kokkos.hpp
@@ -192,20 +192,4 @@ KOKKOS_FUNCTION auto build_mdspan(
     DDC_IF_NVCC_THEN_POP
 }
 
-struct use_annotated_operator
-{
-};
-
-template <class ExecSpace>
-constexpr bool need_annotated_operator() noexcept
-{
-#if defined(KOKKOS_ENABLE_CUDA)
-    return std::is_same_v<ExecSpace, Kokkos::Cuda>;
-#elif defined(KOKKOS_ENABLE_HIP)
-    return std::is_same_v<ExecSpace, Kokkos::HIP>;
-#else
-    return false;
-#endif
-}
-
 } // namespace ddc::detail

--- a/include/ddc/parallel_for_each.hpp
+++ b/include/ddc/parallel_for_each.hpp
@@ -32,27 +32,13 @@ public:
     explicit ForEachKokkosLambdaAdapter(F const& f) : m_f(f) {}
 
     template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N == 0), bool> = true>
-    void operator()([[maybe_unused]] index_type<void> unused_id) const
-    {
-        m_f(DiscreteElement<>());
-    }
-
-    template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N == 0), bool> = true>
-    KOKKOS_FUNCTION void operator()(
-            use_annotated_operator,
-            [[maybe_unused]] index_type<void> unused_id) const
+    KOKKOS_FUNCTION void operator()([[maybe_unused]] index_type<void> unused_id) const
     {
         m_f(DiscreteElement<>());
     }
 
     template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N > 0), bool> = true>
-    void operator()(index_type<DDims>... ids) const
-    {
-        m_f(DiscreteElement<DDims...>(ids...));
-    }
-
-    template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N > 0), bool> = true>
-    KOKKOS_FUNCTION void operator()(use_annotated_operator, index_type<DDims>... ids) const
+    KOKKOS_FUNCTION void operator()(index_type<DDims>... ids) const
     {
         m_f(DiscreteElement<DDims...>(ids...));
     }

--- a/include/ddc/parallel_transform_reduce.hpp
+++ b/include/ddc/parallel_transform_reduce.hpp
@@ -104,15 +104,7 @@ public:
     }
 
     template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N == 0), bool> = true>
-    void operator()([[maybe_unused]] index_type<void> unused_id, typename Reducer::value_type& a)
-            const
-    {
-        a = reducer(a, functor(DiscreteElement<>()));
-    }
-
-    template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N == 0), bool> = true>
     KOKKOS_FUNCTION void operator()(
-            use_annotated_operator,
             [[maybe_unused]] index_type<void> unused_id,
             typename Reducer::value_type& a) const
 
@@ -121,17 +113,7 @@ public:
     }
 
     template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N > 0), bool> = true>
-    void operator()(index_type<DDims>... ids, typename Reducer::value_type& a) const
-    {
-        a = reducer(a, functor(DiscreteElement<DDims...>(ids...)));
-    }
-
-
-    template <std::size_t N = sizeof...(DDims), std::enable_if_t<(N > 0), bool> = true>
-    KOKKOS_FUNCTION void operator()(
-            use_annotated_operator,
-            index_type<DDims>... ids,
-            typename Reducer::value_type& a) const
+    KOKKOS_FUNCTION void operator()(index_type<DDims>... ids, typename Reducer::value_type& a) const
     {
         a = reducer(a, functor(DiscreteElement<DDims...>(ids...)));
     }


### PR DESCRIPTION
Reasons:
- not used
- std algorithms of Kokkos always annotate KOKKOS_FUNCTION the functors