### PR TITLE
Add an automatic spell checker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,17 @@ jobs:
       if: always()
       uses: fsfe/reuse-action@v5
 
+  spelling:
+    name: Spell Check with Typos
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Actions Repository
+      uses: actions/checkout@v4
+    - name: Spell Check Repo
+      uses: crate-ci/typos@v1.29.4
+      with:
+        files: ./AUTHORS ./benchmarks/ ./cmake/ ./CMakeLists.txt ./docs/ ./examples/ ./include/ ./README.md ./tests/
+
   cmake-format:
     runs-on: ubuntu-latest
     steps:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,9 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+[default.extend-words]
+# Don't correct these word (parts)
+benchs = "benchs"
+iy = "iy"
+ND = "ND"

--- a/.typos.toml
+++ b/.typos.toml
@@ -4,6 +4,5 @@
 
 [default.extend-words]
 # Don't correct these word (parts)
-benchs = "benchs"
 iy = "iy"
 ND = "ND"

--- a/AUTHORS
+++ b/AUTHORS
@@ -15,7 +15,7 @@ Julien Bigot - CEA (julien.bigot@cea.fr)
 * Co-maintainer
 * Initial designer and first development steps
 * Co-developer
-* Participation to DDC-based redisign of splines
+* Participation to DDC-based redesign of splines
 
 Emily Bourne - CEA (emily.bourne@cea.fr)
 * Work on splines and linear algebra

--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -94,7 +94,7 @@ void characteristics_advection_unitary(benchmark::State& state)
     std::size_t freeMem = 0;
     std::size_t totalMem = 0;
     cudaMemGetInfo(&freeMem, &totalMem);
-    // cudaMemGetInfo gives GPU total memory occupation, we consider that other users of the GPU have constant occupancy and substract it.
+    // cudaMemGetInfo gives GPU total memory occupation, we consider that other users of the GPU have constant occupancy and subtract it.
     std::size_t const initUsedMem = totalMem - freeMem;
 #else
     std::size_t const initUsedMem = 0;
@@ -232,7 +232,7 @@ void characteristics_advection(benchmark::State& state)
     long const dev = 1;
     long const uniform = 0;
     long const non_uniform = 1;
-    // Preallocate 12 unitary benchs for each combination of cpu/gpu execution space, uniform/non-uniform and spline degree we may want to benchmark (those are determined at compile-time, that's why we need to build explicitely 12 variants of the bench even if we call only one of them)
+    // Preallocate 12 unitary benchs for each combination of cpu/gpu execution space, uniform/non-uniform and spline degree we may want to benchmark (those are determined at compile-time, that's why we need to build explicitly 12 variants of the bench even if we call only one of them)
     std::map<std::array<long, 3>, std::function<void(benchmark::State&)>> benchs;
     benchs[std::array {host, uniform, 3L}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, false, 3>;

--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -232,35 +232,35 @@ void characteristics_advection(benchmark::State& state)
     long const dev = 1;
     long const uniform = 0;
     long const non_uniform = 1;
-    // Preallocate 12 unitary benchs for each combination of cpu/gpu execution space, uniform/non-uniform and spline degree we may want to benchmark (those are determined at compile-time, that's why we need to build explicitly 12 variants of the bench even if we call only one of them)
-    std::map<std::array<long, 3>, std::function<void(benchmark::State&)>> benchs;
-    benchs[std::array {host, uniform, 3L}]
+    // Preallocate 12 unitary benchmarks for each combination of cpu/gpu execution space, uniform/non-uniform and spline degree we may want to benchmark (those are determined at compile-time, that's why we need to build explicitly 12 variants of the bench even if we call only one of them)
+    std::map<std::array<long, 3>, std::function<void(benchmark::State&)>> benchmarks;
+    benchmarks[std::array {host, uniform, 3L}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, false, 3>;
-    benchs[std::array {host, uniform, 4L}]
+    benchmarks[std::array {host, uniform, 4L}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, false, 4>;
-    benchs[std::array {host, uniform, 5L}]
+    benchmarks[std::array {host, uniform, 5L}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, false, 5>;
-    benchs[std::array {host, non_uniform, 3L}]
+    benchmarks[std::array {host, non_uniform, 3L}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, true, 3>;
-    benchs[std::array {host, non_uniform, 4L}]
+    benchmarks[std::array {host, non_uniform, 4L}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, true, 4>;
-    benchs[std::array {host, non_uniform, 5L}]
+    benchmarks[std::array {host, non_uniform, 5L}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, true, 5>;
-    benchs[std::array {dev, uniform, 3L}]
+    benchmarks[std::array {dev, uniform, 3L}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, false, 3>;
-    benchs[std::array {dev, uniform, 4L}]
+    benchmarks[std::array {dev, uniform, 4L}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, false, 4>;
-    benchs[std::array {dev, uniform, 5L}]
+    benchmarks[std::array {dev, uniform, 5L}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, false, 5>;
-    benchs[std::array {dev, non_uniform, 3L}]
+    benchmarks[std::array {dev, non_uniform, 3L}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, true, 3>;
-    benchs[std::array {dev, non_uniform, 4L}]
+    benchmarks[std::array {dev, non_uniform, 4L}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, true, 4>;
-    benchs[std::array {dev, non_uniform, 5L}]
+    benchmarks[std::array {dev, non_uniform, 5L}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, true, 5>;
 
     // Run the desired bench
-    benchs.at(std::array {state.range(0), state.range(1), state.range(2)})(state);
+    benchmarks.at(std::array {state.range(0), state.range(1), state.range(2)})(state);
 }
 
 } // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(SPLINES_CPP)

--- a/docs/first_steps.md
+++ b/docs/first_steps.md
@@ -124,7 +124,7 @@ Then we initialize the domain along this dimension just like we did with the `X`
 
 #### Time dimension
 
-Then we handle the domains for the simulated time dimension. We first give the simulated time at which to stard and end the simulation.
+Then we handle the domains for the simulated time dimension. We first give the simulated time at which to start and end the simulation.
 
 \snippet{trimleft} uniform_heat_equation.cpp main-start-t-parameters
 
@@ -151,7 +151,7 @@ Note that the `DeviceAllocator` is responsible for allocating memory on the defa
 
 ## Initial conditions
 
-To set the initial conditions, the `ghosted_intial_temp` is created and acts as a pointer to the chunk. The const qualifier makes it clear that ghosted_initial_temp always references the same chunk, `ghosted_last_temp` in this case.
+To set the initial conditions, the `ghosted_initial_temp` is created and acts as a pointer to the chunk. The const qualifier makes it clear that ghosted_initial_temp always references the same chunk, `ghosted_last_temp` in this case.
 
 \snippet{trimleft} uniform_heat_equation.cpp initial-chunkspan
 

--- a/docs/going_further.md
+++ b/docs/going_further.md
@@ -84,7 +84,7 @@ And we use them to build the 4 domains in the same way as for the X dimension.
 
 #### Time dimension
 
-Then we handle the domains for the simulated time dimension. We first give the simulated time at which to stard and end the simulation.
+Then we handle the domains for the simulated time dimension. We first give the simulated time at which to start and end the simulation.
 
 \snippet{trimleft} non_uniform_heat_equation.cpp main-start-t-parameters
 

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -256,7 +256,7 @@ int main(int argc, char** argv)
                     feet_coords(e) = ddc::coordinate(ddc::DiscreteElement<DDimX>(e))
                                      - ddc::Coordinate<X>(vx * ddc::step<DDimT>());
                 });
-        // Interpolate the values at feets on the grid
+        // Interpolate the values at feet on the grid
         spline_builder(coef, last_density.span_cview());
         spline_evaluator(next_density, feet_coords.span_cview(), coef.span_cview());
         //! [numerical scheme]

--- a/include/ddc/detail/type_seq.hpp
+++ b/include/ddc/detail/type_seq.hpp
@@ -105,7 +105,7 @@ struct TypeSeqMerge<TypeSeq<TagsA...>, TypeSeq<HeadTagsB, TailTagsB...>, TypeSeq
 };
 
 /// A is replaced by element of C at same position than the first element of B equal to A.
-/// Remark : It may not be usefull in its own, it is an helper for TypeSeqReplace
+/// Remark : It may not be useful in its own, it is an helper for TypeSeqReplace
 template <class TagA, class TagSeqB, class TagSeqC>
 struct TypeSeqReplaceSingle;
 

--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -423,7 +423,7 @@ struct cartesian_prod<>
 template <typename... DDoms>
 using cartesian_prod_t = typename cartesian_prod<DDoms...>::type;
 
-// Computes the substraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
+// Computes the subtraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
 template <class... DDimsA, class... DDimsB>
 KOKKOS_FUNCTION constexpr auto remove_dims_of(
         DiscreteDomain<DDimsA...> const& DDom_a,
@@ -455,7 +455,7 @@ using remove_dims_of_t = decltype(remove_dims_of<DDims...>(std::declval<DDom>())
 
 namespace detail {
 
-// Checks if dimension of DDom_a is DDim1. If not, returns restriction to DDim2 of DDom_b. May not be usefull in its own, it helps for replace_dim_of
+// Checks if dimension of DDom_a is DDim1. If not, returns restriction to DDim2 of DDom_b. May not be useful in its own, it helps for replace_dim_of
 template <typename DDim1, typename DDim2, typename DDimA, typename... DDimsB>
 KOKKOS_FUNCTION constexpr std::conditional_t<
         std::is_same_v<DDimA, DDim1>,

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -213,14 +213,14 @@ public:
         /** @brief Evaluates non-zero B-spline derivatives at a given coordinate
          *
          * The derivatives are computed for every B-spline with support at the given coordinate x. There are only (degree+1)
-         * B-splines which are non-zero at any given point. It is these B-splines which are derived.
+         * B-splines which are non-zero at any given point. It is these B-splines which are differentiated.
          * A spline approximation of a derivative at coordinate x is a linear
          * combination of those B-spline derivatives weighted with the spline coefficients of the spline-transformed
          * initial discrete function.
          *
          * @param[out] derivs The derivatives of the B-splines evaluated at coordinate x. It has to be a 1D mdspan with (degree+1) elements.
          * @param[in] x The coordinate where B-spline derivatives are evaluated. It has to be in the range of break points coordinates.
-         * @return The index of the first B-spline which is derived.
+         * @return The index of the first B-spline which is differentiated.
          */
         KOKKOS_INLINE_FUNCTION discrete_element_type
         eval_deriv(DSpan1D derivs, ddc::Coordinate<CDim> const& x) const;
@@ -228,7 +228,7 @@ public:
         /** @brief Evaluates non-zero B-spline values and \f$n\f$ derivatives at a given coordinate
          *
          * The values and derivatives are computed for every B-spline with support at the given coordinate x. There are only (degree+1)
-         * B-splines which are non-zero at any given point. It is these B-splines which are evaluated and derived.
+         * B-splines which are non-zero at any given point. It is these B-splines which are evaluated and differentiated.
          * A spline approximation of a derivative at coordinate x is a linear
          * combination of those B-spline derivatives weighted with spline coefficients of the spline-transformed
          * initial discrete function.

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -213,14 +213,14 @@ public:
         /** @brief Evaluates non-zero B-spline derivatives at a given coordinate
          *
          * The derivatives are computed for every B-spline with support at the given coordinate x. There are only (degree+1)
-         * B-splines which are non-zero at any given point. It is these B-splines which are derivated.
+         * B-splines which are non-zero at any given point. It is these B-splines which are derived.
          * A spline approximation of a derivative at coordinate x is a linear
          * combination of those B-spline derivatives weighted with the spline coefficients of the spline-transformed
          * initial discrete function.
          *
          * @param[out] derivs The derivatives of the B-splines evaluated at coordinate x. It has to be a 1D mdspan with (degree+1) elements.
          * @param[in] x The coordinate where B-spline derivatives are evaluated. It has to be in the range of break points coordinates.
-         * @return The index of the first B-spline which is derivated.
+         * @return The index of the first B-spline which is derived.
          */
         KOKKOS_INLINE_FUNCTION discrete_element_type
         eval_deriv(DSpan1D derivs, ddc::Coordinate<CDim> const& x) const;
@@ -228,7 +228,7 @@ public:
         /** @brief Evaluates non-zero B-spline values and \f$n\f$ derivatives at a given coordinate
          *
          * The values and derivatives are computed for every B-spline with support at the given coordinate x. There are only (degree+1)
-         * B-splines which are non-zero at any given point. It is these B-splines which are evaluated and derivated.
+         * B-splines which are non-zero at any given point. It is these B-splines which are evaluated and derived.
          * A spline approximation of a derivative at coordinate x is a linear
          * combination of those B-spline derivatives weighted with spline coefficients of the spline-transformed
          * initial discrete function.

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -204,7 +204,7 @@ public:
         /** @brief Evaluates non-zero B-spline derivatives at a given coordinate
          *
          * The derivatives are computed for every B-spline with support at the given coordinate x. There are only (degree+1)
-         * B-splines which are non-zero at any given point. It is these B-splines which are derived.
+         * B-splines which are non-zero at any given point. It is these B-splines which are differentiated.
          * A spline approximation of a derivative at coordinate x is a linear
          * combination of those B-spline derivatives weighted with the spline coefficients of the spline-transformed
          * initial discrete function.
@@ -219,7 +219,7 @@ public:
         /** @brief Evaluates non-zero B-spline values and \f$n\f$ derivatives at a given coordinate
          *
          * The values and derivatives are computed for every B-spline with support at the given coordinate x. There are only (degree+1)
-         * B-splines which are non-zero at any given point. It is these B-splines which are evaluated and derived.
+         * B-splines which are non-zero at any given point. It is these B-splines which are evaluated and differentiated.
          * A spline approximation of a derivative at coordinate x is a linear
          * combination of those B-spline derivatives weighted with spline coefficients of the spline-transformed
          * initial discrete function.

--- a/include/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_uniform.hpp
@@ -204,7 +204,7 @@ public:
         /** @brief Evaluates non-zero B-spline derivatives at a given coordinate
          *
          * The derivatives are computed for every B-spline with support at the given coordinate x. There are only (degree+1)
-         * B-splines which are non-zero at any given point. It is these B-splines which are derivated.
+         * B-splines which are non-zero at any given point. It is these B-splines which are derived.
          * A spline approximation of a derivative at coordinate x is a linear
          * combination of those B-spline derivatives weighted with the spline coefficients of the spline-transformed
          * initial discrete function.
@@ -219,7 +219,7 @@ public:
         /** @brief Evaluates non-zero B-spline values and \f$n\f$ derivatives at a given coordinate
          *
          * The values and derivatives are computed for every B-spline with support at the given coordinate x. There are only (degree+1)
-         * B-splines which are non-zero at any given point. It is these B-splines which are evaluated and derivated.
+         * B-splines which are non-zero at any given point. It is these B-splines which are evaluated and derived.
          * A spline approximation of a derivative at coordinate x is a linear
          * combination of those B-spline derivatives weighted with spline coefficients of the spline-transformed
          * initial discrete function.

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -400,7 +400,7 @@ public:
      *
      * This function solves matrix equation A^t*Q=integral_bsplines. In case of HERMITE boundary conditions,
      * integral_bsplines contains the integral coefficients at the boundaries, and Q thus has to
-     * be splitted in three parts (quadrature coefficients for the derivatives at lower boundary,
+     * be split in three parts (quadrature coefficients for the derivatives at lower boundary,
      * for the values inside the domain and for the derivatives at upper boundary).
      *
      * A discrete function f can then be integrated using sum_j Q_j*f_j for j in interpolation_domain.

--- a/include/ddc/kernels/splines/splines_linear_problem.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem.hpp
@@ -57,8 +57,8 @@ public:
     /**
      * @brief Set an element of the matrix at indexes i, j. It must not be called after `setup_solver`.
      *
-     * @param i The row index of the setted element.
-     * @param j The column index of the setted element.
+     * @param i The row index of the set element.
+     * @param j The column index of the set element.
      * @param aij The value to set in the element of the matrix.
      */
     virtual void set_element(std::size_t i, std::size_t j, double aij) = 0;

--- a/include/ddc/kernels/splines/splines_linear_problem_2x2_blocks.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_2x2_blocks.hpp
@@ -186,7 +186,7 @@ public:
      *
      * [SHOULD BE PRIVATE (GPU programming limitation)]
      *
-     * Runs on a single thread to garantee ordering.
+     * Runs on a single thread to guarantee ordering.
      *
      * @param[in] dense_matrix The dense storage matrix whose non-zeros are extracted to fill the COO matrix.
      * @param[in] tol The tolerancy applied to filter the non-zeros.

--- a/include/ddc/kernels/splines/splines_linear_problem_maker.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_maker.hpp
@@ -48,7 +48,7 @@ public:
      * @param n The size of one of the dimensions of the square matrix.
      * @param kl The number of subdiagonals.
      * @param ku The number of superdiagonals.
-     * @param pds A boolean indicating if the matrix is positive-definite symetric or not.
+     * @param pds A boolean indicating if the matrix is positive-definite symmetric or not.
      *
      * @return The SplinesLinearProblem instance.
      */
@@ -82,7 +82,7 @@ public:
      * @param n The size of one of the dimensions of the whole square matrix.
      * @param kl The number of subdiagonals in the band block.
      * @param ku The number of superdiagonals in the band block.
-     * @param pds A boolean indicating if the band block is positive-definite symetric or not.
+     * @param pds A boolean indicating if the band block is positive-definite symmetric or not.
      * @param bottom_right_size The size of one of the dimensions of the bottom-right square block.
      * @param top_left_size The size of one of the dimensions of the top-left square block.
      *
@@ -121,7 +121,7 @@ public:
      * @param n The size of one of the dimensions of the whole square matrix.
      * @param kl The number of subdiagonals in the band block.
      * @param ku The number of superdiagonals in the band block.
-     * @param pds A boolean indicating if the band block is positive-definite symetric or not.
+     * @param pds A boolean indicating if the band block is positive-definite symmetric or not.
      *
      * @return The SplinesLinearProblem instance.
      */

--- a/include/ddc/kernels/splines/splines_linear_problem_sparse.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_sparse.hpp
@@ -48,7 +48,7 @@ auto to_gko_dense(std::shared_ptr<const gko::Executor> const& gko_exec, KokkosVi
 /**
  * @brief Return the default value of the parameter cols_per_chunk for a given Kokkos::ExecutionSpace.
  *
- * The values are hardware-specific (but they can be overriden in the constructor of SplinesLinearProblemSparse).
+ * The values are hardware-specific (but they can be overridden in the constructor of SplinesLinearProblemSparse).
  * They have been tuned on the basis of ddc/benchmarks/splines.cpp results on 4xIntel 6230 + Nvidia V100.
  *
  * @tparam ExecSpace The Kokkos::ExecutionSpace type.
@@ -83,7 +83,7 @@ std::size_t default_cols_per_chunk() noexcept
 /**
  * @brief Return the default value of the parameter preconditioner_max_block_size for a given Kokkos::ExecutionSpace.
  *
- * The values are hardware-specific (but they can be overriden in the constructor of SplinesLinearProblemSparse).
+ * The values are hardware-specific (but they can be overridden in the constructor of SplinesLinearProblemSparse).
  * They have been tuned on the basis of ddc/benchmarks/splines.cpp results on 4xIntel 6230 + Nvidia V100.
  *
  * @tparam ExecSpace The Kokkos::ExecutionSpace type.

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -223,7 +223,7 @@ void Batched2dSplineTest()
             ddc::SplineSolver::GINKGO,
             DDims...> const spline_builder(dom_vals);
 
-    // Compute usefull domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
+    // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI1, DDimI2> const dom_interpolation
             = spline_builder.interpolation_domain();
     auto const dom_spline = spline_builder.batched_spline_domain();

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -210,7 +210,7 @@ void BatchedSplineTest()
 #endif
             DDims...> const spline_builder(dom_vals);
 
-    // Compute usefull domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
+    // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI> const dom_interpolation = spline_builder.interpolation_domain();
     auto const dom_batch = spline_builder.batch_domain();
     auto const dom_spline = spline_builder.batched_spline_domain();

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -194,7 +194,7 @@ void ExtrapolationRuleSplineTest()
             ddc::SplineSolver::GINKGO,
             DDims...> const spline_builder(dom_vals);
 
-    // Compute usefull domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
+    // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI1, DDimI2> const dom_interpolation
             = spline_builder.interpolation_domain();
     auto const dom_spline = spline_builder.batched_spline_domain();

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -134,7 +134,7 @@ void PeriodicitySplineBuilderTest()
             ddc::SplineSolver::GINKGO,
             DDim<X>> const spline_builder(dom_vals);
 
-    // Compute usefull domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
+    // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<BSplines<X>> const dom_bsplines = spline_builder.spline_domain();
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions


### PR DESCRIPTION
- exclude "iy" that was fixed by "it"
- exclude "ND" related to words like "ViewND", that was fixed by "AND"
- rename "benchs" by "benchmarks"
- replace "derived" by "differentiated"
