### PR TITLE
Test macOS CI

### DIFF
--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -1,0 +1,177 @@
+# Copyright (C) The DDC development team, see COPYRIGHT.md file
+#
+# SPDX-License-Identifier: MIT
+
+name: Tests on macOS
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # every day at 1am
+  pull_request:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == github.ref_protected && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  id_repo:
+    runs-on: macos-latest
+    steps:
+    - name: Identify repository
+      id: identify_repo
+      run: |
+        echo "in_base_repo=${{ (github.event_name == 'push' && github.repository == 'CExA-project/ddc') || github.event.pull_request.head.repo.full_name == 'CExA-project/ddc' }}" >> "$GITHUB_OUTPUT"
+    outputs: { in_base_repo: '${{ steps.identify_repo.outputs.in_base_repo }}' }
+
+  test-macos:
+    if: github.ref_name != 'main'
+    strategy:
+      fail-fast: false
+      matrix:
+        backend:
+        - name: 'cpu'
+          c_compiler: 'clang'
+          cxx_compiler: 'clang++'
+          ddc_extra_cxx_flags: '-Wextra-semi -Wextra-semi-stmt -Wold-style-cast'
+          kokkos_extra_cmake_flags: ''
+        cxx_version: ['17', '20', '23']
+        cmake_build_type: ['Debug', 'Release']
+    runs-on: macos-latest
+    needs: [id_repo]
+    steps:
+    - name: Checkout built branch
+      uses: actions/checkout@v4
+      with: { submodules: true }
+    - name: Install fftw
+      run: brew install fftw
+    - name: Install lapack
+      run: brew install lapack
+    - name: Test
+      id: test
+      run: |
+        git config --global --add safe.directory '*'
+
+        export benchmark_ROOT=$PWD/opt/benchmark
+        export DDC_ROOT=$PWD/opt/ddc
+        export Ginkgo_ROOT=$PWD/opt/ginkgo
+        export GTest_ROOT=$PWD/opt/gtest
+        export Kokkos_ROOT=$PWD/opt/kokkos
+        export KokkosFFT_ROOT=$PWD/opt/kokkos-fft
+        export KokkosKernels_ROOT=$PWD/opt/kokkos-kernels
+
+        export PKG_CONFIG_PATH="/opt/homebrew/opt/lapack/lib/pkgconfig"
+        export LAPACKE_DIR="/opt/homebrew/opt/lapack"
+
+        export CMAKE_BUILD_PARALLEL_LEVEL=4
+        export CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}}
+
+        export CC=${{matrix.backend.c_compiler}}
+        export CXX=${{matrix.backend.cxx_compiler}}
+
+        git clone --branch v1.8.0 --depth 1 https://github.com/ginkgo-project/ginkgo.git
+        cmake \
+          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
+          -DGINKGO_BUILD_BENCHMARKS=OFF \
+          -DGINKGO_BUILD_EXAMPLES=OFF \
+          -DGINKGO_BUILD_MPI=OFF \
+          -DGINKGO_BUILD_REFERENCE=ON \
+          -DGINKGO_BUILD_TESTS=OFF \
+          -B build \
+          -S ./ginkgo
+        cmake --build build
+        cmake --install build --prefix $Ginkgo_ROOT
+        rm -rf build
+
+        cmake \
+          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
+          -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
+          -DBENCHMARK_ENABLE_TESTING=OFF \
+          -DBENCHMARK_INSTALL_DOCS=OFF \
+          -DBENCHMARK_USE_BUNDLED_GTEST=OFF \
+          -B build \
+          -S ./vendor/benchmark
+        cmake --build build
+        cmake --install build --prefix $benchmark_ROOT
+        rm -rf build
+
+        cmake \
+          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
+          -B build \
+          -S ./vendor/googletest
+        cmake --build build
+        cmake --install build --prefix $GTest_ROOT
+        rm -rf build
+
+        cmake \
+          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
+          -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
+          -DKokkos_ENABLE_DEPRECATION_WARNINGS=OFF \
+          -DKokkos_ENABLE_SERIAL=ON \
+          ${{matrix.backend.kokkos_extra_cmake_flags}} \
+          -B build \
+          -S ./vendor/kokkos
+        cmake --build build
+        cmake --install build --prefix $Kokkos_ROOT
+        rm -rf build
+
+        cmake \
+          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
+          -DKokkosFFT_ENABLE_HOST_AND_DEVICE=ON \
+          -B build \
+          -S ./vendor/kokkos-fft
+        cmake --build build
+        cmake --install build --prefix $KokkosFFT_ROOT
+        rm -rf build
+
+        cmake \
+          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
+          -DKokkosKernels_ADD_DEFAULT_ETI=OFF \
+          -DKokkosKernels_ENABLE_ALL_COMPONENTS=OFF \
+          -DKokkosKernels_ENABLE_COMPONENT_BLAS=ON \
+          -DKokkosKernels_ENABLE_COMPONENT_BATCHED=ON \
+          -DKokkosKernels_ENABLE_COMPONENT_LAPACK=OFF \
+          -DKokkosKernels_ENABLE_TPL_BLAS=OFF \
+          -DKokkosKernels_ENABLE_TPL_CUSOLVER=OFF \
+          -DKokkosKernels_ENABLE_TPL_LAPACK=OFF \
+          -B build \
+          -S ./vendor/kokkos-kernels
+        cmake --build build
+        cmake --install build --prefix $KokkosKernels_ROOT
+        rm -rf build
+
+        cmake \
+          -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-sign-compare -pedantic-errors ${{matrix.backend.ddc_extra_cxx_flags}}" \
+          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
+          -DDDC_BUILD_BENCHMARKS=ON \
+          -DDDC_benchmark_DEPENDENCY_POLICY=INSTALLED \
+          -DDDC_GTest_DEPENDENCY_POLICY=INSTALLED \
+          -DDDC_Kokkos_DEPENDENCY_POLICY=INSTALLED \
+          -DDDC_KokkosFFT_DEPENDENCY_POLICY=INSTALLED \
+          -DDDC_BUILD_PDI_WRAPPER=OFF \
+          -DBLA_PREFER_PKGCONFIG=ON \
+          -B build
+
+        cmake --build build
+        ctest --test-dir build --output-on-failure --timeout 10 --output-junit tests.xml
+        ./build/examples/characteristics_advection
+        ./build/examples/game_of_life
+        ./build/examples/heat_equation_spectral
+        ./build/examples/heat_equation
+        ./build/examples/non_uniform_heat_equation
+        ./build/examples/uniform_heat_equation
+
+        cmake --install build --prefix $DDC_ROOT
+        rm -rf build
+
+        # cmake \
+        #   -B build \
+        #   -S ./install_test
+        # cmake --build build
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v5
+      if: ( success() || failure() ) # always run even if the previous step fails
+      with:
+        report_paths: '/home/runner/work/ddc/ddc/tests.xml'

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -41,6 +41,20 @@ jobs:
         cmake_build_type: ['Debug', 'Release']
     runs-on: macos-latest
     needs: [id_repo]
+    env:
+      benchmark_ROOT: ${{github.workspace}}/opt/benchmark
+      DDC_ROOT: ${{github.workspace}}/opt/ddc
+      Ginkgo_ROOT: ${{github.workspace}}/opt/ginkgo
+      GTest_ROOT: ${{github.workspace}}/opt/gtest
+      Kokkos_ROOT: ${{github.workspace}}/opt/kokkos
+      KokkosFFT_ROOT: ${{github.workspace}}/opt/kokkos-fft
+      KokkosKernels_ROOT: ${{github.workspace}}/opt/kokkos-kernels
+      CMAKE_BUILD_PARALLEL_LEVEL: 4
+      PKG_CONFIG_PATH: /opt/homebrew/opt/lapack/lib/pkgconfig
+      LAPACKE_DIR: /opt/homebrew/opt/lapack
+      CC: ${{matrix.backend.c_compiler}}
+      CXX: ${{matrix.backend.cxx_compiler}}
+      CMAKE_BUILD_TYPE: ${{matrix.cmake_build_type}}
     steps:
     - name: Checkout built branch
       uses: actions/checkout@v4
@@ -49,28 +63,9 @@ jobs:
       run: brew install fftw
     - name: Install lapack
       run: brew install lapack
-    - name: Test
-      id: test
+    - run: git config --global --add safe.directory '*'
+    - name: Install Ginkgo
       run: |
-        git config --global --add safe.directory '*'
-
-        export benchmark_ROOT=$PWD/opt/benchmark
-        export DDC_ROOT=$PWD/opt/ddc
-        export Ginkgo_ROOT=$PWD/opt/ginkgo
-        export GTest_ROOT=$PWD/opt/gtest
-        export Kokkos_ROOT=$PWD/opt/kokkos
-        export KokkosFFT_ROOT=$PWD/opt/kokkos-fft
-        export KokkosKernels_ROOT=$PWD/opt/kokkos-kernels
-
-        export PKG_CONFIG_PATH="/opt/homebrew/opt/lapack/lib/pkgconfig"
-        export LAPACKE_DIR="/opt/homebrew/opt/lapack"
-
-        export CMAKE_BUILD_PARALLEL_LEVEL=4
-        export CMAKE_BUILD_TYPE=${{matrix.cmake_build_type}}
-
-        export CC=${{matrix.backend.c_compiler}}
-        export CXX=${{matrix.backend.cxx_compiler}}
-
         git clone --branch v1.8.0 --depth 1 https://github.com/ginkgo-project/ginkgo.git
         cmake \
           -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
@@ -84,7 +79,8 @@ jobs:
         cmake --build build
         cmake --install build --prefix $Ginkgo_ROOT
         rm -rf build
-
+    - name: Install Google benchmark
+      run: |
         cmake \
           -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
           -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
@@ -96,7 +92,8 @@ jobs:
         cmake --build build
         cmake --install build --prefix $benchmark_ROOT
         rm -rf build
-
+    - name: Install Google Test
+      run: |
         cmake \
           -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
           -B build \
@@ -104,7 +101,8 @@ jobs:
         cmake --build build
         cmake --install build --prefix $GTest_ROOT
         rm -rf build
-
+    - name: Install Kokkos
+      run: |
         cmake \
           -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
           -DKokkos_ENABLE_DEPRECATED_CODE_4=OFF \
@@ -116,7 +114,8 @@ jobs:
         cmake --build build
         cmake --install build --prefix $Kokkos_ROOT
         rm -rf build
-
+    - name: Install Kokkos-fft
+      run: |
         cmake \
           -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
           -DKokkosFFT_ENABLE_HOST_AND_DEVICE=ON \
@@ -125,7 +124,8 @@ jobs:
         cmake --build build
         cmake --install build --prefix $KokkosFFT_ROOT
         rm -rf build
-
+    - name: Install Kokkos Kernels
+      run: |
         cmake \
           -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
           -DKokkosKernels_ADD_DEFAULT_ETI=OFF \
@@ -141,7 +141,8 @@ jobs:
         cmake --build build
         cmake --install build --prefix $KokkosKernels_ROOT
         rm -rf build
-
+    - name: Build DDC
+      run: |
         cmake \
           -DCMAKE_CXX_FLAGS="-Werror -Wall -Wextra -Wpedantic -Wno-sign-compare -pedantic-errors ${{matrix.backend.ddc_extra_cxx_flags}}" \
           -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
@@ -153,23 +154,27 @@ jobs:
           -DDDC_BUILD_PDI_WRAPPER=OFF \
           -DBLA_PREFER_PKGCONFIG=ON \
           -B build
-
         cmake --build build
-        ctest --test-dir build --output-on-failure --timeout 10 --output-junit tests.xml
+    - name: Run unit tests
+      run: ctest --test-dir build --output-on-failure --timeout 10 --output-junit tests.xml
+    - name: Run examples
+      run: |
         ./build/examples/characteristics_advection
         ./build/examples/game_of_life
         ./build/examples/heat_equation_spectral
         ./build/examples/heat_equation
         ./build/examples/non_uniform_heat_equation
         ./build/examples/uniform_heat_equation
-
+    - name: Install DDC
+      run: |
         cmake --install build --prefix $DDC_ROOT
         rm -rf build
-
-        # cmake \
-        #   -B build \
-        #   -S ./install_test
-        # cmake --build build
+    # - name: Run install tests
+    #   run: |
+    #     cmake \
+    #       -B build \
+    #       -S ./install_test
+    #     cmake --build build
     - name: Publish Test Report
       uses: mikepenz/action-junit-report@v5
       if: ( success() || failure() ) # always run even if the previous step fails

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -45,10 +45,8 @@ jobs:
     runs-on: macos-latest
     needs: [id_repo]
     env:
-      benchmark_ROOT: ${{github.workspace}}/opt/benchmark
       DDC_ROOT: ${{github.workspace}}/opt/ddc
       Ginkgo_ROOT: ${{github.workspace}}/opt/ginkgo
-      GTest_ROOT: ${{github.workspace}}/opt/gtest
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos
       KokkosFFT_ROOT: ${{github.workspace}}/opt/kokkos-fft
       KokkosKernels_ROOT: ${{github.workspace}}/opt/kokkos-kernels
@@ -94,6 +92,10 @@ jobs:
       run: brew install fftw
     - name: Install lapack
       run: brew install lapack
+    - name: Install Google Test
+      run: brew install googletest
+    - name: Install Google benchmark
+      run: brew install google-benchmark
     - run: git config --global --add safe.directory '*'
     - name: Install Ginkgo
       run: |
@@ -109,28 +111,6 @@ jobs:
           -S ./ginkgo
         cmake --build build
         cmake --install build --prefix $Ginkgo_ROOT
-        rm -rf build
-    - name: Install Google benchmark
-      run: |
-        cmake \
-          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-          -DBENCHMARK_ENABLE_GTEST_TESTS=OFF \
-          -DBENCHMARK_ENABLE_TESTING=OFF \
-          -DBENCHMARK_INSTALL_DOCS=OFF \
-          -DBENCHMARK_USE_BUNDLED_GTEST=OFF \
-          -B build \
-          -S ./vendor/benchmark
-        cmake --build build
-        cmake --install build --prefix $benchmark_ROOT
-        rm -rf build
-    - name: Install Google Test
-      run: |
-        cmake \
-          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-          -B build \
-          -S ./vendor/googletest
-        cmake --build build
-        cmake --install build --prefix $GTest_ROOT
         rm -rf build
     - name: Install Kokkos
       run: |

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -39,6 +39,9 @@ jobs:
           kokkos_extra_cmake_flags: ''
         cxx_version: ['17', '20', '23']
         cmake_build_type: ['Debug', 'Release']
+        exclude:
+        - cxx_version: '20' # To be remove as soon as PDI supports C++20 with clang
+        - cxx_version: '23' # To be remove as soon as PDI supports C++20 with clang
     runs-on: macos-latest
     needs: [id_repo]
     env:
@@ -49,6 +52,7 @@ jobs:
       Kokkos_ROOT: ${{github.workspace}}/opt/kokkos
       KokkosFFT_ROOT: ${{github.workspace}}/opt/kokkos-fft
       KokkosKernels_ROOT: ${{github.workspace}}/opt/kokkos-kernels
+      PDI_ROOT: ${{github.workspace}}/opt/pdi
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       PKG_CONFIG_PATH: /opt/homebrew/opt/lapack/lib/pkgconfig
       LAPACKE_DIR: /opt/homebrew/opt/lapack
@@ -59,6 +63,32 @@ jobs:
     - name: Checkout built branch
       uses: actions/checkout@v4
       with: { submodules: true }
+    - name: Install PDI+user code plugin and dependencies
+      run: |
+        git clone --branch 1.8.1 --depth 1 https://github.com/pdidev/pdi.git
+        # PATCH: remove <link.h> for macOS
+        sed -i.bak 's|#include <link.h>||g' pdi/plugins/user_code/user_code.cxx
+        rm -f pdi/plugins/user_code/user_code.cxx.bak
+        cmake \
+          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
+          -DBUILD_BENCHMARKING=OFF \
+          -DBUILD_DECL_HDF5_PLUGIN=OFF \
+          -DBUILD_DECL_NETCDF_PLUGIN=OFF \
+          -DBUILD_DEISA_PLUGIN=OFF \
+          -DBUILD_DOCUMENTATION=OFF \
+          -DBUILD_FORTRAN=OFF \
+          -DBUILD_MPI_PLUGIN=OFF \
+          -DBUILD_PYCALL_PLUGIN=OFF \
+          -DBUILD_SERIALIZE_PLUGIN=OFF \
+          -DBUILD_SET_VALUE_PLUGIN=OFF \
+          -DBUILD_TESTING=OFF \
+          -DBUILD_TRACE_PLUGIN=OFF \
+          -DBUILD_USER_CODE_PLUGIN=ON \
+          -B build \
+          -S ./pdi
+        cmake --build build
+        cmake --install build --prefix $PDI_ROOT
+        rm -rf build
     - name: Install fftw
       run: brew install fftw
     - name: Install lapack
@@ -151,7 +181,6 @@ jobs:
           -DDDC_GTest_DEPENDENCY_POLICY=INSTALLED \
           -DDDC_Kokkos_DEPENDENCY_POLICY=INSTALLED \
           -DDDC_KokkosFFT_DEPENDENCY_POLICY=INSTALLED \
-          -DDDC_BUILD_PDI_WRAPPER=OFF \
           -DBLA_PREFER_PKGCONFIG=ON \
           -B build
         cmake --build build
@@ -174,9 +203,9 @@ jobs:
       run: |
         cmake --install build --prefix $DDC_ROOT
         rm -rf build
-    # - name: Run install tests
-    #   run: |
-    #     cmake \
-    #       -B build \
-    #       -S ./install_test
-    #     cmake --build build
+    - name: Run install tests
+      run: |
+        cmake \
+          -B build \
+          -S ./install_test
+        cmake --build build

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -40,8 +40,8 @@ jobs:
         cxx_version: ['17', '20', '23']
         cmake_build_type: ['Debug', 'Release']
         exclude:
-        - cxx_version: '20' # To be remove as soon as PDI supports C++20 with clang
-        - cxx_version: '23' # To be remove as soon as PDI supports C++20 with clang
+        - cxx_version: '20' # To be removed as soon as PDI supports C++20 with clang
+        - cxx_version: '23' # To be removed as soon as PDI supports C++20 with clang
     runs-on: macos-latest
     needs: [id_repo]
     env:

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -70,7 +70,6 @@ jobs:
         sed -i.bak 's|#include <link.h>||g' pdi/plugins/user_code/user_code.cxx
         rm -f pdi/plugins/user_code/user_code.cxx.bak
         cmake \
-          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
           -DBUILD_BENCHMARKING=OFF \
           -DBUILD_DECL_HDF5_PLUGIN=OFF \
           -DBUILD_DECL_NETCDF_PLUGIN=OFF \
@@ -84,6 +83,8 @@ jobs:
           -DBUILD_TESTING=OFF \
           -DBUILD_TRACE_PLUGIN=OFF \
           -DBUILD_USER_CODE_PLUGIN=ON \
+          -DCMAKE_CXX_FLAGS="-Wno-unqualified-std-cast-call" \
+          -DCMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
           -B build \
           -S ./pdi
         cmake --build build

--- a/.github/workflows/tests-macos.yml
+++ b/.github/workflows/tests-macos.yml
@@ -157,6 +157,11 @@ jobs:
         cmake --build build
     - name: Run unit tests
       run: ctest --test-dir build --output-on-failure --timeout 10 --output-junit tests.xml
+    - name: Publish Test Report
+      uses: mikepenz/action-junit-report@v5
+      if: ( success() || failure() ) # always run even if the previous step fails
+      with:
+        report_paths: '${{github.workspace}}/build/tests.xml'
     - name: Run examples
       run: |
         ./build/examples/characteristics_advection
@@ -175,8 +180,3 @@ jobs:
     #       -B build \
     #       -S ./install_test
     #     cmake --build build
-    - name: Publish Test Report
-      uses: mikepenz/action-junit-report@v5
-      if: ( success() || failure() ) # always run even if the previous step fails
-      with:
-        report_paths: '/home/runner/work/ddc/ddc/tests.xml'

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-name: Tests
+name: Tests on Ubuntu
 
 on:
   schedule:

--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -228,35 +228,35 @@ void characteristics_advection_unitary(benchmark::State& state)
 
 void characteristics_advection(benchmark::State& state)
 {
-    long const host = 0;
-    long const dev = 1;
-    long const uniform = 0;
-    long const non_uniform = 1;
+    std::int64_t const host = 0;
+    std::int64_t const dev = 1;
+    std::int64_t const uniform = 0;
+    std::int64_t const non_uniform = 1;
     // Preallocate 12 unitary benchmarks for each combination of cpu/gpu execution space, uniform/non-uniform and spline degree we may want to benchmark (those are determined at compile-time, that's why we need to build explicitly 12 variants of the bench even if we call only one of them)
-    std::map<std::array<long, 3>, std::function<void(benchmark::State&)>> benchmarks;
-    benchmarks[std::array {host, uniform, 3L}]
+    std::map<std::array<std::int64_t, 3>, std::function<void(benchmark::State&)>> benchmarks;
+    benchmarks[std::array {host, uniform, std::int64_t(3)}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, false, 3>;
-    benchmarks[std::array {host, uniform, 4L}]
+    benchmarks[std::array {host, uniform, std::int64_t(4)}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, false, 4>;
-    benchmarks[std::array {host, uniform, 5L}]
+    benchmarks[std::array {host, uniform, std::int64_t(5)}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, false, 5>;
-    benchmarks[std::array {host, non_uniform, 3L}]
+    benchmarks[std::array {host, non_uniform, std::int64_t(3)}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, true, 3>;
-    benchmarks[std::array {host, non_uniform, 4L}]
+    benchmarks[std::array {host, non_uniform, std::int64_t(4)}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, true, 4>;
-    benchmarks[std::array {host, non_uniform, 5L}]
+    benchmarks[std::array {host, non_uniform, std::int64_t(5)}]
             = characteristics_advection_unitary<Kokkos::DefaultHostExecutionSpace, true, 5>;
-    benchmarks[std::array {dev, uniform, 3L}]
+    benchmarks[std::array {dev, uniform, std::int64_t(3)}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, false, 3>;
-    benchmarks[std::array {dev, uniform, 4L}]
+    benchmarks[std::array {dev, uniform, std::int64_t(4)}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, false, 4>;
-    benchmarks[std::array {dev, uniform, 5L}]
+    benchmarks[std::array {dev, uniform, std::int64_t(5)}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, false, 5>;
-    benchmarks[std::array {dev, non_uniform, 3L}]
+    benchmarks[std::array {dev, non_uniform, std::int64_t(3)}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, true, 3>;
-    benchmarks[std::array {dev, non_uniform, 4L}]
+    benchmarks[std::array {dev, non_uniform, std::int64_t(4)}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, true, 4>;
-    benchmarks[std::array {dev, non_uniform, 5L}]
+    benchmarks[std::array {dev, non_uniform, std::int64_t(5)}]
             = characteristics_advection_unitary<Kokkos::DefaultExecutionSpace, true, 5>;
 
     // Run the desired bench


### PR DESCRIPTION
A few remarks:
- compared to the linux CI, it does not use docker images (too complicated for me to generate them correctly)
- some dependencies are installed by brew: lapack, fftw, google benchmark and google test. The other dependencies are manually compiled
- lapack is detected using pkg-config, lapacke needed to be manually specified using `LAPACKE_DIR`
- I added a temporary patch to remove `<link.h>` in the user-code plugin as suggested by the PDI team
- I temporarily disabled compilation in C++20/23 modes due to a minor bug in PDI core. The bug has been reported.