### PR TITLE
Fix some spline tests failing

### DIFF
--- a/tests/splines/bsplines.cpp
+++ b/tests/splines/bsplines.cpp
@@ -39,6 +39,12 @@ struct BSplinesFixture<std::tuple<
     struct NUBSplinesX : ddc::NonUniformBSplines<DimX, D>
     {
     };
+    struct RoundingUBSplinesX : ddc::UniformBSplines<DimX, D>
+    {
+    };
+    struct RoundingNUBSplinesX : ddc::NonUniformBSplines<DimX, D>
+    {
+    };
     static constexpr std::size_t spline_degree = D;
     static constexpr std::size_t ncells = Nc;
 };
@@ -137,7 +143,7 @@ TYPED_TEST(BSplinesFixture, RoundingNonUniform)
 {
     std::size_t constexpr degree = TestFixture::spline_degree;
     using DimX = typename TestFixture::DimX;
-    using BSplinesX = typename TestFixture::NUBSplinesX;
+    using BSplinesX = typename TestFixture::RoundingNUBSplinesX;
     using CoordX = ddc::Coordinate<DimX>;
     CoordX const xmin(0.0);
     CoordX const xmax(0.2);
@@ -171,7 +177,7 @@ TYPED_TEST(BSplinesFixture, RoundingUniform)
 {
     std::size_t constexpr degree = TestFixture::spline_degree;
     using DimX = typename TestFixture::DimX;
-    using BSplinesX = typename TestFixture::UBSplinesX;
+    using BSplinesX = typename TestFixture::RoundingUBSplinesX;
     using CoordX = ddc::Coordinate<DimX>;
     CoordX const xmin(0.0);
     CoordX const xmax(0.2);

--- a/tests/splines/spline_builder.cpp
+++ b/tests/splines/spline_builder.cpp
@@ -22,142 +22,143 @@ using CoordX = ddc::Coordinate<DimX>;
 
 static constexpr std::size_t s_degree_x = 2;
 
+struct ShortBSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+{
+};
+
+struct ShortDDimX : ddc::NonUniformPointSampling<DimX>
+{
+};
+
+struct LongBSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+{
+};
+
+struct LongDDimX : ddc::NonUniformPointSampling<DimX>
+{
+};
+
+struct BadBSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+{
+};
+
+struct BadDDimX : ddc::NonUniformPointSampling<DimX>
+{
+};
+
+struct CorrectBSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+{
+};
+
+struct CorrectDDimX : ddc::NonUniformPointSampling<DimX>
+{
+};
+
+
 using execution_space = Kokkos::DefaultHostExecutionSpace;
 using memory_space = Kokkos::HostSpace;
 
 TEST(SplineBuilder, ShortInterpolationGrid)
 {
-    struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
-    {
-    };
-
-    struct DDimX : ddc::NonUniformPointSampling<DimX>
-    {
-    };
-
     CoordX const x0(0.);
     CoordX const xN(1.);
     std::size_t const ncells = 5;
 
-    ddc::init_discrete_space<BSplinesX>(x0, xN, ncells);
+    ddc::init_discrete_space<ShortBSplinesX>(x0, xN, ncells);
 
     // One point missing
     std::vector<double> const range {0.1, 0.3, 0.5, 0.7};
 
-    ddc::DiscreteDomain<DDimX> const interpolation_domain
-            = ddc::init_discrete_space<DDimX>(DDimX::init<DDimX>(range));
+    ddc::DiscreteDomain<ShortDDimX> const interpolation_domain
+            = ddc::init_discrete_space<ShortDDimX>(ShortDDimX::init<ShortDDimX>(range));
 
     EXPECT_THROW(
             (ddc::SplineBuilder<
                     execution_space,
                     memory_space,
-                    BSplinesX,
-                    DDimX,
+                    ShortBSplinesX,
+                    ShortDDimX,
                     ddc::BoundCond::PERIODIC,
                     ddc::BoundCond::PERIODIC,
                     ddc::SplineSolver::GINKGO,
-                    DDimX>(interpolation_domain)),
+                    ShortDDimX>(interpolation_domain)),
             std::runtime_error);
 }
 
 TEST(SplineBuilder, LongInterpolationGrid)
 {
-    struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
-    {
-    };
-
-    struct DDimX : ddc::NonUniformPointSampling<DimX>
-    {
-    };
-
     CoordX const x0(0.);
     CoordX const xN(1.);
     std::size_t const ncells = 5;
 
-    ddc::init_discrete_space<BSplinesX>(x0, xN, ncells);
+    ddc::init_discrete_space<LongBSplinesX>(x0, xN, ncells);
 
     // One point too much
     std::vector<double> const range {0.1, 0.3, 0.5, 0.7, 0.9, 0.95};
 
-    ddc::DiscreteDomain<DDimX> const interpolation_domain
-            = ddc::init_discrete_space<DDimX>(DDimX::init<DDimX>(range));
+    ddc::DiscreteDomain<LongDDimX> const interpolation_domain
+            = ddc::init_discrete_space<LongDDimX>(LongDDimX::init<LongDDimX>(range));
 
     EXPECT_THROW(
             (ddc::SplineBuilder<
                     execution_space,
                     memory_space,
-                    BSplinesX,
-                    DDimX,
+                    LongBSplinesX,
+                    LongDDimX,
                     ddc::BoundCond::PERIODIC,
                     ddc::BoundCond::PERIODIC,
                     ddc::SplineSolver::GINKGO,
-                    DDimX>(interpolation_domain)),
+                    LongDDimX>(interpolation_domain)),
             std::runtime_error);
 }
 
 TEST(SplineBuilder, BadShapeInterpolationGrid)
 {
-    struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
-    {
-    };
-
-    struct DDimX : ddc::NonUniformPointSampling<DimX>
-    {
-    };
-
     CoordX const x0(0.);
     CoordX const xN(1.);
     std::size_t const ncells = 5;
 
-    ddc::init_discrete_space<BSplinesX>(x0, xN, ncells);
+    ddc::init_discrete_space<BadBSplinesX>(x0, xN, ncells);
 
     // All points end up in the first cell ]0, 0.2[
     std::vector<double> const range {0.1, 0.11, 0.12, 0.13, 0.14};
 
-    ddc::DiscreteDomain<DDimX> const interpolation_domain
-            = ddc::init_discrete_space<DDimX>(DDimX::init<DDimX>(range));
+    ddc::DiscreteDomain<BadDDimX> const interpolation_domain
+            = ddc::init_discrete_space<BadDDimX>(BadDDimX::init<BadDDimX>(range));
 
     EXPECT_THROW(
             (ddc::SplineBuilder<
                     execution_space,
                     memory_space,
-                    BSplinesX,
-                    DDimX,
+                    BadBSplinesX,
+                    BadDDimX,
                     ddc::BoundCond::PERIODIC,
                     ddc::BoundCond::PERIODIC,
                     ddc::SplineSolver::GINKGO,
-                    DDimX>(interpolation_domain)),
+                    BadDDimX>(interpolation_domain)),
             std::runtime_error);
 }
 
 TEST(SplineBuilder, CorrectInterpolationGrid)
 {
-    struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
-    {
-    };
-
-    struct DDimX : ddc::NonUniformPointSampling<DimX>
-    {
-    };
-
     CoordX const x0(0.);
     CoordX const xN(1.);
     std::size_t const ncells = 5;
 
-    ddc::init_discrete_space<BSplinesX>(x0, xN, ncells);
+    ddc::init_discrete_space<CorrectBSplinesX>(x0, xN, ncells);
 
     std::vector<double> const range {0.05, 0.15, 0.5, 0.85, 0.95};
 
-    ddc::DiscreteDomain<DDimX> const interpolation_domain
-            = ddc::init_discrete_space<DDimX>(DDimX::init<DDimX>(range));
+    ddc::DiscreteDomain<CorrectDDimX> const interpolation_domain
+            = ddc::init_discrete_space<CorrectDDimX>(CorrectDDimX::init<CorrectDDimX>(range));
 
     EXPECT_NO_THROW((ddc::SplineBuilder<
                      execution_space,
                      memory_space,
-                     BSplinesX,
-                     DDimX,
+                     CorrectBSplinesX,
+                     CorrectDDimX,
                      ddc::BoundCond::PERIODIC,
                      ddc::BoundCond::PERIODIC,
                      ddc::SplineSolver::GINKGO,
-                     DDimX>(interpolation_domain)));
+                     CorrectDDimX>(interpolation_domain)));
 }

--- a/tests/splines/spline_builder.cpp
+++ b/tests/splines/spline_builder.cpp
@@ -22,19 +22,19 @@ using CoordX = ddc::Coordinate<DimX>;
 
 static constexpr std::size_t s_degree_x = 2;
 
-struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
-{
-};
-
-struct DDimX : ddc::NonUniformPointSampling<DimX>
-{
-};
-
 using execution_space = Kokkos::DefaultHostExecutionSpace;
 using memory_space = Kokkos::HostSpace;
 
 TEST(SplineBuilder, ShortInterpolationGrid)
 {
+    struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+    {
+    };
+
+    struct DDimX : ddc::NonUniformPointSampling<DimX>
+    {
+    };
+
     CoordX const x0(0.);
     CoordX const xN(1.);
     std::size_t const ncells = 5;
@@ -62,6 +62,14 @@ TEST(SplineBuilder, ShortInterpolationGrid)
 
 TEST(SplineBuilder, LongInterpolationGrid)
 {
+    struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+    {
+    };
+
+    struct DDimX : ddc::NonUniformPointSampling<DimX>
+    {
+    };
+
     CoordX const x0(0.);
     CoordX const xN(1.);
     std::size_t const ncells = 5;
@@ -89,6 +97,14 @@ TEST(SplineBuilder, LongInterpolationGrid)
 
 TEST(SplineBuilder, BadShapeInterpolationGrid)
 {
+    struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+    {
+    };
+
+    struct DDimX : ddc::NonUniformPointSampling<DimX>
+    {
+    };
+
     CoordX const x0(0.);
     CoordX const xN(1.);
     std::size_t const ncells = 5;
@@ -116,6 +132,14 @@ TEST(SplineBuilder, BadShapeInterpolationGrid)
 
 TEST(SplineBuilder, CorrectInterpolationGrid)
 {
+    struct BSplinesX : ddc::UniformBSplines<DimX, s_degree_x>
+    {
+    };
+
+    struct DDimX : ddc::NonUniformPointSampling<DimX>
+    {
+    };
+
     CoordX const x0(0.);
     CoordX const xN(1.);
     std::size_t const ncells = 5;


### PR DESCRIPTION
Some tests for the splines failed because of discrete spaces being initialized multiple times for the same discrete dimension.

<details><summary>The list of failing tests if needed:</summary>
<p>

```
[----------] Global test environment tear-down
[==========] 245 tests from 46 test suites ran. (510 ms total)
[  PASSED  ] 170 tests.
[  FAILED  ] 75 tests, listed below:
[  FAILED  ] BSplinesFixture/0.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/0.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/1.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/1.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/2.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/2.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/3.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/3.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/4.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/4.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/5.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/5.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/6.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/6.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/7.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/7.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/8.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/8.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/9.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/9.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/10.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/10.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/11.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/11.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/12.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/12.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/13.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/13.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/14.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/14.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/15.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/15.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/16.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/16.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/17.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/17.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,true> >
[  FAILED  ] BSplinesFixture/18.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/18.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/19.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/19.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/20.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/20.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/21.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/21.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/22.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/22.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/23.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/23.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,10ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/24.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/24.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/25.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/25.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/26.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/26.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/27.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/27.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/28.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/28.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/29.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/29.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,20ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/30.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/30.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,1ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/31.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/31.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,2ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/32.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/32.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,3ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/33.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/33.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,4ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/34.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/34.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,5ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/35.RoundingNonUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] BSplinesFixture/35.RoundingUniform, where TypeParam = std::tuple<std::integral_constant<unsigned long,6ul>,std::integral_constant<unsigned long,100ul>,std::integral_constant<bool,false> >
[  FAILED  ] SplineBuilder.LongInterpolationGrid
[  FAILED  ] SplineBuilder.BadShapeInterpolationGrid
[  FAILED  ] SplineBuilder.CorrectInterpolationGrid
``` 

</p>
</details> 