### PR TITLE
Remove the batch dimensions from the SplineBuilder and SplineEvaluator class templates

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -35,3 +35,6 @@ Baptiste Legouix - CEA (baptiste.legouix@cea.fr)
 Thierry Antoun - CEA (thierry.antoun@cea.fr)
 * Work on Documentation
 * Work on adding new features 
+
+Trévis Morvany - CEA (trevis.morvany@cea.fr)
+* Work on splines

--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -160,7 +160,7 @@ void characteristics_advection_unitary(benchmark::State& state)
             DDimX<IsNonUniform, s_degree_x>,
             ddc::BoundCond::PERIODIC,
             ddc::BoundCond::PERIODIC,
-            Backend> const spline_builder(x_mesh, cols_per_chunk, preconditioner_max_block_size);
+            Backend> const spline_builder(x_domain, cols_per_chunk, preconditioner_max_block_size);
     ddc::PeriodicExtrapolationRule<X> const periodic_extrapolation;
     ddc::SplineEvaluator<
             ExecSpace,

--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -160,9 +160,7 @@ void characteristics_advection_unitary(benchmark::State& state)
             DDimX<IsNonUniform, s_degree_x>,
             ddc::BoundCond::PERIODIC,
             ddc::BoundCond::PERIODIC,
-            Backend,
-            DDimX<IsNonUniform, s_degree_x>,
-            DDimY> const spline_builder(x_mesh, cols_per_chunk, preconditioner_max_block_size);
+            Backend> const spline_builder(x_mesh, cols_per_chunk, preconditioner_max_block_size);
     ddc::PeriodicExtrapolationRule<X> const periodic_extrapolation;
     ddc::SplineEvaluator<
             ExecSpace,
@@ -170,15 +168,14 @@ void characteristics_advection_unitary(benchmark::State& state)
             BSplinesX<IsNonUniform, s_degree_x>,
             DDimX<IsNonUniform, s_degree_x>,
             ddc::PeriodicExtrapolationRule<X>,
-            ddc::PeriodicExtrapolationRule<X>,
-            DDimX<IsNonUniform, s_degree_x>,
-            DDimY> const spline_evaluator(periodic_extrapolation, periodic_extrapolation);
+            ddc::PeriodicExtrapolationRule<X>> const
+            spline_evaluator(periodic_extrapolation, periodic_extrapolation);
     ddc::Chunk coef_alloc(
-            spline_builder.batched_spline_domain(),
+            spline_builder.batched_spline_domain(x_mesh),
             ddc::KokkosAllocator<double, typename ExecSpace::memory_space>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
     ddc::Chunk feet_coords_alloc(
-            spline_builder.batched_interpolation_domain(),
+            spline_builder.batched_interpolation_domain(x_mesh),
             ddc::KokkosAllocator<ddc::Coordinate<X>, typename ExecSpace::memory_space>());
     ddc::ChunkSpan const feet_coords = feet_coords_alloc.span_view();
 

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -220,7 +220,9 @@ int main(int argc, char** argv)
 
     //! [instantiate intermediate chunks]
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(spline_builder.batched_spline_domain(x_mesh), ddc::DeviceAllocator<double>());
+    ddc::Chunk coef_alloc(
+            spline_builder.batched_spline_domain(x_mesh),
+            ddc::DeviceAllocator<double>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Instantiate chunk to receive feet coords

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -215,9 +215,7 @@ int main(int argc, char** argv)
             BSplinesX,
             DDimX,
             ExtrapolationRule,
-            ExtrapolationRule,
-            DDimX,
-            DDimY> const spline_evaluator(extrapolation_rule, extrapolation_rule);
+            ExtrapolationRule> const spline_evaluator(extrapolation_rule, extrapolation_rule);
     //! [instantiate solver]
 
     //! [instantiate intermediate chunks]

--- a/examples/characteristics_advection.cpp
+++ b/examples/characteristics_advection.cpp
@@ -207,9 +207,7 @@ int main(int argc, char** argv)
             DDimX,
             BoundCond,
             BoundCond,
-            ddc::SplineSolver::LAPACK,
-            DDimX,
-            DDimY> const spline_builder(x_mesh);
+            ddc::SplineSolver::LAPACK> const spline_builder(x_domain);
     ExtrapolationRule const extrapolation_rule;
     ddc::SplineEvaluator<
             Kokkos::DefaultExecutionSpace,
@@ -224,12 +222,12 @@ int main(int argc, char** argv)
 
     //! [instantiate intermediate chunks]
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(spline_builder.batched_spline_domain(), ddc::DeviceAllocator<double>());
+    ddc::Chunk coef_alloc(spline_builder.batched_spline_domain(x_mesh), ddc::DeviceAllocator<double>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Instantiate chunk to receive feet coords
     ddc::Chunk feet_coords_alloc(
-            spline_builder.batched_interpolation_domain(),
+            spline_builder.batched_interpolation_domain(x_mesh),
             ddc::DeviceAllocator<ddc::Coordinate<X>>());
     ddc::ChunkSpan const feet_coords = feet_coords_alloc.span_view();
     //! [instantiate intermediate chunks]

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -49,7 +49,6 @@ enum class SplineSolver {
  * @tparam BcLower The lower boundary condition.
  * @tparam BcUpper The upper boundary condition.
  * @tparam Solver The SplineSolver giving the backend used to perform the spline approximation.
- * @tparam DDimX A variadic template of all the discrete dimensions forming the full space (InterpolationDDim + batched dimensions).
  */
 template <
         class ExecSpace,

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -94,8 +94,10 @@ public:
      *
      * @tparam The batched discrete domain on which the interpolation points are defined.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    using batched_interpolation_domain_type = DDom;
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using batched_interpolation_domain_type = BatchedInterpolationDDom;
 
     /**
      * @brief The type of the batch domain (obtained by removing the dimension of interest
@@ -106,8 +108,11 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y,
      * this is DiscreteDomain<X,Z>
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    using batch_domain_type = ddc::remove_dims_of_t<DDom, interpolation_discrete_dimension_type>;
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using batch_domain_type = ddc::
+            remove_dims_of_t<BatchedInterpolationDDom, interpolation_discrete_dimension_type>;
 
     /**
      * @brief The type of the whole spline domain (cartesian product of 1D spline domain
@@ -118,9 +123,13 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y
      * (associated to a B-splines tag BSplinesY), this is DiscreteDomain<X,BSplinesY,Z>.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    using batched_spline_domain_type
-            = ddc::replace_dim_of_t<DDom, interpolation_discrete_dimension_type, bsplines_type>;
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using batched_spline_domain_type = ddc::replace_dim_of_t<
+            BatchedInterpolationDDom,
+            interpolation_discrete_dimension_type,
+            bsplines_type>;
 
 private:
     /**
@@ -132,12 +141,14 @@ private:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y
      * (associated to a B-splines tag BSplinesY), this is DiscreteDomain<BSplinesY,X,Z>.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
     using batched_spline_tr_domain_type =
             typename ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_merge_t<
                     ddc::detail::TypeSeq<bsplines_type>,
                     ddc::type_seq_remove_t<
-                            ddc::to_type_seq_t<DDom>,
+                            ddc::to_type_seq_t<BatchedInterpolationDDom>,
                             ddc::detail::TypeSeq<interpolation_discrete_dimension_type>>>>;
 
 public:
@@ -150,9 +161,13 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and a dimension of interest Y,
      * this is DiscreteDomain<X,Deriv<Y>,Z>
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    using batched_derivs_domain_type
-            = ddc::replace_dim_of_t<DDom, interpolation_discrete_dimension_type, deriv_type>;
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using batched_derivs_domain_type = ddc::replace_dim_of_t<
+            BatchedInterpolationDDom,
+            interpolation_discrete_dimension_type,
+            deriv_type>;
 
     /// @brief Indicates if the degree of the splines is odd or even.
     static constexpr bool s_odd = BSplines::degree() % 2;
@@ -250,9 +265,11 @@ public:
      *
      * @see MatrixSparse
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
     explicit SplineBuilder(
-            DDom const& batched_interpolation_domain,
+            BatchedInterpolationDDom const& batched_interpolation_domain,
             std::optional<std::size_t> cols_per_chunk = std::nullopt,
             std::optional<unsigned int> preconditioner_max_block_size = std::nullopt)
         : SplineBuilder(
@@ -307,9 +324,13 @@ public:
      *
      * @return The domain for the interpolation mesh.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    DDom batched_interpolation_domain(DDom const& batched_interpolation_domain) const noexcept
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    BatchedInterpolationDDom batched_interpolation_domain(
+            BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
+        assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
         return batched_interpolation_domain;
     }
 
@@ -322,9 +343,11 @@ public:
      *
      * @return The batch domain.
      */
-    template <class DDom>
-    batch_domain_type<DDom> batch_domain(DDom const& batched_interpolation_domain) const noexcept
+    template <class BatchedInterpolationDDom>
+    batch_domain_type<BatchedInterpolationDDom> batch_domain(
+            BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
+        assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
         return ddc::remove_dims_of(batched_interpolation_domain, interpolation_domain());
     }
 
@@ -349,10 +372,11 @@ public:
      *
      * @return The domain for the spline coefficients.
      */
-    template <class DDom>
-    batched_spline_domain_type<DDom> batched_spline_domain(
-            DDom const& batched_interpolation_domain) const noexcept
+    template <class BatchedInterpolationDDom>
+    batched_spline_domain_type<BatchedInterpolationDDom> batched_spline_domain(
+            BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
+        assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
         return ddc::replace_dim_of<
                 interpolation_discrete_dimension_type,
                 bsplines_type>(batched_interpolation_domain, spline_domain());
@@ -368,11 +392,12 @@ private:
      *
      * @return The (transposed) domain for the spline coefficients.
      */
-    template <class DDom>
-    batched_spline_tr_domain_type<DDom> batched_spline_tr_domain(
-            DDom const& batched_interpolation_domain) const noexcept
+    template <class BatchedInterpolationDDom>
+    batched_spline_tr_domain_type<BatchedInterpolationDDom> batched_spline_tr_domain(
+            BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
-        return batched_spline_tr_domain_type<DDom>(
+        assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
+        return batched_spline_tr_domain_type<BatchedInterpolationDDom>(
                 ddc::replace_dim_of<bsplines_type, bsplines_type>(
                         batched_spline_domain(batched_interpolation_domain),
                         ddc::DiscreteDomain<bsplines_type>(
@@ -391,10 +416,11 @@ public:
      *
      * @return The domain for the Derivs values.
      */
-    template <class DDom>
-    batched_derivs_domain_type<DDom> batched_derivs_xmin_domain(
-            DDom const& batched_interpolation_domain) const noexcept
+    template <class BatchedInterpolationDDom>
+    batched_derivs_domain_type<BatchedInterpolationDDom> batched_derivs_xmin_domain(
+            BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
+        assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
         return ddc::replace_dim_of<interpolation_discrete_dimension_type, deriv_type>(
                 batched_interpolation_domain,
                 ddc::DiscreteDomain<deriv_type>(
@@ -411,10 +437,11 @@ public:
      *
      * @return The domain for the Derivs values.
      */
-    template <class DDom>
-    batched_derivs_domain_type<DDom> batched_derivs_xmax_domain(
-            DDom const& batched_interpolation_domain) const noexcept
+    template <class BatchedInterpolationDDom>
+    batched_derivs_domain_type<BatchedInterpolationDDom> batched_derivs_xmax_domain(
+            BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
+        assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
         return ddc::replace_dim_of<interpolation_discrete_dimension_type, deriv_type>(
                 batched_interpolation_domain,
                 ddc::DiscreteDomain<deriv_type>(
@@ -441,19 +468,23 @@ public:
      * @param[in] derivs_xmax The values of the derivatives at the upper boundary
      * (used only with BoundCond::HERMITE upper boundary condition).
      */
-    template <class Layout, class DDom>
+    template <class Layout, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<double, batched_spline_domain_type<DDom>, Layout, memory_space> spline,
-            ddc::ChunkSpan<double const, DDom, Layout, memory_space> vals,
+            ddc::ChunkSpan<
+                    double,
+                    batched_spline_domain_type<BatchedInterpolationDDom>,
+                    Layout,
+                    memory_space> spline,
+            ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDom>,
+                    batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_xmin
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDom>,
+                    batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_xmax
             = std::nullopt) const;
@@ -762,25 +793,29 @@ template <
         ddc::BoundCond BcLower,
         ddc::BoundCond BcUpper,
         SplineSolver Solver>
-template <class Layout, class DDom>
+template <class Layout, class BatchedInterpolationDDom>
 void SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, BcLower, BcUpper, Solver>::
 operator()(
-        ddc::ChunkSpan<double, batched_spline_domain_type<DDom>, Layout, memory_space> spline,
-        ddc::ChunkSpan<double const, DDom, Layout, memory_space> vals,
+        ddc::ChunkSpan<
+                double,
+                batched_spline_domain_type<BatchedInterpolationDDom>,
+                Layout,
+                memory_space> spline,
+        ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDom>,
+                batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_xmin,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDom>,
+                batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_xmax) const
 {
     auto const batched_interpolation_domain = vals.domain();
 
-    assert(interpolation_domain_type(batched_interpolation_domain) == m_interpolation_domain);
+    assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
 
     assert(vals.template extent<interpolation_discrete_dimension_type>()
            == ddc::discrete_space<bsplines_type>().nbasis() - s_nbc_xmin - s_nbc_xmax);
@@ -807,7 +842,9 @@ operator()(
                 "ddc_splines_hermite_compute_lower_coefficients",
                 exec_space(),
                 batch_domain(batched_interpolation_domain),
-                KOKKOS_LAMBDA(typename batch_domain_type<DDom>::discrete_element_type j) {
+                KOKKOS_LAMBDA(
+                        typename batch_domain_type<BatchedInterpolationDDom>::discrete_element_type
+                                j) {
                     for (int i = s_nbc_xmin; i > 0; --i) {
                         spline(ddc::DiscreteElement<bsplines_type>(s_nbc_xmin - i), j)
                                 = derivs_xmin_values(ddc::DiscreteElement<deriv_type>(i), j)
@@ -850,7 +887,9 @@ operator()(
                 "ddc_splines_hermite_compute_upper_coefficients",
                 exec_space(),
                 batch_domain(batched_interpolation_domain),
-                KOKKOS_LAMBDA(typename batch_domain_type<DDom>::discrete_element_type j) {
+                KOKKOS_LAMBDA(
+                        typename batch_domain_type<BatchedInterpolationDDom>::discrete_element_type
+                                j) {
                     for (int i = 0; i < s_nbc_xmax; ++i) {
                         spline(ddc::DiscreteElement<bsplines_type>(nbasis_proxy - s_nbc_xmax - i),
                                j)
@@ -870,7 +909,8 @@ operator()(
             "ddc_splines_transpose_rhs",
             exec_space(),
             batch_domain(batched_interpolation_domain),
-            KOKKOS_LAMBDA(typename batch_domain_type<DDom>::discrete_element_type const j) {
+            KOKKOS_LAMBDA(typename batch_domain_type<
+                          BatchedInterpolationDDom>::discrete_element_type const j) {
                 for (std::size_t i = 0; i < nbasis_proxy; ++i) {
                     spline_tr(ddc::DiscreteElement<bsplines_type>(i), j)
                             = spline(ddc::DiscreteElement<bsplines_type>(i + offset_proxy), j);
@@ -888,7 +928,8 @@ operator()(
             "ddc_splines_transpose_back_rhs",
             exec_space(),
             batch_domain(batched_interpolation_domain),
-            KOKKOS_LAMBDA(typename batch_domain_type<DDom>::discrete_element_type const j) {
+            KOKKOS_LAMBDA(typename batch_domain_type<
+                          BatchedInterpolationDDom>::discrete_element_type const j) {
                 for (std::size_t i = 0; i < nbasis_proxy; ++i) {
                     spline(ddc::DiscreteElement<bsplines_type>(i + offset_proxy), j)
                             = spline_tr(ddc::DiscreteElement<bsplines_type>(i), j);
@@ -901,7 +942,8 @@ operator()(
                 "ddc_splines_periodic_rows_duplicate_rhs",
                 exec_space(),
                 batch_domain(batched_interpolation_domain),
-                KOKKOS_LAMBDA(typename batch_domain_type<DDom>::discrete_element_type const j) {
+                KOKKOS_LAMBDA(typename batch_domain_type<
+                              BatchedInterpolationDDom>::discrete_element_type const j) {
                     if (offset_proxy != 0) {
                         for (int i = 0; i < offset_proxy; ++i) {
                             spline(ddc::DiscreteElement<bsplines_type>(i), j) = spline(

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -188,7 +188,7 @@ public:
     /**
      * @brief Build a SplineBuilder2D acting on interpolation_domain.
      *
-     * @param batched_interpolation_domain The domain on which the interpolation points are defined.
+     * @param interpolation_domain The domain on which the interpolation points are defined, without the batch dimensions.
      *
      * @param cols_per_chunk A parameter used by the slicer (internal to the solver) to define the size
      * of a chunk of right-hand-sides of the linear problem to be computed in parallel (chunks are treated

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -94,20 +94,26 @@ public:
             interpolation_discrete_dimension_type1,
             interpolation_discrete_dimension_type2>;
 
-    /// @brief The type of the whole domain representing interpolation points.
-    template <class... DDimX>
-    using batched_interpolation_domain_type = ddc::DiscreteDomain<DDimX...>;
+    /**
+     * @brief The type of the whole domain representing interpolation points.
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     */
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    using batched_interpolation_domain_type = DDom;
 
     /**
      * @brief The type of the batch domain (obtained by removing the dimensions of interest
      * from the whole domain).
      *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Z>.
      */
-    template <class... DDimX>
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
     using batch_domain_type = ddc::remove_dims_of_t<
-            batched_interpolation_domain_type<DDimX...>,
+            DDom,
             interpolation_discrete_dimension_type1,
             interpolation_discrete_dimension_type2>;
 
@@ -115,13 +121,15 @@ public:
      * @brief The type of the whole spline domain (cartesian product of 2D spline domain
      * and batch domain) preserving the order of dimensions.
      *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y
      * (associated to B-splines tags BSplinesX and BSplinesY), this is DiscreteDomain<BSplinesX, BSplinesY, Z>
      */
-    template <class... DDimX>
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
     using batched_spline_domain_type
             = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_replace_t<
-                    ddc::detail::TypeSeq<DDimX...>,
+                    ddc::to_type_seq_t<DDom>,
                     ddc::detail::TypeSeq<
                             interpolation_discrete_dimension_type1,
                             interpolation_discrete_dimension_type2>,
@@ -131,37 +139,41 @@ public:
      * @brief The type of the whole Derivs domain (cartesian product of the 1D Deriv domain
      * and the associated batch domain) in the first dimension, preserving the order of dimensions.
      *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Deriv<X>, Y, Z>.
      */
-    template <class... DDimX>
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
     using batched_derivs_domain_type1 =
-            typename builder_type1::template batched_derivs_domain_type<DDimX...>;
+            typename builder_type1::template batched_derivs_domain_type<DDom>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 1D Deriv domain
      * and the associated batch domain) in the second dimension, preserving the order of dimensions.
      *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<X, Deriv<Y>, Z>.
      */
-    template <class... DDimX>
-    using batched_derivs_domain_type2 = ddc::replace_dim_of_t<
-            batched_interpolation_domain_type<DDimX...>,
-            interpolation_discrete_dimension_type2,
-            deriv_type2>;
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    using batched_derivs_domain_type2
+            = ddc::replace_dim_of_t<DDom, interpolation_discrete_dimension_type2, deriv_type2>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain
      * and the batch domain) in the second dimension, preserving the order of dimensions.
      *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     *
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Deriv<X>, Deriv<Y>, Z>.
      */
-    template <class... DDimX>
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
     using batched_derivs_domain_type
             = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_replace_t<
-                    ddc::detail::TypeSeq<DDimX...>,
+                    ddc::to_type_seq_t<DDom>,
                     ddc::detail::TypeSeq<
                             interpolation_discrete_dimension_type1,
                             interpolation_discrete_dimension_type2>,
@@ -215,9 +227,9 @@ public:
      *
      * @see SplinesLinearProblemSparse
      */
-    template <class... DDimX>
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
     explicit SplineBuilder2D(
-            batched_interpolation_domain_type<DDimX...> const& batched_interpolation_domain,
+            DDom const& batched_interpolation_domain,
             std::optional<std::size_t> cols_per_chunk = std::nullopt,
             std::optional<unsigned int> preconditioner_max_block_size = std::nullopt)
         : SplineBuilder2D(
@@ -270,12 +282,12 @@ public:
      * Values of the function must be provided on this domain in order
      * to build a spline representation of the function (cartesian product of 2D interpolation_domain and batch_domain).
      *
+     * @param batched_interpolation_domain The whole domain on which the interpolation points are defined.
+     *
      * @return The domain for the interpolation mesh.
      */
-    template <class... DDimX>
-    batched_interpolation_domain_type<DDimX...> batched_interpolation_domain(
-            batched_interpolation_domain_type<DDimX...> const& batched_interpolation_domain)
-            const noexcept
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    DDom batched_interpolation_domain(DDom const& batched_interpolation_domain) const noexcept
     {
         return batched_interpolation_domain;
     }
@@ -285,11 +297,12 @@ public:
      *
      * Obtained by removing the dimensions of interest from the whole interpolation domain.
      *
+     * @param batched_interpolation_domain The whole domain on which the interpolation points are defined.
+     *
      * @return The batch domain.
      */
-    template <class... DDimX>
-    batch_domain_type<DDimX...> batch_domain(batched_interpolation_domain_type<DDimX...> const&
-                                                     batched_interpolation_domain) const noexcept
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    batch_domain_type<DDom> batch_domain(DDom const& batched_interpolation_domain) const noexcept
     {
         return ddc::remove_dims_of(batched_interpolation_domain, interpolation_domain());
     }
@@ -313,12 +326,13 @@ public:
      *
      * Spline approximations (spline-transformed functions) are computed on this domain.
      *
+     * @param batched_interpolation_domain The whole domain on which the interpolation points are defined.
+     *
      * @return The domain for the spline coefficients.
      */
-    template <class... DDimX>
-    batched_spline_domain_type<DDimX...> batched_spline_domain(
-            batched_interpolation_domain_type<DDimX...> const& batched_interpolation_domain)
-            const noexcept
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    batched_spline_domain_type<DDom> batched_spline_domain(
+            DDom const& batched_interpolation_domain) const noexcept
     {
         return ddc::replace_dim_of<interpolation_discrete_dimension_type1, bsplines_type1>(
                 ddc::replace_dim_of<
@@ -363,60 +377,55 @@ public:
      *      The values of the the cross-derivatives at the upper boundary in the first dimension
      *      and the upper boundary in the second dimension.
      */
-    template <class Layout, class... DDimX>
+    template <class Layout, class DDom>
     void operator()(
-            ddc::ChunkSpan<double, batched_spline_domain_type<DDimX...>, Layout, memory_space>
-                    spline,
-            ddc::ChunkSpan<
-                    double const,
-                    batched_interpolation_domain_type<DDimX...>,
-                    Layout,
-                    memory_space> vals,
+            ddc::ChunkSpan<double, batched_spline_domain_type<DDom>, Layout, memory_space> spline,
+            ddc::ChunkSpan<double const, DDom, Layout, memory_space> vals,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type1<DDimX...>,
+                    batched_derivs_domain_type1<DDom>,
                     Layout,
                     memory_space>> derivs_min1
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type1<DDimX...>,
+                    batched_derivs_domain_type1<DDom>,
                     Layout,
                     memory_space>> derivs_max1
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type2<DDimX...>,
+                    batched_derivs_domain_type2<DDom>,
                     Layout,
                     memory_space>> derivs_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type2<DDimX...>,
+                    batched_derivs_domain_type2<DDom>,
                     Layout,
                     memory_space>> derivs_max2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDimX...>,
+                    batched_derivs_domain_type<DDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDimX...>,
+                    batched_derivs_domain_type<DDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDimX...>,
+                    batched_derivs_domain_type<DDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_max2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDimX...>,
+                    batched_derivs_domain_type<DDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_max2
             = std::nullopt) const;
@@ -435,7 +444,7 @@ template <
         ddc::BoundCond BcLower2,
         ddc::BoundCond BcUpper2,
         ddc::SplineSolver Solver>
-template <class Layout, class... DDimX>
+template <class Layout, class DDom>
 void SplineBuilder2D<
         ExecSpace,
         MemorySpace,
@@ -449,50 +458,46 @@ void SplineBuilder2D<
         BcUpper2,
         Solver>::
 operator()(
-        ddc::ChunkSpan<double, batched_spline_domain_type<DDimX...>, Layout, memory_space> spline,
-        ddc::ChunkSpan<
-                double const,
-                batched_interpolation_domain_type<DDimX...>,
-                Layout,
-                memory_space> vals,
+        ddc::ChunkSpan<double, batched_spline_domain_type<DDom>, Layout, memory_space> spline,
+        ddc::ChunkSpan<double const, DDom, Layout, memory_space> vals,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1<DDimX...>,
+                batched_derivs_domain_type1<DDom>,
                 Layout,
                 memory_space>> const derivs_min1,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1<DDimX...>,
+                batched_derivs_domain_type1<DDom>,
                 Layout,
                 memory_space>> const derivs_max1,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type2<DDimX...>,
+                batched_derivs_domain_type2<DDom>,
                 Layout,
                 memory_space>> const derivs_min2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type2<DDimX...>,
+                batched_derivs_domain_type2<DDom>,
                 Layout,
                 memory_space>> const derivs_max2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDimX...>,
+                batched_derivs_domain_type<DDom>,
                 Layout,
                 memory_space>> const mixed_derivs_min1_min2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDimX...>,
+                batched_derivs_domain_type<DDom>,
                 Layout,
                 memory_space>> const mixed_derivs_max1_min2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDimX...>,
+                batched_derivs_domain_type<DDom>,
                 Layout,
                 memory_space>> const mixed_derivs_min1_max2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDimX...>,
+                batched_derivs_domain_type<DDom>,
                 Layout,
                 memory_space>> const mixed_derivs_max1_max2) const
 {

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -33,8 +33,7 @@ template <
         ddc::BoundCond BcUpper1,
         ddc::BoundCond BcLower2,
         ddc::BoundCond BcUpper2,
-        ddc::SplineSolver Solver,
-        class... DDimX>
+        ddc::SplineSolver Solver>
 class SplineBuilder2D
 {
 public:
@@ -45,40 +44,16 @@ public:
     using memory_space = MemorySpace;
 
     /// @brief The type of the SplineBuilder used by this class to spline-approximate along first dimension.
-    using builder_type1 = ddc::SplineBuilder<
-            ExecSpace,
-            MemorySpace,
-            BSpline1,
-            DDimI1,
-            BcLower1,
-            BcUpper1,
-            Solver,
-            DDimX...>;
+    using builder_type1 = ddc::
+            SplineBuilder<ExecSpace, MemorySpace, BSpline1, DDimI1, BcLower1, BcUpper1, Solver>;
 
     /// @brief The type of the SplineBuilder used by this class to spline-approximate along second dimension.
-    using builder_type2 = ddc::SplineBuilder<
-            ExecSpace,
-            MemorySpace,
-            BSpline2,
-            DDimI2,
-            BcLower2,
-            BcUpper2,
-            Solver,
-            std::conditional_t<std::is_same_v<DDimX, DDimI1>, BSpline1, DDimX>...>;
+    using builder_type2 = ddc::
+            SplineBuilder<ExecSpace, MemorySpace, BSpline2, DDimI2, BcLower2, BcUpper2, Solver>;
 
     /// @brief The type of the SplineBuilder used by this class to spline-approximate the second-dimension-derivatives along first dimension.
-    using builder_deriv_type1 = ddc::SplineBuilder<
-            ExecSpace,
-            MemorySpace,
-            BSpline1,
-            DDimI1,
-            BcLower1,
-            BcUpper1,
-            Solver,
-            std::conditional_t<
-                    std::is_same_v<DDimX, DDimI2>,
-                    typename builder_type2::deriv_type,
-                    DDimX>...>;
+    using builder_deriv_type1 = ddc::
+            SplineBuilder<ExecSpace, MemorySpace, BSpline1, DDimI1, BcLower1, BcUpper1, Solver>;
 
     /// @brief The type of the first interpolation continuous dimension.
     using continuous_dimension_type1 = typename builder_type1::continuous_dimension_type;
@@ -120,6 +95,7 @@ public:
             interpolation_discrete_dimension_type2>;
 
     /// @brief The type of the whole domain representing interpolation points.
+    template <class... DDimX>
     using batched_interpolation_domain_type = ddc::DiscreteDomain<DDimX...>;
 
     /**
@@ -129,8 +105,9 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Z>.
      */
+    template <class... DDimX>
     using batch_domain_type = ddc::remove_dims_of_t<
-            batched_interpolation_domain_type,
+            batched_interpolation_domain_type<DDimX...>,
             interpolation_discrete_dimension_type1,
             interpolation_discrete_dimension_type2>;
 
@@ -141,6 +118,7 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y
      * (associated to B-splines tags BSplinesX and BSplinesY), this is DiscreteDomain<BSplinesX, BSplinesY, Z>
      */
+    template <class... DDimX>
     using batched_spline_domain_type
             = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_replace_t<
                     ddc::detail::TypeSeq<DDimX...>,
@@ -156,7 +134,9 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Deriv<X>, Y, Z>.
      */
-    using batched_derivs_domain_type1 = typename builder_type1::batched_derivs_domain_type;
+    template <class... DDimX>
+    using batched_derivs_domain_type1 =
+            typename builder_type1::template batched_derivs_domain_type<DDimX...>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 1D Deriv domain
@@ -165,8 +145,9 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<X, Deriv<Y>, Z>.
      */
+    template <class... DDimX>
     using batched_derivs_domain_type2 = ddc::replace_dim_of_t<
-            batched_interpolation_domain_type,
+            batched_interpolation_domain_type<DDimX...>,
             interpolation_discrete_dimension_type2,
             deriv_type2>;
 
@@ -177,6 +158,7 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Deriv<X>, Deriv<Y>, Z>.
      */
+    template <class... DDimX>
     using batched_derivs_domain_type
             = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_replace_t<
                     ddc::detail::TypeSeq<DDimX...>,
@@ -208,21 +190,22 @@ public:
      * @see SplinesLinearProblemSparse
      */
     explicit SplineBuilder2D(
-            batched_interpolation_domain_type const& batched_interpolation_domain,
+            interpolation_domain_type const& interpolation_domain,
             std::optional<std::size_t> cols_per_chunk = std::nullopt,
             std::optional<unsigned int> preconditioner_max_block_size = std::nullopt)
-        : m_spline_builder1(
-                  batched_interpolation_domain,
-                  cols_per_chunk,
-                  preconditioner_max_block_size)
-        , m_spline_builder_deriv1(
-                  ddc::replace_dim_of<interpolation_discrete_dimension_type2, deriv_type2>(
-                          m_spline_builder1.batched_interpolation_domain(),
-                          ddc::DiscreteDomain<deriv_type2>(
-                                  ddc::DiscreteElement<deriv_type2>(1),
-                                  ddc::DiscreteVector<deriv_type2>(bsplines_type2::degree() / 2))))
-        , m_spline_builder2(
-                  m_spline_builder1.batched_spline_domain(),
+        : m_spline_builder1(interpolation_domain, cols_per_chunk, preconditioner_max_block_size)
+        , m_spline_builder_deriv1(interpolation_domain)
+        , m_spline_builder2(interpolation_domain, cols_per_chunk, preconditioner_max_block_size)
+    {
+    }
+
+    template <class... DDimX>
+    explicit SplineBuilder2D(
+            batched_interpolation_domain_type<DDimX...> const& batched_interpolation_domain,
+            std::optional<std::size_t> cols_per_chunk = std::nullopt,
+            std::optional<unsigned int> preconditioner_max_block_size = std::nullopt)
+        : SplineBuilder2D(
+                  interpolation_domain_type(batched_interpolation_domain),
                   cols_per_chunk,
                   preconditioner_max_block_size)
     {
@@ -273,9 +256,12 @@ public:
      *
      * @return The domain for the interpolation mesh.
      */
-    batched_interpolation_domain_type batched_interpolation_domain() const noexcept
+    template <class... DDimX>
+    batched_interpolation_domain_type<DDimX...> batched_interpolation_domain(
+            batched_interpolation_domain_type<DDimX...> const& batched_interpolation_domain)
+            const noexcept
     {
-        return m_spline_builder1.batched_interpolation_domain();
+        return batched_interpolation_domain;
     }
 
     /**
@@ -285,9 +271,11 @@ public:
      *
      * @return The batch domain.
      */
-    batch_domain_type batch_domain() const noexcept
+    template <class... DDimX>
+    batch_domain_type<DDimX...> batch_domain(batched_interpolation_domain_type<DDimX...> const&
+                                                     batched_interpolation_domain) const noexcept
     {
-        return ddc::remove_dims_of(batched_interpolation_domain(), interpolation_domain());
+        return ddc::remove_dims_of(batched_interpolation_domain, interpolation_domain());
     }
 
     /**
@@ -311,12 +299,15 @@ public:
      *
      * @return The domain for the spline coefficients.
      */
-    batched_spline_domain_type batched_spline_domain() const noexcept
+    template <class... DDimX>
+    batched_spline_domain_type<DDimX...> batched_spline_domain(
+            batched_interpolation_domain_type<DDimX...> const& batched_interpolation_domain)
+            const noexcept
     {
         return ddc::replace_dim_of<interpolation_discrete_dimension_type1, bsplines_type1>(
                 ddc::replace_dim_of<
                         interpolation_discrete_dimension_type2,
-                        bsplines_type2>(batched_interpolation_domain(), spline_domain()),
+                        bsplines_type2>(batched_interpolation_domain, spline_domain()),
                 spline_domain());
     }
 
@@ -356,42 +347,62 @@ public:
      *      The values of the the cross-derivatives at the upper boundary in the first dimension
      *      and the upper boundary in the second dimension.
      */
-    template <class Layout>
+    template <class Layout, class... DDimX>
     void operator()(
-            ddc::ChunkSpan<double, batched_spline_domain_type, Layout, memory_space> spline,
-            ddc::ChunkSpan<double const, batched_interpolation_domain_type, Layout, memory_space>
-                    vals,
-            std::optional<
-                    ddc::ChunkSpan<double const, batched_derivs_domain_type1, Layout, memory_space>>
-                    derivs_min1
+            ddc::ChunkSpan<double, batched_spline_domain_type<DDimX...>, Layout, memory_space>
+                    spline,
+            ddc::ChunkSpan<
+                    double const,
+                    batched_interpolation_domain_type<DDimX...>,
+                    Layout,
+                    memory_space> vals,
+            std::optional<ddc::ChunkSpan<
+                    double const,
+                    batched_derivs_domain_type1<DDimX...>,
+                    Layout,
+                    memory_space>> derivs_min1
             = std::nullopt,
-            std::optional<
-                    ddc::ChunkSpan<double const, batched_derivs_domain_type1, Layout, memory_space>>
-                    derivs_max1
+            std::optional<ddc::ChunkSpan<
+                    double const,
+                    batched_derivs_domain_type1<DDimX...>,
+                    Layout,
+                    memory_space>> derivs_max1
             = std::nullopt,
-            std::optional<
-                    ddc::ChunkSpan<double const, batched_derivs_domain_type2, Layout, memory_space>>
-                    derivs_min2
+            std::optional<ddc::ChunkSpan<
+                    double const,
+                    batched_derivs_domain_type2<DDimX...>,
+                    Layout,
+                    memory_space>> derivs_min2
             = std::nullopt,
-            std::optional<
-                    ddc::ChunkSpan<double const, batched_derivs_domain_type2, Layout, memory_space>>
-                    derivs_max2
+            std::optional<ddc::ChunkSpan<
+                    double const,
+                    batched_derivs_domain_type2<DDimX...>,
+                    Layout,
+                    memory_space>> derivs_max2
             = std::nullopt,
-            std::optional<
-                    ddc::ChunkSpan<double const, batched_derivs_domain_type, Layout, memory_space>>
-                    mixed_derivs_min1_min2
+            std::optional<ddc::ChunkSpan<
+                    double const,
+                    batched_derivs_domain_type<DDimX...>,
+                    Layout,
+                    memory_space>> mixed_derivs_min1_min2
             = std::nullopt,
-            std::optional<
-                    ddc::ChunkSpan<double const, batched_derivs_domain_type, Layout, memory_space>>
-                    mixed_derivs_max1_min2
+            std::optional<ddc::ChunkSpan<
+                    double const,
+                    batched_derivs_domain_type<DDimX...>,
+                    Layout,
+                    memory_space>> mixed_derivs_max1_min2
             = std::nullopt,
-            std::optional<
-                    ddc::ChunkSpan<double const, batched_derivs_domain_type, Layout, memory_space>>
-                    mixed_derivs_min1_max2
+            std::optional<ddc::ChunkSpan<
+                    double const,
+                    batched_derivs_domain_type<DDimX...>,
+                    Layout,
+                    memory_space>> mixed_derivs_min1_max2
             = std::nullopt,
-            std::optional<
-                    ddc::ChunkSpan<double const, batched_derivs_domain_type, Layout, memory_space>>
-                    mixed_derivs_max1_max2
+            std::optional<ddc::ChunkSpan<
+                    double const,
+                    batched_derivs_domain_type<DDimX...>,
+                    Layout,
+                    memory_space>> mixed_derivs_max1_max2
             = std::nullopt) const;
 };
 
@@ -407,9 +418,8 @@ template <
         ddc::BoundCond BcUpper1,
         ddc::BoundCond BcLower2,
         ddc::BoundCond BcUpper2,
-        ddc::SplineSolver Solver,
-        class... DDimX>
-template <class Layout>
+        ddc::SplineSolver Solver>
+template <class Layout, class... DDimX>
 void SplineBuilder2D<
         ExecSpace,
         MemorySpace,
@@ -421,56 +431,67 @@ void SplineBuilder2D<
         BcUpper1,
         BcLower2,
         BcUpper2,
-        Solver,
-        DDimX...>::
+        Solver>::
 operator()(
-        ddc::ChunkSpan<double, batched_spline_domain_type, Layout, memory_space> spline,
-        ddc::ChunkSpan<double const, batched_interpolation_domain_type, Layout, memory_space> vals,
+        ddc::ChunkSpan<double, batched_spline_domain_type<DDimX...>, Layout, memory_space> spline,
+        ddc::ChunkSpan<
+                double const,
+                batched_interpolation_domain_type<DDimX...>,
+                Layout,
+                memory_space> vals,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1,
+                batched_derivs_domain_type1<DDimX...>,
                 Layout,
                 memory_space>> const derivs_min1,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1,
+                batched_derivs_domain_type1<DDimX...>,
                 Layout,
                 memory_space>> const derivs_max1,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type2,
+                batched_derivs_domain_type2<DDimX...>,
                 Layout,
                 memory_space>> const derivs_min2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type2,
+                batched_derivs_domain_type2<DDimX...>,
                 Layout,
                 memory_space>> const derivs_max2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type,
+                batched_derivs_domain_type<DDimX...>,
                 Layout,
                 memory_space>> const mixed_derivs_min1_min2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type,
+                batched_derivs_domain_type<DDimX...>,
                 Layout,
                 memory_space>> const mixed_derivs_max1_min2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type,
+                batched_derivs_domain_type<DDimX...>,
                 Layout,
                 memory_space>> const mixed_derivs_min1_max2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type,
+                batched_derivs_domain_type<DDimX...>,
                 Layout,
                 memory_space>> const mixed_derivs_max1_max2) const
 {
     // TODO: perform computations along dimension 1 on different streams ?
     // Spline1-approximate derivs_min2 (to spline1_deriv_min)
+
+    auto const batched_interpolation_deriv_domain
+            = ddc::replace_dim_of<interpolation_discrete_dimension_type2, deriv_type2>(
+                    vals.domain(),
+                    ddc::DiscreteDomain<deriv_type2>(
+                            ddc::DiscreteElement<deriv_type2>(1),
+                            ddc::DiscreteVector<deriv_type2>(bsplines_type2::degree() / 2)));
+
     ddc::Chunk spline1_deriv_min_alloc(
-            m_spline_builder_deriv1.batched_spline_domain(),
+            m_spline_builder_deriv1.batched_spline_domain(batched_interpolation_deriv_domain),
             ddc::KokkosAllocator<double, MemorySpace>());
     auto spline1_deriv_min = spline1_deriv_min_alloc.span_view();
     auto spline1_deriv_min_opt = std::optional(spline1_deriv_min.span_cview());
@@ -486,7 +507,7 @@ operator()(
 
     // Spline1-approximate vals (to spline1)
     ddc::Chunk spline1_alloc(
-            m_spline_builder1.batched_spline_domain(),
+            m_spline_builder1.batched_spline_domain(vals.domain()),
             ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const spline1 = spline1_alloc.span_view();
 
@@ -494,7 +515,7 @@ operator()(
 
     // Spline1-approximate derivs_max2 (to spline1_deriv_max)
     ddc::Chunk spline1_deriv_max_alloc(
-            m_spline_builder_deriv1.batched_spline_domain(),
+            m_spline_builder_deriv1.batched_spline_domain(batched_interpolation_deriv_domain),
             ddc::KokkosAllocator<double, MemorySpace>());
     auto spline1_deriv_max = spline1_deriv_max_alloc.span_view();
     auto spline1_deriv_max_opt = std::optional(spline1_deriv_max.span_cview());

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 #include <optional>
 #include <type_traits>
@@ -99,8 +100,10 @@ public:
      *
      * @tparam The batched discrete domain on which the interpolation points are defined.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    using batched_interpolation_domain_type = DDom;
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using batched_interpolation_domain_type = BatchedInterpolationDDom;
 
     /**
      * @brief The type of the batch domain (obtained by removing the dimensions of interest
@@ -111,9 +114,11 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Z>.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
     using batch_domain_type = ddc::remove_dims_of_t<
-            DDom,
+            BatchedInterpolationDDom,
             interpolation_discrete_dimension_type1,
             interpolation_discrete_dimension_type2>;
 
@@ -126,10 +131,12 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y
      * (associated to B-splines tags BSplinesX and BSplinesY), this is DiscreteDomain<BSplinesX, BSplinesY, Z>
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
     using batched_spline_domain_type
             = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_replace_t<
-                    ddc::to_type_seq_t<DDom>,
+                    ddc::to_type_seq_t<BatchedInterpolationDDom>,
                     ddc::detail::TypeSeq<
                             interpolation_discrete_dimension_type1,
                             interpolation_discrete_dimension_type2>,
@@ -144,9 +151,11 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Deriv<X>, Y, Z>.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
     using batched_derivs_domain_type1 =
-            typename builder_type1::template batched_derivs_domain_type<DDom>;
+            typename builder_type1::template batched_derivs_domain_type<BatchedInterpolationDDom>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 1D Deriv domain
@@ -157,9 +166,13 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<X, Deriv<Y>, Z>.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    using batched_derivs_domain_type2
-            = ddc::replace_dim_of_t<DDom, interpolation_discrete_dimension_type2, deriv_type2>;
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    using batched_derivs_domain_type2 = ddc::replace_dim_of_t<
+            BatchedInterpolationDDom,
+            interpolation_discrete_dimension_type2,
+            deriv_type2>;
 
     /**
      * @brief The type of the whole Derivs domain (cartesian product of the 2D Deriv domain
@@ -170,10 +183,12 @@ public:
      * Example: For batched_interpolation_domain_type = DiscreteDomain<X,Y,Z> and dimensions of interest X and Y,
      * this is DiscreteDomain<Deriv<X>, Deriv<Y>, Z>.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
     using batched_derivs_domain_type
             = ddc::detail::convert_type_seq_to_discrete_domain_t<ddc::type_seq_replace_t<
-                    ddc::to_type_seq_t<DDom>,
+                    ddc::to_type_seq_t<BatchedInterpolationDDom>,
                     ddc::detail::TypeSeq<
                             interpolation_discrete_dimension_type1,
                             interpolation_discrete_dimension_type2>,
@@ -227,9 +242,11 @@ public:
      *
      * @see SplinesLinearProblemSparse
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
     explicit SplineBuilder2D(
-            DDom const& batched_interpolation_domain,
+            BatchedInterpolationDDom const& batched_interpolation_domain,
             std::optional<std::size_t> cols_per_chunk = std::nullopt,
             std::optional<unsigned int> preconditioner_max_block_size = std::nullopt)
         : SplineBuilder2D(
@@ -286,9 +303,13 @@ public:
      *
      * @return The domain for the interpolation mesh.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    DDom batched_interpolation_domain(DDom const& batched_interpolation_domain) const noexcept
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    BatchedInterpolationDDom batched_interpolation_domain(
+            BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
+        assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
         return batched_interpolation_domain;
     }
 
@@ -301,9 +322,13 @@ public:
      *
      * @return The batch domain.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    batch_domain_type<DDom> batch_domain(DDom const& batched_interpolation_domain) const noexcept
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    batch_domain_type<BatchedInterpolationDDom> batch_domain(
+            BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
+        assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
         return ddc::remove_dims_of(batched_interpolation_domain, interpolation_domain());
     }
 
@@ -330,10 +355,13 @@ public:
      *
      * @return The domain for the spline coefficients.
      */
-    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
-    batched_spline_domain_type<DDom> batched_spline_domain(
-            DDom const& batched_interpolation_domain) const noexcept
+    template <
+            class BatchedInterpolationDDom,
+            class = std::enable_if_t<ddc::is_discrete_domain_v<BatchedInterpolationDDom>>>
+    batched_spline_domain_type<BatchedInterpolationDDom> batched_spline_domain(
+            BatchedInterpolationDDom const& batched_interpolation_domain) const noexcept
     {
+        assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
         return ddc::replace_dim_of<interpolation_discrete_dimension_type1, bsplines_type1>(
                 ddc::replace_dim_of<
                         interpolation_discrete_dimension_type2,
@@ -377,55 +405,59 @@ public:
      *      The values of the the cross-derivatives at the upper boundary in the first dimension
      *      and the upper boundary in the second dimension.
      */
-    template <class Layout, class DDom>
+    template <class Layout, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<double, batched_spline_domain_type<DDom>, Layout, memory_space> spline,
-            ddc::ChunkSpan<double const, DDom, Layout, memory_space> vals,
+            ddc::ChunkSpan<
+                    double,
+                    batched_spline_domain_type<BatchedInterpolationDDom>,
+                    Layout,
+                    memory_space> spline,
+            ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type1<DDom>,
+                    batched_derivs_domain_type1<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_min1
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type1<DDom>,
+                    batched_derivs_domain_type1<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_max1
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type2<DDom>,
+                    batched_derivs_domain_type2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type2<DDom>,
+                    batched_derivs_domain_type2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_max2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDom>,
+                    batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDom>,
+                    batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDom>,
+                    batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_max2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
                     double const,
-                    batched_derivs_domain_type<DDom>,
+                    batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_max2
             = std::nullopt) const;
@@ -444,7 +476,7 @@ template <
         ddc::BoundCond BcLower2,
         ddc::BoundCond BcUpper2,
         ddc::SplineSolver Solver>
-template <class Layout, class DDom>
+template <class Layout, class BatchedInterpolationDDom>
 void SplineBuilder2D<
         ExecSpace,
         MemorySpace,
@@ -458,55 +490,63 @@ void SplineBuilder2D<
         BcUpper2,
         Solver>::
 operator()(
-        ddc::ChunkSpan<double, batched_spline_domain_type<DDom>, Layout, memory_space> spline,
-        ddc::ChunkSpan<double const, DDom, Layout, memory_space> vals,
+        ddc::ChunkSpan<
+                double,
+                batched_spline_domain_type<BatchedInterpolationDDom>,
+                Layout,
+                memory_space> spline,
+        ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1<DDom>,
+                batched_derivs_domain_type1<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_min1,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type1<DDom>,
+                batched_derivs_domain_type1<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_max1,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type2<DDom>,
+                batched_derivs_domain_type2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_min2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type2<DDom>,
+                batched_derivs_domain_type2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_max2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDom>,
+                batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const mixed_derivs_min1_min2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDom>,
+                batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const mixed_derivs_max1_min2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDom>,
+                batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const mixed_derivs_min1_max2,
         std::optional<ddc::ChunkSpan<
                 double const,
-                batched_derivs_domain_type<DDom>,
+                batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const mixed_derivs_max1_max2) const
 {
+    auto const batched_interpolation_domain = vals.domain();
+
+    assert(interpolation_domain() == interpolation_domain_type(batched_interpolation_domain));
+
     // TODO: perform computations along dimension 1 on different streams ?
     // Spline1-approximate derivs_min2 (to spline1_deriv_min)
 
     auto const batched_interpolation_deriv_domain
             = ddc::replace_dim_of<interpolation_discrete_dimension_type2, deriv_type2>(
-                    vals.domain(),
+                    batched_interpolation_domain,
                     ddc::DiscreteDomain<deriv_type2>(
                             ddc::DiscreteElement<deriv_type2>(1),
                             ddc::DiscreteVector<deriv_type2>(bsplines_type2::degree() / 2)));
@@ -528,7 +568,7 @@ operator()(
 
     // Spline1-approximate vals (to spline1)
     ddc::Chunk spline1_alloc(
-            m_spline_builder1.batched_spline_domain(vals.domain()),
+            m_spline_builder1.batched_spline_domain(batched_interpolation_domain),
             ddc::KokkosAllocator<double, MemorySpace>());
     ddc::ChunkSpan const spline1 = spline1_alloc.span_view();
 

--- a/include/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/include/ddc/kernels/splines/spline_builder_2d.hpp
@@ -174,7 +174,7 @@ private:
 
 public:
     /**
-     * @brief Build a SplineBuilder2D acting on batched_interpolation_domain.
+     * @brief Build a SplineBuilder2D acting on interpolation_domain.
      *
      * @param batched_interpolation_domain The domain on which the interpolation points are defined.
      *
@@ -199,6 +199,22 @@ public:
     {
     }
 
+    /**
+     * @brief Build a SplineBuilder2D acting on the interpolation domain contained in batched_interpolation_domain.
+     *
+     * @param batched_interpolation_domain The domain on which the interpolation points are defined.
+     *
+     * @param cols_per_chunk A parameter used by the slicer (internal to the solver) to define the size
+     * of a chunk of right-hand-sides of the linear problem to be computed in parallel (chunks are treated
+     * by the linear solver one-after-the-other).
+     * This value is optional. If no value is provided then the default value is chosen by the requested solver.
+     *
+     * @param preconditioner_max_block_size A parameter used by the slicer (internal to the solver) to
+     * define the size of a block used by the Block-Jacobi preconditioner.
+     * This value is optional. If no value is provided then the default value is chosen by the requested solver.
+     *
+     * @see SplinesLinearProblemSparse
+     */
     template <class... DDimX>
     explicit SplineBuilder2D(
             batched_interpolation_domain_type<DDimX...> const& batched_interpolation_domain,

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -73,9 +73,13 @@ public:
     /// @brief The type of the domain for the 1D evaluation mesh used by this class.
     using evaluation_domain_type = ddc::DiscreteDomain<evaluation_discrete_dimension_type>;
 
-    /// @brief The type of the whole domain representing evaluation points.
-    template <class... DDimX>
-    using batched_evaluation_domain_type = ddc::DiscreteDomain<DDimX...>;
+    /**
+     * @brief The type of the whole domain representing evaluation points.
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
+     */
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    using batched_evaluation_domain_type = DDom;
 
     /// @brief The type of the 1D spline domain corresponding to the dimension of interest.
     using spline_domain_type = ddc::DiscreteDomain<bsplines_type>;
@@ -83,21 +87,21 @@ public:
     /**
      * @brief The type of the batch domain (obtained by removing the dimension of interest
      * from the whole domain).
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
      */
-    template <class... DDimX>
-    using batch_domain_type = ddc::remove_dims_of_t<
-            batched_evaluation_domain_type<DDimX...>,
-            evaluation_discrete_dimension_type>;
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    using batch_domain_type = ddc::remove_dims_of_t<DDom, evaluation_discrete_dimension_type>;
 
     /**
      * @brief The type of the whole spline domain (cartesian product of 1D spline domain
      * and batch domain) preserving the order of dimensions.
+     *
+     * @tparam The batched discrete domain on which the interpolation points are defined.
      */
-    template <class... DDimX>
-    using batched_spline_domain_type = ddc::replace_dim_of_t<
-            batched_evaluation_domain_type<DDimX...>,
-            evaluation_discrete_dimension_type,
-            bsplines_type>;
+    template <class DDom, class = std::enable_if_t<ddc::is_discrete_domain_v<DDom>>>
+    using batched_spline_domain_type
+            = ddc::replace_dim_of_t<DDom, evaluation_discrete_dimension_type, bsplines_type>;
 
     /// @brief The type of the extrapolation rule at the lower boundary.
     using lower_extrapolation_rule_type = LowerExtrapolationRule;
@@ -262,33 +266,26 @@ public:
      * the set of 1D spline coefficients retained to perform the evaluation).
      * @param[in] spline_coef A ChunkSpan storing the spline coefficients.
      */
-    template <class Layout1, class Layout2, class Layout3, class... CoordsDims, class... DDimX>
+    template <class Layout1, class Layout2, class Layout3, class DDom, class... CoordsDims>
     void operator()(
-            ddc::ChunkSpan<
-                    double,
-                    batched_evaluation_domain_type<DDimX...>,
-                    Layout1,
-                    memory_space> const spline_eval,
-            ddc::ChunkSpan<
-                    ddc::Coordinate<CoordsDims...> const,
-                    batched_evaluation_domain_type<DDimX...>,
-                    Layout2,
-                    memory_space> const coords_eval,
+            ddc::ChunkSpan<double, DDom, Layout1, memory_space> const spline_eval,
+            ddc::ChunkSpan<ddc::Coordinate<CoordsDims...> const, DDom, Layout2, memory_space> const
+                    coords_eval,
             ddc::ChunkSpan<
                     double const,
-                    batched_spline_domain_type<DDimX...>,
+                    batched_spline_domain_type<DDom>,
                     Layout3,
                     memory_space> const spline_coef) const
     {
         evaluation_domain_type const evaluation_domain(spline_eval.domain());
-        batch_domain_type<DDimX...> const batch_domain(spline_eval.domain());
+        batch_domain_type<DDom> const batch_domain(spline_eval.domain());
 
         ddc::parallel_for_each(
                 "ddc_splines_evaluate",
                 exec_space(),
                 batch_domain,
                 KOKKOS_CLASS_LAMBDA(
-                        typename batch_domain_type<DDimX...>::discrete_element_type const j) {
+                        typename batch_domain_type<DDom>::discrete_element_type const j) {
                     const auto spline_eval_1D = spline_eval[j];
                     const auto coords_eval_1D = coords_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
@@ -316,28 +313,24 @@ public:
      * of the mesh.
      * @param[in] spline_coef A ChunkSpan storing the spline coefficients.
      */
-    template <class Layout1, class Layout2, class... DDimX>
+    template <class Layout1, class Layout2, class DDom>
     void operator()(
-            ddc::ChunkSpan<
-                    double,
-                    batched_evaluation_domain_type<DDimX...>,
-                    Layout1,
-                    memory_space> const spline_eval,
+            ddc::ChunkSpan<double, DDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     double const,
-                    batched_spline_domain_type<DDimX...>,
+                    batched_spline_domain_type<DDom>,
                     Layout2,
                     memory_space> const spline_coef) const
     {
         evaluation_domain_type const evaluation_domain(spline_eval.domain());
-        batch_domain_type<DDimX...> const batch_domain(spline_eval.domain());
+        batch_domain_type<DDom> const batch_domain(spline_eval.domain());
 
         ddc::parallel_for_each(
                 "ddc_splines_evaluate",
                 exec_space(),
                 batch_domain,
                 KOKKOS_CLASS_LAMBDA(
-                        typename batch_domain_type<DDimX...>::discrete_element_type const j) {
+                        typename batch_domain_type<DDom>::discrete_element_type const j) {
                     const auto spline_eval_1D = spline_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
                     for (auto const i : evaluation_domain) {
@@ -386,33 +379,26 @@ public:
      * the set of 1D spline coefficients retained to perform the evaluation).
      * @param[in] spline_coef A ChunkSpan storing the spline coefficients.
      */
-    template <class Layout1, class Layout2, class Layout3, class... CoordsDims, class... DDimX>
+    template <class Layout1, class Layout2, class Layout3, class DDom, class... CoordsDims>
     void deriv(
-            ddc::ChunkSpan<
-                    double,
-                    batched_evaluation_domain_type<DDimX...>,
-                    Layout1,
-                    memory_space> const spline_eval,
-            ddc::ChunkSpan<
-                    ddc::Coordinate<CoordsDims...> const,
-                    batched_evaluation_domain_type<DDimX...>,
-                    Layout2,
-                    memory_space> const coords_eval,
+            ddc::ChunkSpan<double, DDom, Layout1, memory_space> const spline_eval,
+            ddc::ChunkSpan<ddc::Coordinate<CoordsDims...> const, DDom, Layout2, memory_space> const
+                    coords_eval,
             ddc::ChunkSpan<
                     double const,
-                    batched_spline_domain_type<DDimX...>,
+                    batched_spline_domain_type<DDom>,
                     Layout3,
                     memory_space> const spline_coef) const
     {
         evaluation_domain_type const evaluation_domain(spline_eval.domain());
-        batch_domain_type<DDimX...> const batch_domain(spline_eval.domain());
+        batch_domain_type<DDom> const batch_domain(spline_eval.domain());
 
         ddc::parallel_for_each(
                 "ddc_splines_differentiate",
                 exec_space(),
                 batch_domain,
                 KOKKOS_CLASS_LAMBDA(
-                        typename batch_domain_type<DDimX...>::discrete_element_type const j) {
+                        typename batch_domain_type<DDom>::discrete_element_type const j) {
                     const auto spline_eval_1D = spline_eval[j];
                     const auto coords_eval_1D = coords_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
@@ -437,28 +423,24 @@ public:
      * @param[out] spline_eval The derivatives of the spline function at the coordinates.
      * @param[in] spline_coef A ChunkSpan storing the spline coefficients.
      */
-    template <class Layout1, class Layout2, class... DDimX>
+    template <class Layout1, class Layout2, class DDom>
     void deriv(
-            ddc::ChunkSpan<
-                    double,
-                    batched_evaluation_domain_type<DDimX...>,
-                    Layout1,
-                    memory_space> const spline_eval,
+            ddc::ChunkSpan<double, DDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     double const,
-                    batched_spline_domain_type<DDimX...>,
+                    batched_spline_domain_type<DDom>,
                     Layout2,
                     memory_space> const spline_coef) const
     {
         evaluation_domain_type const evaluation_domain(spline_eval.domain());
-        batch_domain_type<DDimX...> const batch_domain(spline_eval.domain());
+        batch_domain_type<DDom> const batch_domain(spline_eval.domain());
 
         ddc::parallel_for_each(
                 "ddc_splines_differentiate",
                 exec_space(),
                 batch_domain,
                 KOKKOS_CLASS_LAMBDA(
-                        typename batch_domain_type<DDimX...>::discrete_element_type const j) {
+                        typename batch_domain_type<DDom>::discrete_element_type const j) {
                     const auto spline_eval_1D = spline_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
                     for (auto const i : evaluation_domain) {
@@ -483,17 +465,21 @@ public:
      * points represented by this domain are unused and irrelevant.
      * @param[in] spline_coef A ChunkSpan storing the spline coefficients.
      */
-    template <class... DDimX, class Layout1, class Layout2>
+    template <class Layout1, class Layout2, class BatchedSplineDDom, class BatchDDom>
     void integrate(
-            ddc::ChunkSpan<double, batch_domain_type<DDimX...>, Layout1, memory_space> const
-                    integrals,
-            ddc::ChunkSpan<
-                    double const,
-                    batched_spline_domain_type<DDimX...>,
-                    Layout2,
-                    memory_space> const spline_coef) const
+            ddc::ChunkSpan<double, BatchDDom, Layout1, memory_space> const integrals,
+            ddc::ChunkSpan<double const, BatchedSplineDDom, Layout2, memory_space> const
+                    spline_coef) const
     {
-        batch_domain_type<DDimX...> const batch_domain(integrals.domain());
+        static_assert(
+                ddc::in_tags_v<bsplines_type, to_type_seq_t<BatchedSplineDDom>>,
+                "The spline coefficients domain must contain the bsplines dimension");
+        using batch_domain_type = ddc::remove_dims_of_t<BatchedSplineDDom, bsplines_type>;
+        static_assert(
+                std::is_same_v<batch_domain_type, BatchDDom>,
+                "The integrals domain must only contain the batch dimensions");
+
+        BatchDDom const batch_domain(integrals.domain());
         ddc::Chunk values_alloc(
                 ddc::DiscreteDomain<bsplines_type>(spline_coef.domain()),
                 ddc::KokkosAllocator<double, memory_space>());
@@ -504,7 +490,7 @@ public:
                 "ddc_splines_integrate",
                 exec_space(),
                 batch_domain,
-                KOKKOS_LAMBDA(typename batch_domain_type<DDimX...>::discrete_element_type const j) {
+                KOKKOS_LAMBDA(typename BatchDDom::discrete_element_type const j) {
                     integrals(j) = 0;
                     for (typename spline_domain_type::discrete_element_type const i :
                          values.domain()) {

--- a/tests/splines/CMakeLists.txt
+++ b/tests/splines/CMakeLists.txt
@@ -142,3 +142,47 @@ foreach(BC "BC_PERIODIC" "BC_GREVILLE" "BC_HERMITE")
         endforeach()
     endforeach()
 endforeach()
+
+foreach(SOLVER "GINKGO" "LAPACK")
+    foreach(BC "BC_PERIODIC" "BC_GREVILLE" "BC_HERMITE")
+        foreach(DEGREE_X RANGE "${DDC_SPLINES_TEST_DEGREE_MIN}" "${DDC_SPLINES_TEST_DEGREE_MAX}")
+            foreach(BSPLINES_TYPE "BSPLINES_TYPE_UNIFORM" "BSPLINES_TYPE_NON_UNIFORM")
+                set(test_name
+                    "splines_tests_BATCHED_MULTIPLE_DOMAINS_DEGREE_X_${DEGREE_X}_${BSPLINES_TYPE}_${BC}_${SOLVER}"
+                )
+                add_executable("${test_name}" ../main.cpp multiple_batch_domain_spline_builder.cpp)
+                target_compile_definitions(
+                    "${test_name}"
+                    PUBLIC -DDEGREE_X=${DEGREE_X} -D${BSPLINES_TYPE} -D${BC} -DSOLVER_${SOLVER}
+                )
+                target_compile_features("${test_name}" PUBLIC cxx_std_17)
+                target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
+                gtest_discover_tests("${test_name}" DISCOVERY_MODE PRE_TEST)
+            endforeach()
+        endforeach()
+    endforeach()
+endforeach()
+
+foreach(BC "BC_PERIODIC" "BC_GREVILLE" "BC_HERMITE")
+    foreach(EVALUATOR "EVALUATOR_POLYNOMIAL")
+        foreach(DEGREE RANGE "${DDC_SPLINES_TEST_DEGREE_MIN}" "${DDC_SPLINES_TEST_DEGREE_MAX}")
+            foreach(BSPLINES_TYPE "BSPLINES_TYPE_UNIFORM" "BSPLINES_TYPE_NON_UNIFORM")
+                set(test_name
+                    "2d_splines_tests_BATCHED_MULTIPLE_DOMAINS_DEGREE_${DEGREE}_${BSPLINES_TYPE}_${EVALUATOR}_${BC}"
+                )
+                add_executable(
+                    "${test_name}"
+                    ../main.cpp
+                    multiple_batch_domain_2d_spline_builder.cpp
+                )
+                target_compile_definitions(
+                    "${test_name}"
+                    PUBLIC -DDEGREE=${DEGREE} -D${BSPLINES_TYPE} -D${EVALUATOR} -D${BC}
+                )
+                target_compile_features("${test_name}" PUBLIC cxx_std_17)
+                target_link_libraries("${test_name}" PUBLIC DDC::core DDC::splines GTest::gtest)
+                gtest_discover_tests("${test_name}" DISCOVERY_MODE PRE_TEST)
+            endforeach()
+        endforeach()
+    endforeach()
+endforeach()

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -471,8 +471,7 @@ void Batched2dSplineTest()
             extrapolation_rule_1_type,
             extrapolation_rule_1_type,
             extrapolation_rule_2_type,
-            extrapolation_rule_2_type,
-            DDims...> const
+            extrapolation_rule_2_type> const
             spline_evaluator(
                     extrapolation_rule_1,
                     extrapolation_rule_1,

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -220,13 +220,12 @@ void Batched2dSplineTest()
             s_bcr,
             s_bcl,
             s_bcr,
-            ddc::SplineSolver::GINKGO,
-            DDims...> const spline_builder(dom_vals);
+            ddc::SplineSolver::GINKGO> const spline_builder(dom_vals);
 
     // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI1, DDimI2> const dom_interpolation
             = spline_builder.interpolation_domain();
-    auto const dom_spline = spline_builder.batched_spline_domain();
+    auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -308,7 +308,8 @@ void BatchedSplineTest()
             BSplines<I>,
             DDimI,
             extrapolation_rule_type,
-            extrapolation_rule_type> const spline_evaluator_batched(extrapolation_rule, extrapolation_rule);
+            extrapolation_rule_type> const
+            spline_evaluator_batched(extrapolation_rule, extrapolation_rule);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<I>, MemorySpace>());
@@ -332,7 +333,7 @@ void BatchedSplineTest()
     // Call spline_evaluator on the same mesh we started with
     spline_evaluator_batched(spline_eval, coords_eval.span_cview(), coef.span_cview());
     spline_evaluator_batched.deriv(spline_eval_deriv, coords_eval.span_cview(), coef.span_cview());
-    spline_evaluator_batched.template integrate<DDims...>(spline_eval_integrals, coef.span_cview());
+    spline_evaluator_batched.integrate(spline_eval_integrals, coef.span_cview());
 
     // Checking errors (we recover the initial values)
     double const max_norm_error = ddc::parallel_transform_reduce(
@@ -359,7 +360,7 @@ void BatchedSplineTest()
             0.,
             ddc::reducer::max<double>(),
             KOKKOS_LAMBDA(typename decltype(spline_builder)::template batch_domain_type<
-                          DDims...>::discrete_element_type const e) {
+                          ddc::DiscreteDomain<DDims...>>::discrete_element_type const e) {
                 return Kokkos::abs(
                         spline_eval_integrals(e) - evaluator.deriv(xN<I>(), -1)
                         + evaluator.deriv(x0<I>(), -1));

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -204,16 +204,16 @@ void BatchedSplineTest()
             s_bcl,
             s_bcr,
 #if defined(SOLVER_LAPACK)
-            ddc::SplineSolver::LAPACK,
+            ddc::SplineSolver::LAPACK
 #elif defined(SOLVER_GINKGO)
-            ddc::SplineSolver::GINKGO,
+            ddc::SplineSolver::GINKGO
 #endif
-            DDims...> const spline_builder(dom_vals);
+            > const spline_builder(dom_vals);
 
     // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI> const dom_interpolation = spline_builder.interpolation_domain();
-    auto const dom_batch = spline_builder.batch_domain();
-    auto const dom_spline = spline_builder.batched_spline_domain();
+    auto const dom_batch = spline_builder.batch_domain(dom_vals);
+    auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
@@ -359,8 +359,8 @@ void BatchedSplineTest()
             spline_eval_integrals.domain(),
             0.,
             ddc::reducer::max<double>(),
-            KOKKOS_LAMBDA(typename decltype(spline_builder)::batch_domain_type::
-                                  discrete_element_type const e) {
+            KOKKOS_LAMBDA(typename decltype(spline_builder)::template batch_domain_type<
+                          DDims...>::discrete_element_type const e) {
                 return Kokkos::abs(
                         spline_eval_integrals(e) - evaluator.deriv(xN<I>(), -1)
                         + evaluator.deriv(x0<I>(), -1));

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -308,8 +308,7 @@ void BatchedSplineTest()
             BSplines<I>,
             DDimI,
             extrapolation_rule_type,
-            extrapolation_rule_type,
-            DDims...> const spline_evaluator_batched(extrapolation_rule, extrapolation_rule);
+            extrapolation_rule_type> const spline_evaluator_batched(extrapolation_rule, extrapolation_rule);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<I>, MemorySpace>());
@@ -333,7 +332,7 @@ void BatchedSplineTest()
     // Call spline_evaluator on the same mesh we started with
     spline_evaluator_batched(spline_eval, coords_eval.span_cview(), coef.span_cview());
     spline_evaluator_batched.deriv(spline_eval_deriv, coords_eval.span_cview(), coef.span_cview());
-    spline_evaluator_batched.integrate(spline_eval_integrals, coef.span_cview());
+    spline_evaluator_batched.template integrate<DDims...>(spline_eval_integrals, coef.span_cview());
 
     // Checking errors (we recover the initial values)
     double const max_norm_error = ddc::parallel_transform_reduce(

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -191,7 +191,7 @@ void ExtrapolationRuleSplineTest()
             s_bcr1,
             s_bcl2,
             s_bcr2,
-            ddc::SplineSolver::GINKGO> const spline_builder(dom_vals);
+            ddc::SplineSolver::GINKGO> const spline_builder(interpolation_domain);
 
     // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI1, DDimI2> const dom_interpolation

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -191,13 +191,12 @@ void ExtrapolationRuleSplineTest()
             s_bcr1,
             s_bcl2,
             s_bcr2,
-            ddc::SplineSolver::GINKGO,
-            DDims...> const spline_builder(dom_vals);
+            ddc::SplineSolver::GINKGO> const spline_builder(dom_vals);
 
     // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI1, DDimI2> const dom_interpolation
             = spline_builder.interpolation_domain();
-    auto const dom_spline = spline_builder.batched_spline_domain();
+    auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -266,8 +266,7 @@ void ExtrapolationRuleSplineTest()
             extrapolation_rule_dim_1_type,
             extrapolation_rule_dim_1_type,
             extrapolation_rule_dim_2_type,
-            extrapolation_rule_dim_2_type,
-            DDims...> const
+            extrapolation_rule_dim_2_type> const
             spline_evaluator_batched(
                     extrapolation_rule_left_dim_1,
                     extrapolation_rule_right_dim_1,

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -709,18 +709,7 @@ void MultipleBatchDomain2dSplineTest()
 #define SUFFIX(name) name##Hermite##NonUniform
 #endif
 
-TEST(SUFFIX(MultipleBatchDomain2dSplineHost), 2DXY)
-{
-    MultipleBatchDomain2dSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimX>,
-            DDimGPS<DimY>,
-            DDimGPS<DimX>,
-            DDimGPS<DimY>>();
-}
-
-TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 2DXY)
+TEST(SUFFIX(MultipleBatchDomain2dSpline), 2DXY)
 {
     MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultExecutionSpace,
@@ -731,43 +720,7 @@ TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 2DXY)
             DDimGPS<DimY>>();
 }
 
-TEST(SUFFIX(MultipleBatchDomain2dSplineHost), 3DXY)
-{
-    MultipleBatchDomain2dSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimX>,
-            DDimGPS<DimY>,
-            DDimGPS<DimX>,
-            DDimGPS<DimY>,
-            DDimBatch>();
-}
-
-TEST(SUFFIX(MultipleBatchDomain2dSplineHost), 3DXZ)
-{
-    MultipleBatchDomain2dSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimX>,
-            DDimGPS<DimZ>,
-            DDimGPS<DimX>,
-            DDimBatch,
-            DDimGPS<DimZ>>();
-}
-
-TEST(SUFFIX(MultipleBatchDomain2dSplineHost), 3DYZ)
-{
-    MultipleBatchDomain2dSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimY>,
-            DDimGPS<DimZ>,
-            DDimBatch,
-            DDimGPS<DimY>,
-            DDimGPS<DimZ>>();
-}
-
-TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 3DXY)
+TEST(SUFFIX(MultipleBatchDomain2dSpline), 3DXY)
 {
     MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultExecutionSpace,
@@ -779,7 +732,7 @@ TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 3DXY)
             DDimBatch>();
 }
 
-TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 3DXZ)
+TEST(SUFFIX(MultipleBatchDomain2dSpline), 3DXZ)
 {
     MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultExecutionSpace,
@@ -791,7 +744,7 @@ TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 3DXZ)
             DDimGPS<DimZ>>();
 }
 
-TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 3DYZ)
+TEST(SUFFIX(MultipleBatchDomain2dSpline), 3DYZ)
 {
     MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultExecutionSpace,

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <tuple>
 #if defined(BC_HERMITE)
 #include <optional>
 #endif
@@ -63,6 +64,10 @@ struct DimZ
 #endif
 
 struct DDimBatch
+{
+};
+
+struct DDimBatchExtra
 {
 };
 
@@ -162,37 +167,26 @@ void InterestDimInitializer(std::size_t const ncells)
     ddc::init_discrete_space<DDim>(GrevillePoints<BSplines<CDim>>::template get_sampling<DDim>());
 }
 
-// Checks that when evaluating the spline at interpolation points one
-// recovers values that were used to build the spline
+/// Computes the evaluation error when evaluating a 2D spline on its interpolation points.
 template <
         typename ExecSpace,
         typename MemorySpace,
         typename DDimI1,
         typename DDimI2,
+        typename Builder,
+        typename Evaluator,
         typename... DDims>
-void Batched2dSplineTest()
+std::tuple<double, double, double, double> ComputeEvaluationError(
+        ExecSpace const& exec_space,
+        ddc::DiscreteDomain<DDims...> const& dom_vals,
+        ddc::DiscreteDomain<DDimI1> const& interpolation_domain1,
+        ddc::DiscreteDomain<DDimI2> const& interpolation_domain2,
+        Builder const& spline_builder,
+        Evaluator const& spline_evaluator,
+        evaluator_type<DDimI1, DDimI2> const& evaluator)
 {
     using I1 = typename DDimI1::continuous_dimension_type;
     using I2 = typename DDimI2::continuous_dimension_type;
-
-    // Instantiate execution spaces and initialize spaces
-    ExecSpace const exec_space;
-    std::size_t const ncells = 10;
-    InterestDimInitializer<DDimI1>(ncells);
-    InterestDimInitializer<DDimI2>(ncells);
-
-    // Create the values domain (mesh)
-    ddc::DiscreteDomain<DDimI1> const interpolation_domain1
-            = GrevillePoints<BSplines<I1>>::template get_domain<DDimI1>();
-    ddc::DiscreteDomain<DDimI2> const interpolation_domain2
-            = GrevillePoints<BSplines<I2>>::template get_domain<DDimI2>();
-    ddc::DiscreteDomain<DDimI1, DDimI2> const
-            interpolation_domain(interpolation_domain1, interpolation_domain2);
-    // The following line creates a discrete domain over all dimensions (DDims...) except DDimI1 and DDimI2.
-    auto const dom_vals_tmp = ddc::remove_dims_of_t<ddc::DiscreteDomain<DDims...>, DDimI1, DDimI2>(
-            ddc::DiscreteDomain<DDims>(DElem<DDims>(0), DVect<DDims>(ncells))...);
-    ddc::DiscreteDomain<DDims...> const
-            dom_vals(dom_vals_tmp, interpolation_domain1, interpolation_domain2);
 
 #if defined(BC_HERMITE)
     // Create the derivs domain
@@ -210,20 +204,6 @@ void Batched2dSplineTest()
             = ddc::replace_dim_of<DDimI2, ddc::Deriv<I2>>(dom_derivs_1d, derivs_domain2);
 #endif
 
-    // Create a SplineBuilder over BSplines<I> and batched along other dimensions using some boundary conditions
-    ddc::SplineBuilder2D<
-            ExecSpace,
-            MemorySpace,
-            BSplines<I1>,
-            BSplines<I2>,
-            DDimI1,
-            DDimI2,
-            s_bcl,
-            s_bcr,
-            s_bcl,
-            s_bcr,
-            ddc::SplineSolver::GINKGO> const spline_builder(interpolation_domain);
-
     // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI1, DDimI2> const dom_interpolation
             = spline_builder.interpolation_domain();
@@ -232,7 +212,6 @@ void Batched2dSplineTest()
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
-    evaluator_type<DDimI1, DDimI2> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
@@ -452,34 +431,6 @@ void Batched2dSplineTest()
     spline_builder(coef, vals.span_cview());
 #endif
 
-    // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
-#if defined(BC_PERIODIC)
-    using extrapolation_rule_1_type = ddc::PeriodicExtrapolationRule<I1>;
-    using extrapolation_rule_2_type = ddc::PeriodicExtrapolationRule<I2>;
-#else
-    using extrapolation_rule_1_type = ddc::NullExtrapolationRule;
-    using extrapolation_rule_2_type = ddc::NullExtrapolationRule;
-#endif
-    extrapolation_rule_1_type const extrapolation_rule_1;
-    extrapolation_rule_2_type const extrapolation_rule_2;
-
-    ddc::SplineEvaluator2D<
-            ExecSpace,
-            MemorySpace,
-            BSplines<I1>,
-            BSplines<I2>,
-            DDimI1,
-            DDimI2,
-            extrapolation_rule_1_type,
-            extrapolation_rule_1_type,
-            extrapolation_rule_2_type,
-            extrapolation_rule_2_type> const
-            spline_evaluator(
-                    extrapolation_rule_1,
-                    extrapolation_rule_1,
-                    extrapolation_rule_2,
-                    extrapolation_rule_2);
-
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<I1, I2>, MemorySpace>());
     ddc::ChunkSpan const coords_eval = coords_eval_alloc.span_view();
@@ -551,6 +502,107 @@ void Batched2dSplineTest()
                 return Kokkos::abs(spline_eval_deriv12(e) - evaluator.deriv(x, y, 1, 1));
             });
 
+    return std::make_tuple(
+            max_norm_error,
+            max_norm_error_diff1,
+            max_norm_error_diff2,
+            max_norm_error_diff2);
+}
+
+// Checks that when evaluating the spline at interpolation points one
+// recovers values that were used to build the spline
+template <
+        typename ExecSpace,
+        typename MemorySpace,
+        typename DDimI1,
+        typename DDimI2,
+        typename... DDims>
+void MultipleBatchDomain2dSplineTest()
+{
+    using I1 = typename DDimI1::continuous_dimension_type;
+    using I2 = typename DDimI2::continuous_dimension_type;
+
+    // Instantiate execution spaces and initialize spaces
+    ExecSpace const exec_space;
+    std::size_t const ncells = 10;
+    InterestDimInitializer<DDimI1>(ncells);
+    InterestDimInitializer<DDimI2>(ncells);
+
+    // Create the values domain (mesh)
+    ddc::DiscreteDomain<DDimI1> const interpolation_domain1
+            = GrevillePoints<BSplines<I1>>::template get_domain<DDimI1>();
+    ddc::DiscreteDomain<DDimI2> const interpolation_domain2
+            = GrevillePoints<BSplines<I2>>::template get_domain<DDimI2>();
+    ddc::DiscreteDomain<DDimI1, DDimI2> const
+            interpolation_domain(interpolation_domain1, interpolation_domain2);
+    // The following line creates a discrete domain over all dimensions (DDims...) except DDimI1 and DDimI2.
+    auto const dom_vals_tmp = ddc::remove_dims_of_t<ddc::DiscreteDomain<DDims...>, DDimI1, DDimI2>(
+            ddc::DiscreteDomain<DDims>(DElem<DDims>(0), DVect<DDims>(ncells))...);
+    ddc::DiscreteDomain<DDims...> const
+            dom_vals(dom_vals_tmp, interpolation_domain1, interpolation_domain2);
+
+    ddc::DiscreteDomain<DDimBatchExtra>
+            extra_batch_domain(DElem<DDimBatchExtra>(0), DVect<DDimBatchExtra>(ncells));
+    ddc::DiscreteDomain<DDims..., DDimBatchExtra> const dom_vals_extra(
+            dom_vals_tmp,
+            interpolation_domain1,
+            interpolation_domain2,
+            extra_batch_domain);
+
+    // Create a SplineBuilder over BSplines<I1> and BSplines<I2> and using some boundary conditions
+    ddc::SplineBuilder2D<
+            ExecSpace,
+            MemorySpace,
+            BSplines<I1>,
+            BSplines<I2>,
+            DDimI1,
+            DDimI2,
+            s_bcl,
+            s_bcr,
+            s_bcl,
+            s_bcr,
+            ddc::SplineSolver::GINKGO> const spline_builder(interpolation_domain);
+
+    evaluator_type<DDimI1, DDimI2> const evaluator(spline_builder.interpolation_domain());
+
+    // Instantiate a SplineEvaluator over interest dimensions
+#if defined(BC_PERIODIC)
+    using extrapolation_rule_1_type = ddc::PeriodicExtrapolationRule<I1>;
+    using extrapolation_rule_2_type = ddc::PeriodicExtrapolationRule<I2>;
+#else
+    using extrapolation_rule_1_type = ddc::NullExtrapolationRule;
+    using extrapolation_rule_2_type = ddc::NullExtrapolationRule;
+#endif
+    extrapolation_rule_1_type const extrapolation_rule_1;
+    extrapolation_rule_2_type const extrapolation_rule_2;
+
+    ddc::SplineEvaluator2D<
+            ExecSpace,
+            MemorySpace,
+            BSplines<I1>,
+            BSplines<I2>,
+            DDimI1,
+            DDimI2,
+            extrapolation_rule_1_type,
+            extrapolation_rule_1_type,
+            extrapolation_rule_2_type,
+            extrapolation_rule_2_type> const
+            spline_evaluator(
+                    extrapolation_rule_1,
+                    extrapolation_rule_1,
+                    extrapolation_rule_2,
+                    extrapolation_rule_2);
+
+    // Check the evaluation error for the first domain
+    const auto [max_norm_error, max_norm_error_diff1, max_norm_error_diff2, max_norm_error_diff12]
+            = ComputeEvaluationError<ExecSpace, MemorySpace>(
+                    exec_space,
+                    dom_vals,
+                    interpolation_domain1,
+                    interpolation_domain2,
+                    spline_builder,
+                    spline_evaluator,
+                    evaluator);
 
     double const max_norm = evaluator.max_norm();
     double const max_norm_diff1 = evaluator.max_norm(1, 0);
@@ -591,6 +643,61 @@ void Batched2dSplineTest()
                                 s_degree,
                                 s_degree),
                         1e-11 * max_norm_diff12));
+
+    // Check the evaluation for the domain with an additional batch dimension
+    const auto
+            [max_norm_error_extra,
+             max_norm_error_diff1_extra,
+             max_norm_error_diff2_extra,
+             max_norm_error_diff12_extra]
+            = ComputeEvaluationError<ExecSpace, MemorySpace>(
+                    exec_space,
+                    dom_vals_extra,
+                    interpolation_domain1,
+                    interpolation_domain2,
+                    spline_builder,
+                    spline_evaluator,
+                    evaluator);
+
+    double const max_norm_extra = evaluator.max_norm();
+    double const max_norm_diff1_extra = evaluator.max_norm(1, 0);
+    double const max_norm_diff2_extra = evaluator.max_norm(0, 1);
+    double const max_norm_diff12_extra = evaluator.max_norm(1, 1);
+
+    SplineErrorBounds<evaluator_type<DDimI1, DDimI2>> const error_bounds_extra(evaluator);
+    EXPECT_LE(
+            max_norm_error_extra,
+            std::
+                    max(error_bounds_extra
+                                .error_bound(dx<I1>(ncells), dx<I2>(ncells), s_degree, s_degree),
+                        1.0e-14 * max_norm_extra));
+    EXPECT_LE(
+            max_norm_error_diff1_extra,
+            std::
+                    max(error_bounds_extra.error_bound_on_deriv_1(
+                                dx<I1>(ncells),
+                                dx<I2>(ncells),
+                                s_degree,
+                                s_degree),
+                        1e-12 * max_norm_diff1_extra));
+    EXPECT_LE(
+            max_norm_error_diff2_extra,
+            std::
+                    max(error_bounds_extra.error_bound_on_deriv_2(
+                                dx<I1>(ncells),
+                                dx<I2>(ncells),
+                                s_degree,
+                                s_degree),
+                        1e-12 * max_norm_diff2_extra));
+    EXPECT_LE(
+            max_norm_error_diff12_extra,
+            std::
+                    max(error_bounds_extra.error_bound_on_deriv_12(
+                                dx<I1>(ncells),
+                                dx<I2>(ncells),
+                                s_degree,
+                                s_degree),
+                        1e-11 * max_norm_diff12_extra));
 }
 
 } // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_2D_SPLINE_BUILDER_CPP)
@@ -609,9 +716,9 @@ void Batched2dSplineTest()
 #define SUFFIX(name) name##Hermite##NonUniform
 #endif
 
-TEST(SUFFIX(Batched2dSplineHost), 2DXY)
+TEST(SUFFIX(MultipleBatchDomain2dSplineHost), 2DXY)
 {
-    Batched2dSplineTest<
+    MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -620,9 +727,9 @@ TEST(SUFFIX(Batched2dSplineHost), 2DXY)
             DDimGPS<DimY>>();
 }
 
-TEST(SUFFIX(Batched2dSplineDevice), 2DXY)
+TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 2DXY)
 {
-    Batched2dSplineTest<
+    MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -631,9 +738,9 @@ TEST(SUFFIX(Batched2dSplineDevice), 2DXY)
             DDimGPS<DimY>>();
 }
 
-TEST(SUFFIX(Batched2dSplineHost), 3DXY)
+TEST(SUFFIX(MultipleBatchDomain2dSplineHost), 3DXY)
 {
-    Batched2dSplineTest<
+    MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -643,9 +750,9 @@ TEST(SUFFIX(Batched2dSplineHost), 3DXY)
             DDimBatch>();
 }
 
-TEST(SUFFIX(Batched2dSplineHost), 3DXZ)
+TEST(SUFFIX(MultipleBatchDomain2dSplineHost), 3DXZ)
 {
-    Batched2dSplineTest<
+    MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -655,9 +762,9 @@ TEST(SUFFIX(Batched2dSplineHost), 3DXZ)
             DDimGPS<DimZ>>();
 }
 
-TEST(SUFFIX(Batched2dSplineHost), 3DYZ)
+TEST(SUFFIX(MultipleBatchDomain2dSplineHost), 3DYZ)
 {
-    Batched2dSplineTest<
+    MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimY>,
@@ -667,9 +774,9 @@ TEST(SUFFIX(Batched2dSplineHost), 3DYZ)
             DDimGPS<DimZ>>();
 }
 
-TEST(SUFFIX(Batched2dSplineDevice), 3DXY)
+TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 3DXY)
 {
-    Batched2dSplineTest<
+    MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -679,9 +786,9 @@ TEST(SUFFIX(Batched2dSplineDevice), 3DXY)
             DDimBatch>();
 }
 
-TEST(SUFFIX(Batched2dSplineDevice), 3DXZ)
+TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 3DXZ)
 {
-    Batched2dSplineTest<
+    MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -691,9 +798,9 @@ TEST(SUFFIX(Batched2dSplineDevice), 3DXZ)
             DDimGPS<DimZ>>();
 }
 
-TEST(SUFFIX(Batched2dSplineDevice), 3DYZ)
+TEST(SUFFIX(MultipleBatchDomain2dSplineDevice), 3DYZ)
 {
-    Batched2dSplineTest<
+    MultipleBatchDomain2dSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimY>,

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -179,8 +179,6 @@ template <
 std::tuple<double, double, double, double> ComputeEvaluationError(
         ExecSpace const& exec_space,
         ddc::DiscreteDomain<DDims...> const& dom_vals,
-        ddc::DiscreteDomain<DDimI1> const& interpolation_domain1,
-        ddc::DiscreteDomain<DDimI2> const& interpolation_domain2,
         Builder const& spline_builder,
         Evaluator const& spline_evaluator,
         evaluator_type<DDimI1, DDimI2> const& evaluator)
@@ -189,6 +187,8 @@ std::tuple<double, double, double, double> ComputeEvaluationError(
     using I2 = typename DDimI2::continuous_dimension_type;
 
 #if defined(BC_HERMITE)
+    ddc::DiscreteDomain<DDimI1> const interpolation_domain1(dom_vals);
+    ddc::DiscreteDomain<DDimI2> const interpolation_domain2(dom_vals);
     // Create the derivs domain
     ddc::DiscreteDomain<ddc::Deriv<I1>> const
             derivs_domain1(DElem<ddc::Deriv<I1>>(1), DVect<ddc::Deriv<I1>>(s_degree / 2));
@@ -506,7 +506,7 @@ std::tuple<double, double, double, double> ComputeEvaluationError(
             max_norm_error,
             max_norm_error_diff1,
             max_norm_error_diff2,
-            max_norm_error_diff2);
+            max_norm_error_diff12);
 }
 
 // Checks that when evaluating the spline at interpolation points one
@@ -595,14 +595,9 @@ void MultipleBatchDomain2dSplineTest()
 
     // Check the evaluation error for the first domain
     const auto [max_norm_error, max_norm_error_diff1, max_norm_error_diff2, max_norm_error_diff12]
-            = ComputeEvaluationError<ExecSpace, MemorySpace>(
-                    exec_space,
-                    dom_vals,
-                    interpolation_domain1,
-                    interpolation_domain2,
-                    spline_builder,
-                    spline_evaluator,
-                    evaluator);
+            = ComputeEvaluationError<
+                    ExecSpace,
+                    MemorySpace>(exec_space, dom_vals, spline_builder, spline_evaluator, evaluator);
 
     double const max_norm = evaluator.max_norm();
     double const max_norm_diff1 = evaluator.max_norm(1, 0);
@@ -653,8 +648,6 @@ void MultipleBatchDomain2dSplineTest()
             = ComputeEvaluationError<ExecSpace, MemorySpace>(
                     exec_space,
                     dom_vals_extra,
-                    interpolation_domain1,
-                    interpolation_domain2,
                     spline_builder,
                     spline_evaluator,
                     evaluator);

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -541,7 +541,7 @@ void MultipleBatchDomain2dSplineTest()
     ddc::DiscreteDomain<DDims...> const
             dom_vals(dom_vals_tmp, interpolation_domain1, interpolation_domain2);
 
-    ddc::DiscreteDomain<DDimBatchExtra>
+    ddc::DiscreteDomain<DDimBatchExtra> const
             extra_batch_domain(DElem<DDimBatchExtra>(0), DVect<DDimBatchExtra>(ncells));
     ddc::DiscreteDomain<DDims..., DDimBatchExtra> const dom_vals_extra(
             dom_vals_tmp,
@@ -594,7 +594,7 @@ void MultipleBatchDomain2dSplineTest()
                     extrapolation_rule_2);
 
     // Check the evaluation error for the first domain
-    const auto [max_norm_error, max_norm_error_diff1, max_norm_error_diff2, max_norm_error_diff12]
+    auto const [max_norm_error, max_norm_error_diff1, max_norm_error_diff2, max_norm_error_diff12]
             = ComputeEvaluationError<
                     ExecSpace,
                     MemorySpace>(exec_space, dom_vals, spline_builder, spline_evaluator, evaluator);
@@ -639,8 +639,8 @@ void MultipleBatchDomain2dSplineTest()
                                 s_degree),
                         1e-11 * max_norm_diff12));
 
-    // Check the evaluation for the domain with an additional batch dimension
-    const auto
+    // Check the evaluation error for the domain with an additional batch dimension
+    auto const
             [max_norm_error_extra,
              max_norm_error_diff1_extra,
              max_norm_error_diff2_extra,

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstddef>
+#include <tuple>
 #if defined(BC_HERMITE)
 #include <optional>
 #endif
@@ -76,6 +77,10 @@ struct DDimBatch2
 };
 
 struct DDimBatch3
+{
+};
+
+struct DDimBatchExtra
 {
 };
 
@@ -167,48 +172,29 @@ void InterestDimInitializer(std::size_t const ncells)
     ddc::init_discrete_space<DDim>(GrevillePoints<BSplines<CDim>>::template get_sampling<DDim>());
 }
 
-// Checks that when evaluating the spline at interpolation points one
-// recovers values that were used to build the spline
-template <typename ExecSpace, typename MemorySpace, typename DDimI, typename... DDims>
-void BatchedSplineTest()
+/// Computes the evaluation error when evaluating a spline on its interpolation points.
+template <
+        typename ExecSpace,
+        typename MemorySpace,
+        typename DDimI,
+        class Builder,
+        class Evaluator,
+        typename... DDims>
+std::tuple<double, double, double> ComputeEvaluationError(
+        ExecSpace const& exec_space,
+        ddc::DiscreteDomain<DDims...> const& dom_vals,
+        Builder const& spline_builder,
+        Evaluator const& spline_evaluator,
+        evaluator_type<DDimI> const& evaluator)
 {
     using I = typename DDimI::continuous_dimension_type;
 
-    // Instantiate execution spaces and initialize spaces
-    ExecSpace const exec_space;
-
-    std::size_t const ncells = 10;
-    InterestDimInitializer<DDimI>(ncells);
-
-    // Create the values domain (mesh)
-    ddc::DiscreteDomain<DDimI> const interpolation_domain
-            = GrevillePoints<BSplines<I>>::template get_domain<DDimI>();
-    // The following line creates a discrete domain over all dimensions (DDims...) except DDimI.
-    auto const dom_vals_tmp = ddc::remove_dims_of_t<ddc::DiscreteDomain<DDims...>, DDimI>(
-            ddc::DiscreteDomain<DDims>(DElem<DDims>(0), DVect<DDims>(ncells))...);
-    ddc::DiscreteDomain<DDims...> const dom_vals(dom_vals_tmp, interpolation_domain);
-
 #if defined(BC_HERMITE)
-    // Create the derivs domain
+    // Create the derivs domains
     ddc::DiscreteDomain<ddc::Deriv<I>> const
             derivs_domain(DElem<ddc::Deriv<I>>(1), DVect<ddc::Deriv<I>>(s_degree_x / 2));
     auto const dom_derivs = ddc::replace_dim_of<DDimI, ddc::Deriv<I>>(dom_vals, derivs_domain);
 #endif
-
-    // Create a SplineBuilder over BSplines<I> and batched along other dimensions using some boundary conditions
-    ddc::SplineBuilder<
-            ExecSpace,
-            MemorySpace,
-            BSplines<I>,
-            DDimI,
-            s_bcl,
-            s_bcr,
-#if defined(SOLVER_LAPACK)
-            ddc::SplineSolver::LAPACK
-#elif defined(SOLVER_GINKGO)
-            ddc::SplineSolver::GINKGO
-#endif
-            > const spline_builder(interpolation_domain);
 
     // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<DDimI> const dom_interpolation = spline_builder.interpolation_domain();
@@ -218,7 +204,6 @@ void BatchedSplineTest()
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
     ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
-    evaluator_type<DDimI> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
@@ -294,23 +279,6 @@ void BatchedSplineTest()
     spline_builder(coef, vals.span_cview());
 #endif
 
-    // Instantiate a SplineEvaluator over interest dimension and batched along other dimensions
-#if defined(BC_PERIODIC)
-    using extrapolation_rule_type = ddc::PeriodicExtrapolationRule<I>;
-#else
-    using extrapolation_rule_type = ddc::NullExtrapolationRule;
-#endif
-    extrapolation_rule_type const extrapolation_rule;
-
-    ddc::SplineEvaluator<
-            ExecSpace,
-            MemorySpace,
-            BSplines<I>,
-            DDimI,
-            extrapolation_rule_type,
-            extrapolation_rule_type> const
-            spline_evaluator_batched(extrapolation_rule, extrapolation_rule);
-
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<I>, MemorySpace>());
     ddc::ChunkSpan const coords_eval = coords_eval_alloc.span_view();
@@ -331,9 +299,9 @@ void BatchedSplineTest()
     ddc::ChunkSpan const spline_eval_integrals = spline_eval_integrals_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
-    spline_evaluator_batched(spline_eval, coords_eval.span_cview(), coef.span_cview());
-    spline_evaluator_batched.deriv(spline_eval_deriv, coords_eval.span_cview(), coef.span_cview());
-    spline_evaluator_batched.integrate(spline_eval_integrals, coef.span_cview());
+    spline_evaluator(spline_eval, coords_eval.span_cview(), coef.span_cview());
+    spline_evaluator.deriv(spline_eval_deriv, coords_eval.span_cview(), coef.span_cview());
+    spline_evaluator.integrate(spline_eval_integrals, coef.span_cview());
 
     // Checking errors (we recover the initial values)
     double const max_norm_error = ddc::parallel_transform_reduce(
@@ -359,12 +327,82 @@ void BatchedSplineTest()
             spline_eval_integrals.domain(),
             0.,
             ddc::reducer::max<double>(),
-            KOKKOS_LAMBDA(typename decltype(spline_builder)::template batch_domain_type<
+            KOKKOS_LAMBDA(typename Builder::template batch_domain_type<
                           ddc::DiscreteDomain<DDims...>>::discrete_element_type const e) {
                 return Kokkos::abs(
                         spline_eval_integrals(e) - evaluator.deriv(xN<I>(), -1)
                         + evaluator.deriv(x0<I>(), -1));
             });
+
+    return std::make_tuple(max_norm_error, max_norm_error_diff, max_norm_error_integ);
+}
+
+// Checks that when evaluating the spline at interpolation points with
+// multiple batch patterns using the same builders and evaluators, one
+// recovers values that were used to build the spline
+template <typename ExecSpace, typename MemorySpace, typename DDimI, typename... DDims>
+void MultipleBatchDomainSplineTest()
+{
+    using I = typename DDimI::continuous_dimension_type;
+
+    // Instantiate execution spaces and initialize spaces
+    ExecSpace const exec_space;
+
+    std::size_t const ncells = 10;
+    InterestDimInitializer<DDimI>(ncells);
+
+    // Create the values domain (mesh)
+    ddc::DiscreteDomain<DDimI> const interpolation_domain
+            = GrevillePoints<BSplines<I>>::template get_domain<DDimI>();
+    // The following line creates a discrete domain over all dimensions (DDims...) except DDimI.
+    auto const dom_vals_tmp = ddc::remove_dims_of_t<ddc::DiscreteDomain<DDims...>, DDimI>(
+            ddc::DiscreteDomain<DDims>(DElem<DDims>(0), DVect<DDims>(ncells))...);
+    ddc::DiscreteDomain<DDims...> const dom_vals(dom_vals_tmp, interpolation_domain);
+
+    // Create a discrete domain with an additional batch dimension
+    ddc::DiscreteDomain<DDimBatchExtra> const
+            extra_domain(DElem<DDimBatchExtra>(0), DVect<DDimBatchExtra>(ncells));
+    ddc::DiscreteDomain<DDims..., DDimBatchExtra> const
+            dom_vals_extra(dom_vals_tmp, interpolation_domain, extra_domain);
+
+    // Create a SplineBuilder over BSplines<I> using some boundary conditions
+    ddc::SplineBuilder<
+            ExecSpace,
+            MemorySpace,
+            BSplines<I>,
+            DDimI,
+            s_bcl,
+            s_bcr,
+#if defined(SOLVER_LAPACK)
+            ddc::SplineSolver::LAPACK
+#elif defined(SOLVER_GINKGO)
+            ddc::SplineSolver::GINKGO
+#endif
+            > const spline_builder(interpolation_domain);
+
+    // Instantiate a SplineEvaluator over interest dimension
+#if defined(BC_PERIODIC)
+    using extrapolation_rule_type = ddc::PeriodicExtrapolationRule<I>;
+#else
+    using extrapolation_rule_type = ddc::NullExtrapolationRule;
+#endif
+    extrapolation_rule_type const extrapolation_rule;
+
+    ddc::SplineEvaluator<
+            ExecSpace,
+            MemorySpace,
+            BSplines<I>,
+            DDimI,
+            extrapolation_rule_type,
+            extrapolation_rule_type> const
+            spline_evaluator_batched(extrapolation_rule, extrapolation_rule);
+
+    evaluator_type<DDimI> const evaluator(spline_builder.interpolation_domain());
+
+    // Check the evaluation error for the first domain
+    auto const [max_norm_error, max_norm_error_diff, max_norm_error_integ] = ComputeEvaluationError<
+            ExecSpace,
+            MemorySpace>(exec_space, dom_vals, spline_builder, spline_evaluator_batched, evaluator);
 
     double const max_norm = evaluator.max_norm();
     double const max_norm_diff = evaluator.max_norm(1);
@@ -384,7 +422,38 @@ void BatchedSplineTest()
             std::
                     max(error_bounds.error_bound_on_int(dx<I>(ncells), s_degree_x),
                         1.0e-14 * max_norm_int));
+
+    // Check the evaluation error for the domain with an additional batch dimension
+    auto const [max_norm_error_extra, max_norm_error_diff_extra, max_norm_error_integ_extra]
+            = ComputeEvaluationError<ExecSpace, MemorySpace>(
+                    exec_space,
+                    dom_vals_extra,
+                    spline_builder,
+                    spline_evaluator_batched,
+                    evaluator);
+
+    double const max_norm_extra = evaluator.max_norm();
+    double const max_norm_diff_extra = evaluator.max_norm(1);
+    double const max_norm_int_extra = evaluator.max_norm(-1);
+
+    SplineErrorBounds<evaluator_type<DDimI>> const error_bounds_extra(evaluator);
+    EXPECT_LE(
+            max_norm_error_extra,
+            std::
+                    max(error_bounds_extra.error_bound(dx<I>(ncells), s_degree_x),
+                        1.0e-14 * max_norm_extra));
+    EXPECT_LE(
+            max_norm_error_diff_extra,
+            std::
+                    max(error_bounds_extra.error_bound_on_deriv(dx<I>(ncells), s_degree_x),
+                        1e-12 * max_norm_diff_extra));
+    EXPECT_LE(
+            max_norm_error_integ_extra,
+            std::
+                    max(error_bounds_extra.error_bound_on_int(dx<I>(ncells), s_degree_x),
+                        1.0e-14 * max_norm_int_extra));
 }
+
 
 } // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_SPLINE_BUILDER_CPP)
 
@@ -414,27 +483,27 @@ void BatchedSplineTest()
 #define SUFFIX(name) name##Ginkgo##Hermite##NonUniform
 #endif
 
-TEST(SUFFIX(BatchedSplineHost), 1DX)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 1DX)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimX>,
             DDimGPS<DimX>>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 1DX)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 1DX)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimX>,
             DDimGPS<DimX>>();
 }
 
-TEST(SUFFIX(BatchedSplineHost), 2DX)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 2DX)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -442,9 +511,9 @@ TEST(SUFFIX(BatchedSplineHost), 2DX)
             DDimBatch1>();
 }
 
-TEST(SUFFIX(BatchedSplineHost), 2DY)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 2DY)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimY>,
@@ -452,9 +521,9 @@ TEST(SUFFIX(BatchedSplineHost), 2DY)
             DDimGPS<DimY>>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 2DX)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 2DX)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -462,9 +531,9 @@ TEST(SUFFIX(BatchedSplineDevice), 2DX)
             DDimBatch1>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 2DY)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 2DY)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimY>,
@@ -472,9 +541,9 @@ TEST(SUFFIX(BatchedSplineDevice), 2DY)
             DDimGPS<DimY>>();
 }
 
-TEST(SUFFIX(BatchedSplineHost), 3DX)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 3DX)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -483,9 +552,9 @@ TEST(SUFFIX(BatchedSplineHost), 3DX)
             DDimBatch2>();
 }
 
-TEST(SUFFIX(BatchedSplineHost), 3DY)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 3DY)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimY>,
@@ -494,9 +563,9 @@ TEST(SUFFIX(BatchedSplineHost), 3DY)
             DDimBatch2>();
 }
 
-TEST(SUFFIX(BatchedSplineHost), 3DZ)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 3DZ)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimZ>,
@@ -505,9 +574,9 @@ TEST(SUFFIX(BatchedSplineHost), 3DZ)
             DDimGPS<DimZ>>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 3DX)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 3DX)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -516,9 +585,9 @@ TEST(SUFFIX(BatchedSplineDevice), 3DX)
             DDimBatch2>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 3DY)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 3DY)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimY>,
@@ -527,9 +596,9 @@ TEST(SUFFIX(BatchedSplineDevice), 3DY)
             DDimBatch2>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 3DZ)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 3DZ)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimZ>,
@@ -539,9 +608,9 @@ TEST(SUFFIX(BatchedSplineDevice), 3DZ)
 }
 
 
-TEST(SUFFIX(BatchedSplineHost), 4DX)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 4DX)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -551,9 +620,9 @@ TEST(SUFFIX(BatchedSplineHost), 4DX)
             DDimBatch3>();
 }
 
-TEST(SUFFIX(BatchedSplineHost), 4DY)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 4DY)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimY>,
@@ -563,9 +632,9 @@ TEST(SUFFIX(BatchedSplineHost), 4DY)
             DDimBatch3>();
 }
 
-TEST(SUFFIX(BatchedSplineHost), 4DZ)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 4DZ)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimZ>,
@@ -575,9 +644,9 @@ TEST(SUFFIX(BatchedSplineHost), 4DZ)
             DDimBatch3>();
 }
 
-TEST(SUFFIX(BatchedSplineHost), 4DT)
+TEST(SUFFIX(MultipleBatchDomainSplineHost), 4DT)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultHostExecutionSpace,
             Kokkos::DefaultHostExecutionSpace::memory_space,
             DDimGPS<DimT>,
@@ -587,9 +656,9 @@ TEST(SUFFIX(BatchedSplineHost), 4DT)
             DDimGPS<DimT>>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 4DX)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 4DX)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimX>,
@@ -599,9 +668,9 @@ TEST(SUFFIX(BatchedSplineDevice), 4DX)
             DDimBatch3>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 4DY)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 4DY)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimY>,
@@ -611,9 +680,9 @@ TEST(SUFFIX(BatchedSplineDevice), 4DY)
             DDimBatch3>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 4DZ)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 4DZ)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimZ>,
@@ -623,9 +692,9 @@ TEST(SUFFIX(BatchedSplineDevice), 4DZ)
             DDimBatch3>();
 }
 
-TEST(SUFFIX(BatchedSplineDevice), 4DT)
+TEST(SUFFIX(MultipleBatchDomainSplineDevice), 4DT)
 {
-    BatchedSplineTest<
+    MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
             Kokkos::DefaultExecutionSpace::memory_space,
             DDimGPS<DimT>,

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -35,16 +35,6 @@ struct DimY
 {
     static constexpr bool PERIODIC = true;
 };
-
-struct DimZ
-{
-    static constexpr bool PERIODIC = true;
-};
-
-struct DimT
-{
-    static constexpr bool PERIODIC = true;
-};
 #else
 
 struct DimX
@@ -56,27 +46,9 @@ struct DimY
 {
     static constexpr bool PERIODIC = false;
 };
-
-struct DimZ
-{
-    static constexpr bool PERIODIC = false;
-};
-
-struct DimT
-{
-    static constexpr bool PERIODIC = false;
-};
 #endif
 
 struct DDimBatch1
-{
-};
-
-struct DDimBatch2
-{
-};
-
-struct DDimBatch3
 {
 };
 
@@ -483,16 +455,7 @@ void MultipleBatchDomainSplineTest()
 #define SUFFIX(name) name##Ginkgo##Hermite##NonUniform
 #endif
 
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 1DX)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimX>,
-            DDimGPS<DimX>>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 1DX)
+TEST(SUFFIX(MultipleBatchDomainSpline), 1DX)
 {
     MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
@@ -501,27 +464,7 @@ TEST(SUFFIX(MultipleBatchDomainSplineDevice), 1DX)
             DDimGPS<DimX>>();
 }
 
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 2DX)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimX>,
-            DDimGPS<DimX>,
-            DDimBatch1>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 2DY)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimY>,
-            DDimBatch1,
-            DDimGPS<DimY>>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 2DX)
+TEST(SUFFIX(MultipleBatchDomainSpline), 2DX)
 {
     MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
@@ -531,7 +474,7 @@ TEST(SUFFIX(MultipleBatchDomainSplineDevice), 2DX)
             DDimBatch1>();
 }
 
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 2DY)
+TEST(SUFFIX(MultipleBatchDomainSpline), 2DY)
 {
     MultipleBatchDomainSplineTest<
             Kokkos::DefaultExecutionSpace,
@@ -539,167 +482,4 @@ TEST(SUFFIX(MultipleBatchDomainSplineDevice), 2DY)
             DDimGPS<DimY>,
             DDimBatch1,
             DDimGPS<DimY>>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 3DX)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimX>,
-            DDimGPS<DimX>,
-            DDimBatch1,
-            DDimBatch2>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 3DY)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimY>,
-            DDimBatch1,
-            DDimGPS<DimY>,
-            DDimBatch2>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 3DZ)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimZ>,
-            DDimBatch1,
-            DDimBatch2,
-            DDimGPS<DimZ>>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 3DX)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            DDimGPS<DimX>,
-            DDimGPS<DimX>,
-            DDimBatch1,
-            DDimBatch2>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 3DY)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            DDimGPS<DimY>,
-            DDimBatch1,
-            DDimGPS<DimY>,
-            DDimBatch2>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 3DZ)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            DDimGPS<DimZ>,
-            DDimBatch1,
-            DDimBatch2,
-            DDimGPS<DimZ>>();
-}
-
-
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 4DX)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimX>,
-            DDimGPS<DimX>,
-            DDimBatch1,
-            DDimBatch2,
-            DDimBatch3>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 4DY)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimY>,
-            DDimBatch1,
-            DDimGPS<DimY>,
-            DDimBatch2,
-            DDimBatch3>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 4DZ)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimZ>,
-            DDimBatch1,
-            DDimBatch2,
-            DDimGPS<DimZ>,
-            DDimBatch3>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineHost), 4DT)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultHostExecutionSpace,
-            Kokkos::DefaultHostExecutionSpace::memory_space,
-            DDimGPS<DimT>,
-            DDimBatch1,
-            DDimBatch2,
-            DDimBatch3,
-            DDimGPS<DimT>>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 4DX)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            DDimGPS<DimX>,
-            DDimGPS<DimX>,
-            DDimBatch1,
-            DDimBatch2,
-            DDimBatch3>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 4DY)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            DDimGPS<DimY>,
-            DDimBatch1,
-            DDimGPS<DimY>,
-            DDimBatch2,
-            DDimBatch3>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 4DZ)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            DDimGPS<DimZ>,
-            DDimBatch1,
-            DDimBatch2,
-            DDimGPS<DimZ>,
-            DDimBatch3>();
-}
-
-TEST(SUFFIX(MultipleBatchDomainSplineDevice), 4DT)
-{
-    MultipleBatchDomainSplineTest<
-            Kokkos::DefaultExecutionSpace,
-            Kokkos::DefaultExecutionSpace::memory_space,
-            DDimGPS<DimT>,
-            DDimBatch1,
-            DDimBatch2,
-            DDimBatch3,
-            DDimGPS<DimT>>();
 }

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -176,8 +176,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
             BSplinesX,
             DDimX,
             ddc::NullExtrapolationRule,
-            ddc::NullExtrapolationRule,
-            DDimX> const spline_evaluator(extrapolation_rule, extrapolation_rule);
+            ddc::NullExtrapolationRule> const spline_evaluator(extrapolation_rule, extrapolation_rule);
 
     ddc::Chunk
             coords_eval_alloc(interpolation_domain, ddc::KokkosAllocator<CoordX, memory_space>());
@@ -202,7 +201,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
     ddc::Chunk integral(
             spline_builder.batch_domain(interpolation_domain),
             ddc::KokkosAllocator<double, memory_space>());
-    spline_evaluator.integrate(integral.span_view(), coef.span_cview());
+    spline_evaluator.integrate<DDimX>(integral.span_view(), coef.span_cview());
 
     ddc::Chunk<
             double,

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -176,7 +176,8 @@ void TestNonPeriodicSplineBuilderTestIdentity()
             BSplinesX,
             DDimX,
             ddc::NullExtrapolationRule,
-            ddc::NullExtrapolationRule> const spline_evaluator(extrapolation_rule, extrapolation_rule);
+            ddc::NullExtrapolationRule> const
+            spline_evaluator(extrapolation_rule, extrapolation_rule);
 
     ddc::Chunk
             coords_eval_alloc(interpolation_domain, ddc::KokkosAllocator<CoordX, memory_space>());

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -201,7 +201,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
     ddc::Chunk integral(
             spline_builder.batch_domain(interpolation_domain),
             ddc::KokkosAllocator<double, memory_space>());
-    spline_evaluator.integrate<DDimX>(integral.span_view(), coef.span_cview());
+    spline_evaluator.integrate(integral.span_view(), coef.span_cview());
 
     ddc::Chunk<
             double,

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -119,8 +119,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
             DDimX,
             s_bcl,
             s_bcr,
-            ddc::SplineSolver::GINKGO,
-            DDimX> const spline_builder(interpolation_domain);
+            ddc::SplineSolver::GINKGO> const spline_builder(interpolation_domain);
 
     // 5. Allocate and fill a chunk over the interpolation domain
     ddc::Chunk yvals_alloc(interpolation_domain, ddc::KokkosAllocator<double, memory_space>());
@@ -200,8 +199,9 @@ void TestNonPeriodicSplineBuilderTestIdentity()
     spline_evaluator
             .deriv(spline_eval_deriv.span_view(), coords_eval.span_cview(), coef.span_cview());
 
-    ddc::Chunk
-            integral(spline_builder.batch_domain(), ddc::KokkosAllocator<double, memory_space>());
+    ddc::Chunk integral(
+            spline_builder.batch_domain(interpolation_domain),
+            ddc::KokkosAllocator<double, memory_space>());
     spline_evaluator.integrate(integral.span_view(), coef.span_cview());
 
     ddc::Chunk<

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -94,8 +94,7 @@ void TestPeriodicSplineBuilderTestIdentity()
             DDimX,
             ddc::BoundCond::PERIODIC,
             ddc::BoundCond::PERIODIC,
-            ddc::SplineSolver::GINKGO,
-            DDimX> const spline_builder(interpolation_domain);
+            ddc::SplineSolver::GINKGO> const spline_builder(interpolation_domain);
 
     // 5. Allocate and fill a chunk over the interpolation domain
     ddc::Chunk yvals_alloc(interpolation_domain, ddc::KokkosAllocator<double, memory_space>());
@@ -140,8 +139,9 @@ void TestPeriodicSplineBuilderTestIdentity()
     spline_evaluator
             .deriv(spline_eval_deriv.span_view(), coords_eval.span_cview(), coef.span_cview());
 
-    ddc::Chunk
-            integral(spline_builder.batch_domain(), ddc::KokkosAllocator<double, memory_space>());
+    ddc::Chunk integral(
+            spline_builder.batch_domain(interpolation_domain),
+            ddc::KokkosAllocator<double, memory_space>());
     spline_evaluator.integrate(integral.span_view(), coef.span_cview());
 
     ddc::Chunk<double, ddc::DiscreteDomain<DDimX>, ddc::KokkosAllocator<double, memory_space>>

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -116,7 +116,8 @@ void TestPeriodicSplineBuilderTestIdentity()
             BSplinesX,
             DDimX,
             ddc::PeriodicExtrapolationRule<DimX>,
-            ddc::PeriodicExtrapolationRule<DimX>> const spline_evaluator(periodic_extrapolation, periodic_extrapolation);
+            ddc::PeriodicExtrapolationRule<DimX>> const
+            spline_evaluator(periodic_extrapolation, periodic_extrapolation);
 
     ddc::Chunk
             coords_eval_alloc(interpolation_domain, ddc::KokkosAllocator<CoordX, memory_space>());

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -141,7 +141,7 @@ void TestPeriodicSplineBuilderTestIdentity()
     ddc::Chunk integral(
             spline_builder.batch_domain(interpolation_domain),
             ddc::KokkosAllocator<double, memory_space>());
-    spline_evaluator.integrate<DDimX>(integral.span_view(), coef.span_cview());
+    spline_evaluator.integrate(integral.span_view(), coef.span_cview());
 
     ddc::Chunk<double, ddc::DiscreteDomain<DDimX>, ddc::KokkosAllocator<double, memory_space>>
             quadrature_coefficients_alloc;

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -116,8 +116,7 @@ void TestPeriodicSplineBuilderTestIdentity()
             BSplinesX,
             DDimX,
             ddc::PeriodicExtrapolationRule<DimX>,
-            ddc::PeriodicExtrapolationRule<DimX>,
-            DDimX> const spline_evaluator(periodic_extrapolation, periodic_extrapolation);
+            ddc::PeriodicExtrapolationRule<DimX>> const spline_evaluator(periodic_extrapolation, periodic_extrapolation);
 
     ddc::Chunk
             coords_eval_alloc(interpolation_domain, ddc::KokkosAllocator<CoordX, memory_space>());
@@ -142,7 +141,7 @@ void TestPeriodicSplineBuilderTestIdentity()
     ddc::Chunk integral(
             spline_builder.batch_domain(interpolation_domain),
             ddc::KokkosAllocator<double, memory_space>());
-    spline_evaluator.integrate(integral.span_view(), coef.span_cview());
+    spline_evaluator.integrate<DDimX>(integral.span_view(), coef.span_cview());
 
     ddc::Chunk<double, ddc::DiscreteDomain<DDimX>, ddc::KokkosAllocator<double, memory_space>>
             quadrature_coefficients_alloc;

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -159,8 +159,7 @@ void PeriodicitySplineBuilderTest()
             BSplines<X>,
             DDim<X>,
             ddc::PeriodicExtrapolationRule<X>,
-            ddc::PeriodicExtrapolationRule<X>,
-            DDim<X>> const spline_evaluator(extrapolation_rule, extrapolation_rule);
+            ddc::PeriodicExtrapolationRule<X>> const spline_evaluator(extrapolation_rule, extrapolation_rule);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X>, MemorySpace>());

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -159,7 +159,8 @@ void PeriodicitySplineBuilderTest()
             BSplines<X>,
             DDim<X>,
             ddc::PeriodicExtrapolationRule<X>,
-            ddc::PeriodicExtrapolationRule<X>> const spline_evaluator(extrapolation_rule, extrapolation_rule);
+            ddc::PeriodicExtrapolationRule<X>> const
+            spline_evaluator(extrapolation_rule, extrapolation_rule);
 
     // Instantiate chunk of coordinates of dom_interpolation
     ddc::Chunk coords_eval_alloc(dom_vals, ddc::KokkosAllocator<Coord<X>, MemorySpace>());

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -131,8 +131,7 @@ void PeriodicitySplineBuilderTest()
             DDim<X>,
             ddc::BoundCond::PERIODIC,
             ddc::BoundCond::PERIODIC,
-            ddc::SplineSolver::GINKGO,
-            DDim<X>> const spline_builder(dom_vals);
+            ddc::SplineSolver::GINKGO> const spline_builder(dom_vals);
 
     // Compute useful domains (dom_interpolation, dom_batch, dom_bsplines and dom_spline)
     ddc::DiscreteDomain<BSplines<X>> const dom_bsplines = spline_builder.spline_domain();

--- a/tests/splines/spline_builder.cpp
+++ b/tests/splines/spline_builder.cpp
@@ -55,8 +55,7 @@ TEST(SplineBuilder, ShortInterpolationGrid)
                     DDimX,
                     ddc::BoundCond::PERIODIC,
                     ddc::BoundCond::PERIODIC,
-                    ddc::SplineSolver::GINKGO,
-                    DDimX>(interpolation_domain)),
+                    ddc::SplineSolver::GINKGO>(interpolation_domain)),
             std::runtime_error);
 }
 
@@ -82,8 +81,7 @@ TEST(SplineBuilder, LongInterpolationGrid)
                     DDimX,
                     ddc::BoundCond::PERIODIC,
                     ddc::BoundCond::PERIODIC,
-                    ddc::SplineSolver::GINKGO,
-                    DDimX>(interpolation_domain)),
+                    ddc::SplineSolver::GINKGO>(interpolation_domain)),
             std::runtime_error);
 }
 
@@ -109,8 +107,7 @@ TEST(SplineBuilder, BadShapeInterpolationGrid)
                     DDimX,
                     ddc::BoundCond::PERIODIC,
                     ddc::BoundCond::PERIODIC,
-                    ddc::SplineSolver::GINKGO,
-                    DDimX>(interpolation_domain)),
+                    ddc::SplineSolver::GINKGO>(interpolation_domain)),
             std::runtime_error);
 }
 
@@ -134,6 +131,5 @@ TEST(SplineBuilder, CorrectInterpolationGrid)
                      DDimX,
                      ddc::BoundCond::PERIODIC,
                      ddc::BoundCond::PERIODIC,
-                     ddc::SplineSolver::GINKGO,
-                     DDimX>(interpolation_domain)));
+                     ddc::SplineSolver::GINKGO>(interpolation_domain)));
 }


### PR DESCRIPTION
This PR addresses #668

The batch dimensions are removed from the class templates of `SplineBuilder`, `SplineBuilder2D`, `SplineEvaluator` and `SplineEvaluator2D`, the `operator()`, relevant type aliases and methods are templated on the batched interpolation/evaluation domain instead. Some methods of the `SplineBuilder` classes now need the batched interpolation domain to be passed as argument.