### PR TITLE
Change to a more active clang-format github action

### DIFF
--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jidicula/clang-format-action@v4.15.0
         with:
-          clang-format-version: '19'
+          clang-format-version: '20'
       - name: Prefer 'if defined' over 'ifdef'
         run: if grep -R "ifdef" $(git ls-files '*.hpp' '*.cpp'); then exit 1; fi
       - name: Do not include <iostream> in the headers of the library

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: jidicula/clang-format-action@v4.15.0
         with:
-          clang-format-version: '18'
+          clang-format-version: '19'
       - name: Prefer 'if defined' over 'ifdef'
         run: if grep -R "ifdef" $(git ls-files '*.hpp' '*.cpp'); then exit 1; fi
       - name: Do not include <iostream> in the headers of the library

--- a/.github/workflows/tests-ubuntu.yml
+++ b/.github/workflows/tests-ubuntu.yml
@@ -43,12 +43,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: DoozyX/clang-format-lint-action@v0.18
+      - uses: jidicula/clang-format-action@v4.15.0
         with:
-          source: 'benchmarks/ examples/ include/ddc/ install_test/ tests/'
-          exclude: ''
-          extensions: 'hpp,cpp'
-          clangFormatVersion: 18
+          clang-format-version: '18'
       - name: Prefer 'if defined' over 'ifdef'
         run: if grep -R "ifdef" $(git ls-files '*.hpp' '*.cpp'); then exit 1; fi
       - name: Do not include <iostream> in the headers of the library

--- a/benchmarks/deepcopy.cpp
+++ b/benchmarks/deepcopy.cpp
@@ -12,7 +12,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DEEPCOPY_CPP) {
+inline namespace anonymous_namespace_workaround_deepcopy_cpp {
 
 struct DDimX
 {
@@ -123,7 +123,7 @@ void deepcopy_subchunk_2d(benchmark::State& state)
             * int64_t(state.range(0) * state.range(1) * sizeof(double)));
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DEEPCOPY_CPP)
+} // namespace anonymous_namespace_workaround_deepcopy_cpp
 
 // NOLINTBEGIN(misc-use-anonymous-namespace)
 // 1D

--- a/benchmarks/splines.cpp
+++ b/benchmarks/splines.cpp
@@ -24,7 +24,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(SPLINES_CPP) {
+inline namespace anonymous_namespace_workaround_splines_cpp {
 
 ddc::SplineSolver const Backend = ddc::SplineSolver::LAPACK;
 
@@ -260,7 +260,7 @@ void characteristics_advection(benchmark::State& state)
     benchmarks.at(std::array {state.range(0), state.range(1), state.range(2)})(state);
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(SPLINES_CPP)
+} // namespace anonymous_namespace_workaround_splines_cpp
 
 // Reference parameters: the benchmarks sweep on two parameters and fix all the others according to those reference parameters.
 bool on_gpu_ref = true;

--- a/include/ddc/chunk.hpp
+++ b/include/ddc/chunk.hpp
@@ -561,12 +561,11 @@ public:
 };
 
 template <class SupportType, class Allocator>
-Chunk(std::string const&,
-      SupportType const&,
-      Allocator) -> Chunk<typename Allocator::value_type, SupportType, Allocator>;
+Chunk(std::string const&, SupportType const&, Allocator)
+        -> Chunk<typename Allocator::value_type, SupportType, Allocator>;
 
 template <class SupportType, class Allocator>
-Chunk(SupportType const&,
-      Allocator) -> Chunk<typename Allocator::value_type, SupportType, Allocator>;
+Chunk(SupportType const&, Allocator)
+        -> Chunk<typename Allocator::value_type, SupportType, Allocator>;
 
 } // namespace ddc

--- a/include/ddc/chunk_span.hpp
+++ b/include/ddc/chunk_span.hpp
@@ -683,20 +683,18 @@ KOKKOS_DEDUCTION_GUIDE ChunkSpan(
                 typename Kokkos::View<DataType, Properties...>::memory_space>;
 
 template <class ElementType, class SupportType, class Allocator>
-ChunkSpan(Chunk<ElementType, SupportType, Allocator>& other)
-        -> ChunkSpan<
-                ElementType,
-                SupportType,
-                Kokkos::layout_right,
-                typename Allocator::memory_space>;
+ChunkSpan(Chunk<ElementType, SupportType, Allocator>& other) -> ChunkSpan<
+        ElementType,
+        SupportType,
+        Kokkos::layout_right,
+        typename Allocator::memory_space>;
 
 template <class ElementType, class SupportType, class Allocator>
-ChunkSpan(Chunk<ElementType, SupportType, Allocator> const& other)
-        -> ChunkSpan<
-                const ElementType,
-                SupportType,
-                Kokkos::layout_right,
-                typename Allocator::memory_space>;
+ChunkSpan(Chunk<ElementType, SupportType, Allocator> const& other) -> ChunkSpan<
+        const ElementType,
+        SupportType,
+        Kokkos::layout_right,
+        typename Allocator::memory_space>;
 
 template <
         class ElementType,

--- a/include/ddc/detail/macros.hpp
+++ b/include/ddc/detail/macros.hpp
@@ -45,12 +45,3 @@
 #else
 #    define DDC_CURRENT_KOKKOS_SPACE Kokkos::HostSpace
 #endif
-
-#if defined(__HIPCC__)
-#    define DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(NAME)                                       \
-        DDC_NAMESPACE_##NAME {}                                                                    \
-        using namespace DDC_NAMESPACE_##NAME;                                                      \
-        namespace DDC_NAMESPACE_##NAME
-#else
-#    define DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(NAME)
-#endif

--- a/include/ddc/kernels/splines/greville_interpolation_points.hpp
+++ b/include/ddc/kernels/splines/greville_interpolation_points.hpp
@@ -224,8 +224,8 @@ public:
                     points_with_bcs[npoints - 1 - i] /= BSplines::degree();
                 }
             } else {
-                points_with_bcs[npoints - 1]
-                        = points_wo_bcs.coordinate(ddc::DiscreteElement<IntermediateSampling>(
+                points_with_bcs[npoints - 1] = points_wo_bcs.coordinate(
+                        ddc::DiscreteElement<IntermediateSampling>(
                                 ddc::discrete_space<BSplines>().ncells() - 1
                                 + BSplines::degree() % 2));
             }

--- a/include/ddc/kernels/splines/math_tools.hpp
+++ b/include/ddc/kernels/splines/math_tools.hpp
@@ -23,11 +23,12 @@ KOKKOS_INLINE_FUNCTION T sum(T* array, int size)
 }
 
 template <class ElementType, class LayoutPolicy, class AccessorPolicy, std::size_t Ext>
-KOKKOS_INLINE_FUNCTION ElementType sum(Kokkos::mdspan<
-                                       ElementType,
-                                       Kokkos::extents<std::size_t, Ext>,
-                                       LayoutPolicy,
-                                       AccessorPolicy> const& array)
+KOKKOS_INLINE_FUNCTION ElementType
+sum(Kokkos::mdspan<
+        ElementType,
+        Kokkos::extents<std::size_t, Ext>,
+        LayoutPolicy,
+        AccessorPolicy> const& array)
 {
     ElementType val(0.0);
     for (std::size_t i(0); i < array.extent(0); ++i) {

--- a/include/ddc/kernels/splines/spline_builder.hpp
+++ b/include/ddc/kernels/splines/spline_builder.hpp
@@ -909,8 +909,9 @@ operator()(
             "ddc_splines_transpose_rhs",
             exec_space(),
             batch_domain(batched_interpolation_domain),
-            KOKKOS_LAMBDA(typename batch_domain_type<
-                          BatchedInterpolationDDom>::discrete_element_type const j) {
+            KOKKOS_LAMBDA(
+                    typename batch_domain_type<
+                            BatchedInterpolationDDom>::discrete_element_type const j) {
                 for (std::size_t i = 0; i < nbasis_proxy; ++i) {
                     spline_tr(ddc::DiscreteElement<bsplines_type>(i), j)
                             = spline(ddc::DiscreteElement<bsplines_type>(i + offset_proxy), j);
@@ -928,8 +929,9 @@ operator()(
             "ddc_splines_transpose_back_rhs",
             exec_space(),
             batch_domain(batched_interpolation_domain),
-            KOKKOS_LAMBDA(typename batch_domain_type<
-                          BatchedInterpolationDDom>::discrete_element_type const j) {
+            KOKKOS_LAMBDA(
+                    typename batch_domain_type<
+                            BatchedInterpolationDDom>::discrete_element_type const j) {
                 for (std::size_t i = 0; i < nbasis_proxy; ++i) {
                     spline(ddc::DiscreteElement<bsplines_type>(i + offset_proxy), j)
                             = spline_tr(ddc::DiscreteElement<bsplines_type>(i), j);
@@ -942,8 +944,9 @@ operator()(
                 "ddc_splines_periodic_rows_duplicate_rhs",
                 exec_space(),
                 batch_domain(batched_interpolation_domain),
-                KOKKOS_LAMBDA(typename batch_domain_type<
-                              BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     if (offset_proxy != 0) {
                         for (int i = 0; i < offset_proxy; ++i) {
                             spline(ddc::DiscreteElement<bsplines_type>(i), j) = spline(
@@ -1034,14 +1037,16 @@ SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, BcLower, BcUp
     ddc::ChunkSpan const coefficients = integral_bsplines_without_periodic_additional_bsplines
             [spline_domain()
                      .remove_first(ddc::DiscreteVector<bsplines_type>(s_nbc_xmin))
-                     .take_first(ddc::DiscreteVector<bsplines_type>(
-                             ddc::discrete_space<bsplines_type>().nbasis() - s_nbc_xmin
-                             - s_nbc_xmax))];
+                     .take_first(
+                             ddc::DiscreteVector<bsplines_type>(
+                                     ddc::discrete_space<bsplines_type>().nbasis() - s_nbc_xmin
+                                     - s_nbc_xmax))];
     ddc::ChunkSpan const coefficients_derivs_xmax
             = integral_bsplines_without_periodic_additional_bsplines
                     [spline_domain()
-                             .remove_first(ddc::DiscreteVector<bsplines_type>(
-                                     s_nbc_xmin + coefficients.size()))
+                             .remove_first(
+                                     ddc::DiscreteVector<bsplines_type>(
+                                             s_nbc_xmin + coefficients.size()))
                              .take_first(ddc::DiscreteVector<bsplines_type>(s_nbc_xmax))];
     interpolation_domain_type const interpolation_domain_proxy = interpolation_domain();
 

--- a/include/ddc/kernels/splines/spline_evaluator.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator.hpp
@@ -302,8 +302,9 @@ public:
                 "ddc_splines_evaluate",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_1D = spline_eval[j];
                     const auto coords_eval_1D = coords_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
@@ -348,8 +349,9 @@ public:
                 "ddc_splines_evaluate",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_1D = spline_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
                     for (auto const i : evaluation_domain) {
@@ -425,8 +427,9 @@ public:
                 "ddc_splines_differentiate",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_1D = spline_eval[j];
                     const auto coords_eval_1D = coords_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
@@ -468,8 +471,9 @@ public:
                 "ddc_splines_differentiate",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_1D = spline_eval[j];
                     const auto spline_coef_1D = spline_coef[j];
                     for (auto const i : evaluation_domain) {

--- a/include/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/include/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -414,8 +414,9 @@ public:
                 "ddc_splines_evaluate_2d",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_2D = spline_eval[j];
                     const auto coords_eval_2D = coords_eval[j];
                     const auto spline_coef_2D = spline_coef[j];
@@ -459,8 +460,9 @@ public:
                 "ddc_splines_evaluate_2d",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_2D = spline_eval[j];
                     const auto spline_coef_2D = spline_coef[j];
                     for (auto const i1 : evaluation_domain1) {
@@ -649,8 +651,9 @@ public:
                 "ddc_splines_differentiate_2d_dim_1",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_2D = spline_eval[j];
                     const auto coords_eval_2D = coords_eval[j];
                     const auto spline_coef_2D = spline_coef[j];
@@ -694,8 +697,9 @@ public:
                 "ddc_splines_differentiate_2d_dim_1",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_2D = spline_eval[j];
                     const auto spline_coef_2D = spline_coef[j];
                     for (auto const i1 : evaluation_domain1) {
@@ -755,8 +759,9 @@ public:
                 "ddc_splines_differentiate_2d_dim_2",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_2D = spline_eval[j];
                     const auto coords_eval_2D = coords_eval[j];
                     const auto spline_coef_2D = spline_coef[j];
@@ -800,8 +805,9 @@ public:
                 "ddc_splines_differentiate_2d_dim_2",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_2D = spline_eval[j];
                     const auto spline_coef_2D = spline_coef[j];
                     for (auto const i1 : evaluation_domain1) {
@@ -861,8 +867,9 @@ public:
                 "ddc_splines_cross_differentiate",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_2D = spline_eval[j];
                     const auto coords_eval_2D = coords_eval[j];
                     const auto spline_coef_2D = spline_coef[j];
@@ -906,8 +913,9 @@ public:
                 "ddc_splines_cross_differentiate",
                 exec_space(),
                 batch_domain,
-                KOKKOS_CLASS_LAMBDA(typename batch_domain_type<
-                                    BatchedInterpolationDDom>::discrete_element_type const j) {
+                KOKKOS_CLASS_LAMBDA(
+                        typename batch_domain_type<
+                                BatchedInterpolationDDom>::discrete_element_type const j) {
                     const auto spline_eval_2D = spline_eval[j];
                     const auto spline_coef_2D = spline_coef[j];
                     for (auto const i1 : evaluation_domain1) {
@@ -1295,9 +1303,10 @@ private:
         double y = 0.0;
         for (std::size_t i = 0; i < bsplines_type1::degree() + 1; ++i) {
             for (std::size_t j = 0; j < bsplines_type2::degree() + 1; ++j) {
-                y += spline_coef(ddc::DiscreteElement<
-                                 bsplines_type1,
-                                 bsplines_type2>(jmin1 + i, jmin2 + j))
+                y += spline_coef(
+                             ddc::DiscreteElement<
+                                     bsplines_type1,
+                                     bsplines_type2>(jmin1 + i, jmin2 + j))
                      * vals1[i] * vals2[j];
             }
         }

--- a/tests/chunk.cpp
+++ b/tests/chunk.cpp
@@ -13,7 +13,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(CHUNK_CPP) {
+inline namespace anonymous_namespace_workaround_chunk_cpp {
 
 using DElem0D = ddc::DiscreteElement<>;
 using DVect0D = ddc::DiscreteVector<>;
@@ -86,7 +86,7 @@ DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
 DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
 DDomXY constexpr dom_x_y(lbound_x_y, nelems_x_y);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(CHUNK_CPP)
+} // namespace anonymous_namespace_workaround_chunk_cpp
 
 // Member types of Chunk 1D \{
 

--- a/tests/chunk_span.cpp
+++ b/tests/chunk_span.cpp
@@ -9,7 +9,7 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(CHUNK_SPAN_CPP) {
+inline namespace anonymous_namespace_workaround_chunk_span_cpp {
 
 struct DDimX
 {
@@ -31,7 +31,7 @@ using ChunkX = ddc::Chunk<Datatype, DDomX>;
 template <class Datatype>
 using ChunkSpanX = ddc::ChunkSpan<Datatype, DDomX>;
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(CHUNK_SPAN_CPP)
+} // namespace anonymous_namespace_workaround_chunk_span_cpp
 
 TEST(ChunkSpan1DTest, ConstructionFromChunk)
 {
@@ -68,7 +68,7 @@ TEST(ChunkSpan1DTest, CtadFromKokkosView)
                  ddc::ChunkSpan<const int, DDomX, Kokkos::layout_right, Kokkos::HostSpace>>));
 }
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(CHUNK_SPAN_CPP) {
+inline namespace anonymous_namespace_workaround_chunk_span_cpp {
 
 void TestChunkSpan1DTestCtadOnDevice()
 {
@@ -87,7 +87,7 @@ void TestChunkSpan1DTestCtadOnDevice()
     EXPECT_EQ(sum, view.size());
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(CHUNK_SPAN_CPP)
+} // namespace anonymous_namespace_workaround_chunk_span_cpp
 
 TEST(ChunkSpan1DTest, CtadOnDevice)
 {

--- a/tests/create_mirror.cpp
+++ b/tests/create_mirror.cpp
@@ -11,7 +11,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(CHUNK_CPP) {
+inline namespace anonymous_namespace_workaround_chunk_cpp {
 
 struct DDimX
 {
@@ -38,7 +38,7 @@ template <class ElementType, class Support, class Layout, class MemorySpace, cla
             KOKKOS_LAMBDA(DElemX elem_x) { return chunk_span(elem_x) == value; });
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(CHUNK_CPP)
+} // namespace anonymous_namespace_workaround_chunk_cpp
 
 TEST(CreateMirror, Host)
 {

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -6,7 +6,7 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP) {
+inline namespace anonymous_namespace_workaround_discrete_domain_cpp {
 
 struct DDimX
 {
@@ -79,7 +79,7 @@ DElemXY constexpr ubound_x_y(ubound_x, ubound_y);
 DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
 DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP)
+} // namespace anonymous_namespace_workaround_discrete_domain_cpp
 
 TEST(DiscreteDomainTest, Constructor)
 {

--- a/tests/discrete_element.cpp
+++ b/tests/discrete_element.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_ELEMENT_CPP) {
+inline namespace anonymous_namespace_workaround_discrete_element_cpp {
 
 struct DDimX
 {
@@ -42,7 +42,7 @@ using DVectYX = ddc::DiscreteVector<DDimY, DDimX>;
 using DElemXYZ = ddc::DiscreteElement<DDimX, DDimY, DDimZ>;
 using DVectXYZ = ddc::DiscreteVector<DDimX, DDimY, DDimZ>;
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_ELEMENT_CPP)
+} // namespace anonymous_namespace_workaround_discrete_element_cpp
 
 TEST(DiscreteElementXYZTest, ConstructorFromDiscreteElements)
 {

--- a/tests/discrete_space.cpp
+++ b/tests/discrete_space.cpp
@@ -6,14 +6,14 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_SPACE_CPP) {
+inline namespace anonymous_namespace_workaround_discrete_space_cpp {
 
 struct DimX;
 struct DDimX : ddc::UniformPointSampling<DimX>
 {
 };
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_SPACE_CPP)
+} // namespace anonymous_namespace_workaround_discrete_space_cpp
 
 TEST(DiscreteSpace, IsDiscreteSpaceInitialized)
 {

--- a/tests/discrete_vector.cpp
+++ b/tests/discrete_vector.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_VECTOR_CPP) {
+inline namespace anonymous_namespace_workaround_discrete_vector_cpp {
 
 struct DDimX
 {
@@ -33,7 +33,7 @@ using DVectXZ = ddc::DiscreteVector<DDimX, DDimZ>;
 
 using DVectXYZ = ddc::DiscreteVector<DDimX, DDimY, DDimZ>;
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_VECTOR_CPP)
+} // namespace anonymous_namespace_workaround_discrete_vector_cpp
 
 TEST(DiscreteVectorXYZTest, ConstructorFromDiscreteVectors)
 {

--- a/tests/fft/fft.cpp
+++ b/tests/fft/fft.cpp
@@ -25,7 +25,7 @@
 #    endif
 #endif
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(FFT_CPP) {
+inline namespace anonymous_namespace_workaround_fft_cpp {
 
 template <typename X>
 struct DDim : ddc::UniformPointSampling<X>
@@ -238,7 +238,7 @@ struct RDimX;
 struct RDimY;
 struct RDimZ;
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(FFT_CPP)
+} // namespace anonymous_namespace_workaround_fft_cpp
 
 TEST(FourierMesh, Extents)
 {

--- a/tests/fft/fft.cpp
+++ b/tests/fft/fft.cpp
@@ -52,10 +52,11 @@ void test_fourier_mesh(std::size_t Nx)
     double const a = -10;
     double const b = 10;
 
-    DDom<DDim<X>> const x_mesh(ddc::init_discrete_space<DDim<X>>(DDim<X>::template init<DDim<X>>(
-            ddc::Coordinate<X>(a + (b - a) / Nx / 2),
-            ddc::Coordinate<X>(b - (b - a) / Nx / 2),
-            DVect<DDim<X>>(Nx))));
+    DDom<DDim<X>> const x_mesh(
+            ddc::init_discrete_space<DDim<X>>(DDim<X>::template init<DDim<X>>(
+                    ddc::Coordinate<X>(a + (b - a) / Nx / 2),
+                    ddc::Coordinate<X>(b - (b - a) / Nx / 2),
+                    DVect<DDim<X>>(Nx))));
     ddc::init_discrete_space<DFDim<ddc::Fourier<X>>>(
             ddc::init_fourier_space<DFDim<ddc::Fourier<X>>>(ddc::DiscreteDomain<DDim<X>>(x_mesh)));
     DDom<DFDim<ddc::Fourier<X>>> const k_mesh
@@ -86,10 +87,11 @@ void test_fft()
     double const b = 10;
     std::size_t const Nx = 64; // Optimal value is (b-a)^2/(2*pi)
 
-    DDom<DDim<X>...> const x_mesh(ddc::init_discrete_space<DDim<X>>(DDim<X>::template init<DDim<X>>(
-            ddc::Coordinate<X>(a + (b - a) / Nx / 2),
-            ddc::Coordinate<X>(b - (b - a) / Nx / 2),
-            DVect<DDim<X>>(Nx)))...);
+    DDom<DDim<X>...> const x_mesh(
+            ddc::init_discrete_space<DDim<X>>(DDim<X>::template init<DDim<X>>(
+                    ddc::Coordinate<X>(a + (b - a) / Nx / 2),
+                    ddc::Coordinate<X>(b - (b - a) / Nx / 2),
+                    DVect<DDim<X>>(Nx)))...);
     (ddc::init_discrete_space<DFDim<ddc::Fourier<X>>>(
              ddc::init_fourier_space<DFDim<ddc::Fourier<X>>>(ddc::DiscreteDomain<DDim<X>>(x_mesh))),
      ...);
@@ -141,24 +143,27 @@ void test_fft()
     };
 
     std::size_t const mesh_size = x_mesh.size();
-    double const criterion = Kokkos::sqrt(ddc::transform_reduce(
-            Ff_host.domain(),
-            0.,
-            ddc::reducer::sum<double>(),
-            [=](DElem<DFDim<ddc::Fourier<X>>...> const e) {
-                double const xn2 = (pow2(ddc::coordinate(DElem<DFDim<ddc::Fourier<X>>>(e))) + ...);
-                double const diff = Kokkos::abs(Ff_host(e)) - Kokkos::exp(-xn2 / 2);
-                return pow2(diff) / (mesh_size / 2);
-            }));
+    double const criterion = Kokkos::sqrt(
+            ddc::transform_reduce(
+                    Ff_host.domain(),
+                    0.,
+                    ddc::reducer::sum<double>(),
+                    [=](DElem<DFDim<ddc::Fourier<X>>...> const e) {
+                        double const xn2
+                                = (pow2(ddc::coordinate(DElem<DFDim<ddc::Fourier<X>>>(e))) + ...);
+                        double const diff = Kokkos::abs(Ff_host(e)) - Kokkos::exp(-xn2 / 2);
+                        return pow2(diff) / (mesh_size / 2);
+                    }));
 
-    double const criterion2 = Kokkos::sqrt(ddc::transform_reduce(
-            FFf_host.domain(),
-            0.,
-            ddc::reducer::sum<double>(),
-            [=](DElem<DDim<X>...> const e) {
-                double const diff = Kokkos::abs(FFf_host(e)) - Kokkos::abs(f_host(e));
-                return pow2(diff) / mesh_size;
-            }));
+    double const criterion2 = Kokkos::sqrt(
+            ddc::transform_reduce(
+                    FFf_host.domain(),
+                    0.,
+                    ddc::reducer::sum<double>(),
+                    [=](DElem<DDim<X>...> const e) {
+                        double const diff = Kokkos::abs(FFf_host(e)) - Kokkos::abs(f_host(e));
+                        return pow2(diff) / mesh_size;
+                    }));
     double const epsilon
             = std::is_same_v<ddc::detail::fft::real_type_t<Tin>, double> ? 1e-15 : 1e-7;
     EXPECT_LE(criterion, epsilon)
@@ -174,10 +179,11 @@ void test_fft_norm(ddc::FFT_Normalization const norm)
     bool const full_fft
             = ddc::detail::fft::is_complex_v<Tin> && ddc::detail::fft::is_complex_v<Tout>;
 
-    DDom<DDim<X>> const x_mesh(ddc::init_discrete_space<DDim<X>>(DDim<X>::template init<DDim<X>>(
-            ddc::Coordinate<X>(-1. / 4),
-            ddc::Coordinate<X>(1. / 4),
-            DVect<DDim<X>>(2))));
+    DDom<DDim<X>> const x_mesh(
+            ddc::init_discrete_space<DDim<X>>(DDim<X>::template init<DDim<X>>(
+                    ddc::Coordinate<X>(-1. / 4),
+                    ddc::Coordinate<X>(1. / 4),
+                    DVect<DDim<X>>(2))));
     ddc::init_discrete_space<DFDim<ddc::Fourier<X>>>(
             ddc::init_fourier_space<DFDim<ddc::Fourier<X>>>(x_mesh));
     DDom<DFDim<ddc::Fourier<X>>> const k_mesh

--- a/tests/for_each.cpp
+++ b/tests/for_each.cpp
@@ -10,7 +10,7 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(FOR_EACH_CPP) {
+inline namespace anonymous_namespace_workaround_for_each_cpp {
 
 using DElem0D = ddc::DiscreteElement<>;
 using DVect0D = ddc::DiscreteVector<>;
@@ -43,7 +43,7 @@ DVectY constexpr nelems_y(12);
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
 DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(FOR_EACH_CPP)
+} // namespace anonymous_namespace_workaround_for_each_cpp
 
 TEST(ForEachSerialHost, Empty)
 {

--- a/tests/multiple_discrete_dimensions.cpp
+++ b/tests/multiple_discrete_dimensions.cpp
@@ -8,7 +8,7 @@
 
 #include <Kokkos_Macros.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MULTIPLE_DISCRETE_DIMENSIONS_CPP) {
+inline namespace anonymous_namespace_workaround_multiple_discrete_dimensions_cpp {
 
 class SingleValueDiscreteDimension
 {
@@ -62,7 +62,7 @@ struct SVDD2 : SingleValueDiscreteDimension
 {
 };
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MULTIPLE_DISCRETE_DIMENSIONS_CPP)
+} // namespace anonymous_namespace_workaround_multiple_discrete_dimensions_cpp
 
 TEST(MultipleDiscreteDimensions, Value)
 {

--- a/tests/non_uniform_point_sampling.cpp
+++ b/tests/non_uniform_point_sampling.cpp
@@ -27,7 +27,7 @@
      ddc::Coordinate<DimY>(0.3),                                                                   \
      ddc::Coordinate<DimY>(0.4)}
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(NON_UNIFORM_POINT_SAMPLING_CPP) {
+inline namespace anonymous_namespace_workaround_non_uniform_point_sampling_cpp {
 
 struct DimX;
 struct DimY;
@@ -55,7 +55,7 @@ ddc::Coordinate<DimY> constexpr point_ry(0.2);
 ddc::DiscreteElement<DDimX, DDimY> constexpr point_ixy(2, 1);
 ddc::Coordinate<DimX, DimY> constexpr point_rxy(0.3, 0.2);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(NON_UNIFORM_POINT_SAMPLING_CPP)
+} // namespace anonymous_namespace_workaround_non_uniform_point_sampling_cpp
 
 TEST(NonUniformPointSamplingTest, InitializerListConstructor)
 {

--- a/tests/parallel_deepcopy.cpp
+++ b/tests/parallel_deepcopy.cpp
@@ -8,7 +8,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_DEEPCOPY_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_deepcopy_cpp {
 
 struct DDimX
 {
@@ -37,7 +37,7 @@ DVectY constexpr nelems_y(2);
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
 DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_DEEPCOPY_CPP)
+} // namespace anonymous_namespace_workaround_parallel_deepcopy_cpp
 
 TEST(ParallelDeepcopy, TwoDimensions)
 {

--- a/tests/parallel_fill.cpp
+++ b/tests/parallel_fill.cpp
@@ -11,7 +11,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FILL_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_fill_cpp {
 
 struct DDimX
 {
@@ -40,7 +40,7 @@ DVectY constexpr nelems_y(12);
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
 DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FILL_CPP)
+} // namespace anonymous_namespace_workaround_parallel_fill_cpp
 
 TEST(ParallelFill, OneDimension)
 {

--- a/tests/parallel_for_each.cpp
+++ b/tests/parallel_for_each.cpp
@@ -12,7 +12,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FOR_EACH_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_for_each_cpp {
 
 using DElem0D = ddc::DiscreteElement<>;
 using DVect0D = ddc::DiscreteVector<>;
@@ -45,7 +45,7 @@ DVectY constexpr nelems_y(12);
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
 DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FOR_EACH_CPP)
+} // namespace anonymous_namespace_workaround_parallel_for_each_cpp
 
 TEST(ParallelForEachParallelHost, ZeroDimension)
 {
@@ -80,7 +80,7 @@ TEST(ParallelForEachParallelHost, TwoDimensions)
     EXPECT_EQ(std::count(storage.begin(), storage.end(), 1), dom.size());
 }
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FOR_EACH_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_for_each_cpp {
 
 void TestParallelForEachParallelDeviceZeroDimension()
 {
@@ -98,14 +98,14 @@ void TestParallelForEachParallelDeviceZeroDimension()
     EXPECT_EQ(sum, DDom0D::size());
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FOR_EACH_CPP)
+} // namespace anonymous_namespace_workaround_parallel_for_each_cpp
 
 TEST(ParallelForEachParallelDevice, ZeroDimension)
 {
     TestParallelForEachParallelDeviceZeroDimension();
 }
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FOR_EACH_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_for_each_cpp {
 
 void TestParallelForEachParallelDeviceOneDimension()
 {
@@ -123,14 +123,14 @@ void TestParallelForEachParallelDeviceOneDimension()
     EXPECT_EQ(sum, dom.size());
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FOR_EACH_CPP)
+} // namespace anonymous_namespace_workaround_parallel_for_each_cpp
 
 TEST(ParallelForEachParallelDevice, OneDimension)
 {
     TestParallelForEachParallelDeviceOneDimension();
 }
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FOR_EACH_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_for_each_cpp {
 
 void TestParallelForEachParallelDeviceTwoDimensions()
 {
@@ -148,7 +148,7 @@ void TestParallelForEachParallelDeviceTwoDimensions()
     EXPECT_EQ(sum, dom.size());
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_FOR_EACH_CPP)
+} // namespace anonymous_namespace_workaround_parallel_for_each_cpp
 
 TEST(ParallelForEachParallelDevice, TwoDimensions)
 {

--- a/tests/parallel_transform_reduce.cpp
+++ b/tests/parallel_transform_reduce.cpp
@@ -10,7 +10,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_TRANSFORM_REDUCE_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp {
 
 using DElem0D = ddc::DiscreteElement<>;
 using DVect0D = ddc::DiscreteVector<>;
@@ -43,7 +43,7 @@ DVectY constexpr nelems_y(12);
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
 DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_TRANSFORM_REDUCE_CPP)
+} // namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp
 
 TEST(ParallelTransformReduceHost, ZeroDimension)
 {
@@ -96,7 +96,7 @@ TEST(ParallelTransformReduceHost, TwoDimensions)
             dom.size() * (dom.size() - 1) / 2);
 }
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_TRANSFORM_REDUCE_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp {
 
 void TestParallelTransformReduceDeviceZeroDimension()
 {
@@ -113,14 +113,14 @@ void TestParallelTransformReduceDeviceZeroDimension()
             dom.size() * (dom.size() - 1) / 2);
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_TRANSFORM_REDUCE_CPP)
+} // namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp
 
 TEST(ParallelTransformReduceDevice, ZeroDimension)
 {
     TestParallelTransformReduceDeviceZeroDimension();
 }
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_TRANSFORM_REDUCE_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp {
 
 void TestParallelTransformReduceDeviceOneDimension()
 {
@@ -137,14 +137,14 @@ void TestParallelTransformReduceDeviceOneDimension()
             dom.size() * (dom.size() - 1) / 2);
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_TRANSFORM_REDUCE_CPP)
+} // namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp
 
 TEST(ParallelTransformReduceDevice, OneDimension)
 {
     TestParallelTransformReduceDeviceOneDimension();
 }
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_TRANSFORM_REDUCE_CPP) {
+inline namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp {
 
 void TestParallelTransformReduceDeviceTwoDimensions()
 {
@@ -163,7 +163,7 @@ void TestParallelTransformReduceDeviceTwoDimensions()
             dom.size() * (dom.size() - 1) / 2);
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PARALLEL_TRANSFORM_REDUCE_CPP)
+} // namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp
 
 TEST(ParallelTransformReduceDevice, TwoDimensions)
 {

--- a/tests/single_discretization.cpp
+++ b/tests/single_discretization.cpp
@@ -10,7 +10,7 @@
 
 namespace ddcexp = ddc::experimental;
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(SINGLE_DISCRETIZATION_CPP) {
+inline namespace anonymous_namespace_workaround_single_discretization_cpp {
 
 class DimX;
 
@@ -22,7 +22,7 @@ struct DDimX : ddcexp::SingleDiscretization<DimX>
 
 using DElemX = ddc::DiscreteElement<DDimX>;
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(SINGLE_DISCRETIZATION_CPP)
+} // namespace anonymous_namespace_workaround_single_discretization_cpp
 
 TEST(SingleDiscretization, ClassSize)
 {

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -27,7 +27,7 @@
 #endif
 #include "spline_error_bounds.hpp"
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_2D_SPLINE_BUILDER_CPP) {
+inline namespace anonymous_namespace_workaround_batched_2d_spline_builder_cpp {
 
 #if defined(BC_PERIODIC)
 struct DimX
@@ -583,7 +583,7 @@ void Batched2dSplineTest()
                         1e-11 * max_norm_diff12));
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_2D_SPLINE_BUILDER_CPP)
+} // namespace anonymous_namespace_workaround_batched_2d_spline_builder_cpp
 
 #if defined(BC_PERIODIC) && defined(BSPLINES_TYPE_UNIFORM)
 #    define SUFFIX(name) name##Periodic##Uniform

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -326,8 +326,9 @@ void BatchedSplineTest()
             spline_eval_integrals.domain(),
             0.,
             ddc::reducer::max<double>(),
-            KOKKOS_LAMBDA(typename decltype(spline_builder)::template batch_domain_type<
-                          ddc::DiscreteDomain<DDims...>>::discrete_element_type const e) {
+            KOKKOS_LAMBDA(
+                    typename decltype(spline_builder)::template batch_domain_type<
+                            ddc::DiscreteDomain<DDims...>>::discrete_element_type const e) {
                 return Kokkos::abs(
                         spline_eval_integrals(e) - evaluator.deriv(xN<I>(), -1)
                         + evaluator.deriv(x0<I>(), -1));

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -22,7 +22,7 @@
 #include "cosine_evaluator.hpp"
 #include "spline_error_bounds.hpp"
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_SPLINE_BUILDER_CPP) {
+inline namespace anonymous_namespace_workaround_batched_spline_builder_cpp {
 
 #if defined(BC_PERIODIC)
 struct DimX
@@ -353,7 +353,7 @@ void BatchedSplineTest()
                         1.0e-14 * max_norm_int));
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_SPLINE_BUILDER_CPP)
+} // namespace anonymous_namespace_workaround_batched_spline_builder_cpp
 
 #if defined(BC_PERIODIC) && defined(BSPLINES_TYPE_UNIFORM) && defined(SOLVER_LAPACK)
 #    define SUFFIX(name) name##Lapack##Periodic##Uniform

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -19,7 +19,7 @@
 #    include "polynomial_evaluator.hpp"
 #endif
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(EXTRAPOLATION_RULE_CPP) {
+inline namespace anonymous_namespace_workaround_extrapolation_rule_cpp {
 
 #if defined(BC_PERIODIC)
 struct DimX
@@ -332,7 +332,7 @@ void ExtrapolationRuleSplineTest()
     EXPECT_LE(max_norm_error, 1.0e-14 * max_norm);
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(EXTRAPOLATION_RULE_CPP)
+} // namespace anonymous_namespace_workaround_extrapolation_rule_cpp
 
 #if defined(ER_NULL) && defined(BC_PERIODIC) && defined(BSPLINES_TYPE_UNIFORM)
 #    define SUFFIX(name) name##Null##Periodic##Uniform

--- a/tests/splines/knots_as_interpolation_points.cpp
+++ b/tests/splines/knots_as_interpolation_points.cpp
@@ -15,7 +15,7 @@
 
 #include "test_utils.hpp"
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(KNOTS_AS_INTERPOLATION_POINTS_CPP) {
+inline namespace anonymous_namespace_workaround_knots_as_interpolation_points_cpp {
 
 template <class T>
 struct UniformBSplinesFixture;
@@ -65,7 +65,7 @@ struct NonUniformBSplinesFixture<std::tuple<std::integral_constant<bool, IsPerio
     };
 };
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(KNOTS_AS_INTERPOLATION_POINTS_CPP)
+} // namespace anonymous_namespace_workaround_knots_as_interpolation_points_cpp
 
 using periodicity = std::integer_sequence<bool, true, false>;
 

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -28,7 +28,7 @@
 #endif
 #include "spline_error_bounds.hpp"
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_2D_SPLINE_BUILDER_CPP) {
+inline namespace anonymous_namespace_workaround_batched_2d_spline_builder_cpp {
 
 #if defined(BC_PERIODIC)
 struct DimX
@@ -683,7 +683,7 @@ void MultipleBatchDomain2dSplineTest()
                         1e-11 * max_norm_diff12_extra));
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_2D_SPLINE_BUILDER_CPP)
+} // namespace anonymous_namespace_workaround_batched_2d_spline_builder_cpp
 
 #if defined(BC_PERIODIC) && defined(BSPLINES_TYPE_UNIFORM)
 #    define SUFFIX(name) name##Periodic##Uniform

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -295,8 +295,9 @@ std::tuple<double, double, double> ComputeEvaluationError(
             spline_eval_integrals.domain(),
             0.,
             ddc::reducer::max<double>(),
-            KOKKOS_LAMBDA(typename Builder::template batch_domain_type<
-                          ddc::DiscreteDomain<DDims...>>::discrete_element_type const e) {
+            KOKKOS_LAMBDA(
+                    typename Builder::template batch_domain_type<
+                            ddc::DiscreteDomain<DDims...>>::discrete_element_type const e) {
                 return Kokkos::abs(
                         spline_eval_integrals(e) - evaluator.deriv(xN<I>(), -1)
                         + evaluator.deriv(x0<I>(), -1));

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -23,7 +23,7 @@
 #include "cosine_evaluator.hpp"
 #include "spline_error_bounds.hpp"
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_SPLINE_BUILDER_CPP) {
+inline namespace anonymous_namespace_workaround_batched_spline_builder_cpp {
 
 #if defined(BC_PERIODIC)
 struct DimX
@@ -418,7 +418,7 @@ void MultipleBatchDomainSplineTest()
 }
 
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(BATCHED_SPLINE_BUILDER_CPP)
+} // namespace anonymous_namespace_workaround_batched_spline_builder_cpp
 
 #if defined(BC_PERIODIC) && defined(BSPLINES_TYPE_UNIFORM) && defined(SOLVER_LAPACK)
 #    define SUFFIX(name) name##Lapack##Periodic##Uniform

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -230,8 +230,9 @@ void TestNonPeriodicSplineBuilderTestIdentity()
             quadrature_coefficients_derivs_xmin.domain(),
             0.0,
             ddc::reducer::sum<double>(),
-            KOKKOS_LAMBDA(ddc::DiscreteElement<
-                          ddc::Deriv<typename DDimX::continuous_dimension_type>> const ix) {
+            KOKKOS_LAMBDA(
+                    ddc::DiscreteElement<
+                            ddc::Deriv<typename DDimX::continuous_dimension_type>> const ix) {
                 return quadrature_coefficients_derivs_xmin(ix) * derivs_lhs(ix);
             });
 #else
@@ -253,8 +254,9 @@ void TestNonPeriodicSplineBuilderTestIdentity()
             quadrature_coefficients_derivs_xmax.domain(),
             0.0,
             ddc::reducer::sum<double>(),
-            KOKKOS_LAMBDA(ddc::DiscreteElement<
-                          ddc::Deriv<typename DDimX::continuous_dimension_type>> const ix) {
+            KOKKOS_LAMBDA(
+                    ddc::DiscreteElement<
+                            ddc::Deriv<typename DDimX::continuous_dimension_type>> const ix) {
                 return quadrature_coefficients_derivs_xmax(ix) * derivs_rhs(ix);
             });
 #else

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -16,7 +16,7 @@
 #include "cosine_evaluator.hpp"
 #include "spline_error_bounds.hpp"
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PERIODICITY_SPLINE_BUILDER_CPP) {
+inline namespace anonymous_namespace_workaround_periodicity_spline_builder_cpp {
 
 struct DimX
 {
@@ -200,7 +200,7 @@ void PeriodicitySplineBuilderTest()
             std::max(error_bounds.error_bound(dx<X>(ncells), s_degree_x), 1.0e-14 * max_norm));
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(PERIODICITY_SPLINE_BUILDER_CPP)
+} // namespace anonymous_namespace_workaround_periodicity_spline_builder_cpp
 
 TEST(PeriodicitySplineBuilderHost, 1D)
 {

--- a/tests/splines/splines_linear_problem.cpp
+++ b/tests/splines/splines_linear_problem.cpp
@@ -21,7 +21,7 @@
 #include <Kokkos_Core.hpp>
 #include <Kokkos_DualView.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MATRIX_CPP) {
+inline namespace anonymous_namespace_workaround_matrix_cpp {
 
 void fill_identity(
         ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS const& mat)
@@ -142,7 +142,7 @@ void solve_and_validate(
             Kokkos::subview(inv_tr, std::pair<std::size_t, std::size_t> {0, N}, Kokkos::ALL));
 }
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(MATRIX_CPP)
+} // namespace anonymous_namespace_workaround_matrix_cpp
 
 TEST(SplinesLinearProblemSparse, Formatting)
 {

--- a/tests/storage_discrete_domain.cpp
+++ b/tests/storage_discrete_domain.cpp
@@ -6,7 +6,7 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP) {
+inline namespace anonymous_namespace_workaround_discrete_domain_cpp {
 
 struct DDimX
 {
@@ -79,7 +79,7 @@ DElemY constexpr lbound_y(4);
 // DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
 // DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP)
+} // namespace anonymous_namespace_workaround_discrete_domain_cpp
 
 TEST(StorageDiscreteDomainTest, Constructor)
 {

--- a/tests/strided_discrete_domain.cpp
+++ b/tests/strided_discrete_domain.cpp
@@ -6,7 +6,7 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP) {
+inline namespace anonymous_namespace_workaround_discrete_domain_cpp {
 
 struct DDimX
 {
@@ -84,7 +84,7 @@ DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
 DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
 DVectXZ constexpr strides_x_z(strides_x, strides_z);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(DISCRETE_DOMAIN_CPP)
+} // namespace anonymous_namespace_workaround_discrete_domain_cpp
 
 TEST(StridedDiscreteDomainTest, Constructor)
 {

--- a/tests/trivial_space.cpp
+++ b/tests/trivial_space.cpp
@@ -6,11 +6,11 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(TRIVIAL_DIMENSION_CPP) {
+inline namespace anonymous_namespace_workaround_trivial_dimension_cpp {
 
 class DDimX;
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(TRIVIAL_DIMENSION_CPP)
+} // namespace anonymous_namespace_workaround_trivial_dimension_cpp
 
 TEST(TrivialDimension, Size)
 {

--- a/tests/type_seq.cpp
+++ b/tests/type_seq.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-inline namespace anonymous_namespace_workaround_type_sed_cpp {
+inline namespace anonymous_namespace_workaround_type_seq_cpp {
 
 struct a;
 struct b;
@@ -18,7 +18,7 @@ struct e;
 struct y;
 struct z;
 
-} // namespace anonymous_namespace_workaround_type_sed_cpp
+} // namespace anonymous_namespace_workaround_type_seq_cpp
 
 TEST(TypeSeqTest, Size)
 {

--- a/tests/type_seq.cpp
+++ b/tests/type_seq.cpp
@@ -8,7 +8,7 @@
 
 #include <gtest/gtest.h>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(TYPE_SED_CPP) {
+inline namespace anonymous_namespace_workaround_type_sed_cpp {
 
 struct a;
 struct b;
@@ -18,7 +18,7 @@ struct e;
 struct y;
 struct z;
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(TYPE_SED_CPP)
+} // namespace anonymous_namespace_workaround_type_sed_cpp
 
 TEST(TypeSeqTest, Size)
 {

--- a/tests/uniform_point_sampling.cpp
+++ b/tests/uniform_point_sampling.cpp
@@ -11,7 +11,7 @@
 
 #include <Kokkos_Core.hpp>
 
-namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(UNIFORM_POINT_SAMPLING_CPP) {
+inline namespace anonymous_namespace_workaround_uniform_point_sampling_cpp {
 
 struct DimX;
 struct DimY;
@@ -29,7 +29,7 @@ ddc::Real constexpr step = 0.5;
 ddc::DiscreteElement<DDimX> constexpr point_ix(2);
 ddc::Coordinate<DimX> constexpr point_rx(0.);
 
-} // namespace DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND(UNIFORM_POINT_SAMPLING_CPP)
+} // namespace anonymous_namespace_workaround_uniform_point_sampling_cpp
 
 TEST(UniformPointSamplingTest, Constructor)
 {


### PR DESCRIPTION
- use a more active github action: `jidicula/clang-format-action`
- upgrade to clang-format 20
- replace the macro `DDC_HIP_5_7_ANONYMOUS_NAMESPACE_WORKAROUND` with `inline namespace` to avoid many problems both for formatting and GPU compilation.