### PR TITLE
Rename storage to sparse

### DIFF
--- a/include/ddc/ddc.hpp
+++ b/include/ddc/ddc.hpp
@@ -55,7 +55,7 @@ namespace ddc {
 #include "ddc/discrete_vector.hpp"
 #include "ddc/non_uniform_point_sampling.hpp"
 #include "ddc/periodic_sampling.hpp"
-#include "ddc/storage_discrete_domain.hpp"
+#include "ddc/sparse_discrete_domain.hpp"
 #include "ddc/strided_discrete_domain.hpp"
 #include "ddc/trivial_space.hpp"
 #include "ddc/uniform_point_sampling.hpp"

--- a/include/ddc/sparse_discrete_domain.hpp
+++ b/include/ddc/sparse_discrete_domain.hpp
@@ -22,29 +22,29 @@
 namespace ddc {
 
 template <class DDim>
-struct StorageDiscreteDomainIterator;
+struct SparseDiscreteDomainIterator;
 
 template <class... DDims>
-class StorageDiscreteDomain;
+class SparseDiscreteDomain;
 
 template <class T>
-struct is_storage_discrete_domain : std::false_type
+struct is_sparse_discrete_domain : std::false_type
 {
 };
 
 template <class... Tags>
-struct is_storage_discrete_domain<StorageDiscreteDomain<Tags...>> : std::true_type
+struct is_sparse_discrete_domain<SparseDiscreteDomain<Tags...>> : std::true_type
 {
 };
 
 template <class T>
-inline constexpr bool is_storage_discrete_domain_v = is_storage_discrete_domain<T>::value;
+inline constexpr bool is_sparse_discrete_domain_v = is_sparse_discrete_domain<T>::value;
 
 
 namespace detail {
 
 template <class... Tags>
-struct ToTypeSeq<StorageDiscreteDomain<Tags...>>
+struct ToTypeSeq<SparseDiscreteDomain<Tags...>>
 {
     using type = TypeSeq<Tags...>;
 };
@@ -53,9 +53,9 @@ template <class T, class U>
 struct RebindDomain;
 
 template <class... DDims, class... ODDims>
-struct RebindDomain<StorageDiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
+struct RebindDomain<SparseDiscreteDomain<DDims...>, detail::TypeSeq<ODDims...>>
 {
-    using type = StorageDiscreteDomain<ODDims...>;
+    using type = SparseDiscreteDomain<ODDims...>;
 };
 
 template <class InputIt1, class InputIt2>
@@ -117,10 +117,10 @@ struct GetUidFn
 } // namespace detail
 
 template <class... DDims>
-class StorageDiscreteDomain
+class SparseDiscreteDomain
 {
     template <class...>
-    friend class StorageDiscreteDomain;
+    friend class SparseDiscreteDomain;
 
 public:
     using discrete_element_type = DiscreteElement<DDims...>;
@@ -136,21 +136,19 @@ public:
         return sizeof...(DDims);
     }
 
-    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain() = default;
+    KOKKOS_DEFAULTED_FUNCTION SparseDiscreteDomain() = default;
 
-    /// Construct a StorageDiscreteDomain by copies and merge of domains
-    template <
-            class... DDoms,
-            class = std::enable_if_t<(is_storage_discrete_domain_v<DDoms> && ...)>>
-    KOKKOS_FUNCTION constexpr explicit StorageDiscreteDomain(DDoms const&... domains)
+    /// Construct a SparseDiscreteDomain by copies and merge of domains
+    template <class... DDoms, class = std::enable_if_t<(is_sparse_discrete_domain_v<DDoms> && ...)>>
+    KOKKOS_FUNCTION constexpr explicit SparseDiscreteDomain(DDoms const&... domains)
         : m_views(domains.m_views...)
     {
     }
 
-    /** Construct a StorageDiscreteDomain with Kokkos::View explicitly listing the discrete elements.
+    /** Construct a SparseDiscreteDomain with Kokkos::View explicitly listing the discrete elements.
      * @param views list of Kokkos::View
      */
-    explicit StorageDiscreteDomain(
+    explicit SparseDiscreteDomain(
             Kokkos::View<DiscreteElement<DDims>*, Kokkos::SharedSpace> const&... views)
     {
         ((m_views[type_seq_rank_v<DDims, detail::TypeSeq<DDims...>>]
@@ -158,28 +156,28 @@ public:
          ...);
         Kokkos::DefaultExecutionSpace const execution_space;
         ((Kokkos::Experimental::transform(
-                 "StorageDiscreteDomainCtor",
+                 "SparseDiscreteDomainCtor",
                  execution_space,
                  views,
                  m_views[type_seq_rank_v<DDims, detail::TypeSeq<DDims...>>],
                  detail::GetUidFn<DDims>())),
          ...);
-        execution_space.fence("StorageDiscreteDomainCtor");
+        execution_space.fence("SparseDiscreteDomainCtor");
     }
 
-    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain(StorageDiscreteDomain const& x) = default;
+    KOKKOS_DEFAULTED_FUNCTION SparseDiscreteDomain(SparseDiscreteDomain const& x) = default;
 
-    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain(StorageDiscreteDomain&& x) = default;
+    KOKKOS_DEFAULTED_FUNCTION SparseDiscreteDomain(SparseDiscreteDomain&& x) = default;
 
-    KOKKOS_DEFAULTED_FUNCTION ~StorageDiscreteDomain() = default;
+    KOKKOS_DEFAULTED_FUNCTION ~SparseDiscreteDomain() = default;
 
-    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain& operator=(StorageDiscreteDomain const& x)
+    KOKKOS_DEFAULTED_FUNCTION SparseDiscreteDomain& operator=(SparseDiscreteDomain const& x)
             = default;
 
-    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain& operator=(StorageDiscreteDomain&& x) = default;
+    KOKKOS_DEFAULTED_FUNCTION SparseDiscreteDomain& operator=(SparseDiscreteDomain&& x) = default;
 
     template <class... ODims>
-    KOKKOS_FUNCTION constexpr bool operator==(StorageDiscreteDomain<ODims...> const& other) const
+    KOKKOS_FUNCTION constexpr bool operator==(SparseDiscreteDomain<ODims...> const& other) const
     {
         if (empty() && other.empty()) {
             return true;
@@ -204,7 +202,7 @@ public:
 #if !defined(__cpp_impl_three_way_comparison) || __cpp_impl_three_way_comparison < 201902L
     // In C++20, `a!=b` shall be automatically translated by the compiler to `!(a==b)`
     template <class... ODims>
-    KOKKOS_FUNCTION constexpr bool operator!=(StorageDiscreteDomain<ODims...> const& other) const
+    KOKKOS_FUNCTION constexpr bool operator!=(SparseDiscreteDomain<ODims...> const& other) const
     {
         return !(*this == other);
     }
@@ -241,31 +239,31 @@ public:
         return discrete_element_type(get<DDims>(m_views)(get<DDims>(m_views).size() - 1)...);
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain take_first(discrete_vector_type n) const
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain take_first(discrete_vector_type n) const
     {
-        return StorageDiscreteDomain(front(), n);
+        return SparseDiscreteDomain(front(), n);
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain take_last(discrete_vector_type n) const
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain take_last(discrete_vector_type n) const
     {
-        return StorageDiscreteDomain(front() + prod(extents() - n), n);
+        return SparseDiscreteDomain(front() + prod(extents() - n), n);
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove_first(discrete_vector_type n) const
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain remove_first(discrete_vector_type n) const
     {
-        return StorageDiscreteDomain(front() + prod(n), extents() - n);
+        return SparseDiscreteDomain(front() + prod(n), extents() - n);
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove_last(discrete_vector_type n) const
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain remove_last(discrete_vector_type n) const
     {
-        return StorageDiscreteDomain(front(), extents() - n);
+        return SparseDiscreteDomain(front(), extents() - n);
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove(
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain remove(
             discrete_vector_type n1,
             discrete_vector_type n2) const
     {
-        return StorageDiscreteDomain(front() + prod(n1), extents() - n1 - n2);
+        return SparseDiscreteDomain(front() + prod(n1), extents() - n1 - n2);
     }
 
     KOKKOS_FUNCTION constexpr DiscreteElement<DDims...> operator()(
@@ -367,10 +365,10 @@ public:
 };
 
 template <>
-class StorageDiscreteDomain<>
+class SparseDiscreteDomain<>
 {
     template <class...>
-    friend class StorageDiscreteDomain;
+    friend class SparseDiscreteDomain;
 
 public:
     using discrete_element_type = DiscreteElement<>;
@@ -382,35 +380,35 @@ public:
         return 0;
     }
 
-    KOKKOS_DEFAULTED_FUNCTION constexpr StorageDiscreteDomain() = default;
+    KOKKOS_DEFAULTED_FUNCTION constexpr SparseDiscreteDomain() = default;
 
-    // Construct a StorageDiscreteDomain from a reordered copy of `domain`
+    // Construct a SparseDiscreteDomain from a reordered copy of `domain`
     template <class... ODDims>
-    KOKKOS_FUNCTION constexpr explicit StorageDiscreteDomain(
-            [[maybe_unused]] StorageDiscreteDomain<ODDims...> const& domain)
+    KOKKOS_FUNCTION constexpr explicit SparseDiscreteDomain(
+            [[maybe_unused]] SparseDiscreteDomain<ODDims...> const& domain)
     {
     }
 
-    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain(StorageDiscreteDomain const& x) = default;
+    KOKKOS_DEFAULTED_FUNCTION SparseDiscreteDomain(SparseDiscreteDomain const& x) = default;
 
-    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain(StorageDiscreteDomain&& x) = default;
+    KOKKOS_DEFAULTED_FUNCTION SparseDiscreteDomain(SparseDiscreteDomain&& x) = default;
 
-    KOKKOS_DEFAULTED_FUNCTION ~StorageDiscreteDomain() = default;
+    KOKKOS_DEFAULTED_FUNCTION ~SparseDiscreteDomain() = default;
 
-    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain& operator=(StorageDiscreteDomain const& x)
+    KOKKOS_DEFAULTED_FUNCTION SparseDiscreteDomain& operator=(SparseDiscreteDomain const& x)
             = default;
 
-    KOKKOS_DEFAULTED_FUNCTION StorageDiscreteDomain& operator=(StorageDiscreteDomain&& x) = default;
+    KOKKOS_DEFAULTED_FUNCTION SparseDiscreteDomain& operator=(SparseDiscreteDomain&& x) = default;
 
     KOKKOS_FUNCTION constexpr bool operator==(
-            [[maybe_unused]] StorageDiscreteDomain const& other) const
+            [[maybe_unused]] SparseDiscreteDomain const& other) const
     {
         return true;
     }
 
 #if !defined(__cpp_impl_three_way_comparison) || __cpp_impl_three_way_comparison < 201902L
     // In C++20, `a!=b` shall be automatically translated by the compiler to `!(a==b)`
-    KOKKOS_FUNCTION constexpr bool operator!=(StorageDiscreteDomain const& other) const
+    KOKKOS_FUNCTION constexpr bool operator!=(SparseDiscreteDomain const& other) const
     {
         return !(*this == other);
     }
@@ -436,31 +434,31 @@ public:
         return {};
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain take_first(
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain take_first(
             [[maybe_unused]] discrete_vector_type n) const
     {
         return *this;
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain take_last(
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain take_last(
             [[maybe_unused]] discrete_vector_type n) const
     {
         return *this;
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove_first(
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain remove_first(
             [[maybe_unused]] discrete_vector_type n) const
     {
         return *this;
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove_last(
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain remove_last(
             [[maybe_unused]] discrete_vector_type n) const
     {
         return *this;
     }
 
-    KOKKOS_FUNCTION constexpr StorageDiscreteDomain remove(
+    KOKKOS_FUNCTION constexpr SparseDiscreteDomain remove(
             [[maybe_unused]] discrete_vector_type n1,
             [[maybe_unused]] discrete_vector_type n2) const
     {
@@ -505,10 +503,10 @@ public:
 };
 
 template <class... QueryDDims, class... DDims>
-KOKKOS_FUNCTION constexpr StorageDiscreteDomain<QueryDDims...> select(
-        StorageDiscreteDomain<DDims...> const& domain)
+KOKKOS_FUNCTION constexpr SparseDiscreteDomain<QueryDDims...> select(
+        SparseDiscreteDomain<DDims...> const& domain)
 {
-    return StorageDiscreteDomain<QueryDDims...>(
+    return SparseDiscreteDomain<QueryDDims...>(
             DiscreteElement<QueryDDims...>(domain.front()),
             DiscreteElement<QueryDDims...>(domain.extents()));
 }
@@ -516,31 +514,31 @@ KOKKOS_FUNCTION constexpr StorageDiscreteDomain<QueryDDims...> select(
 namespace detail {
 
 template <class T>
-struct ConvertTypeSeqToStorageDiscreteDomain;
+struct ConvertTypeSeqToSparseDiscreteDomain;
 
 template <class... DDims>
-struct ConvertTypeSeqToStorageDiscreteDomain<detail::TypeSeq<DDims...>>
+struct ConvertTypeSeqToSparseDiscreteDomain<detail::TypeSeq<DDims...>>
 {
-    using type = StorageDiscreteDomain<DDims...>;
+    using type = SparseDiscreteDomain<DDims...>;
 };
 
 template <class T>
-using convert_type_seq_to_storage_discrete_domain_t =
-        typename ConvertTypeSeqToStorageDiscreteDomain<T>::type;
+using convert_type_seq_to_sparse_discrete_domain_t =
+        typename ConvertTypeSeqToSparseDiscreteDomain<T>::type;
 
 } // namespace detail
 
 // Computes the subtraction DDom_a - DDom_b in the sense of linear spaces(retained dimensions are those in DDom_a which are not in DDom_b)
 template <class... DDimsA, class... DDimsB>
 KOKKOS_FUNCTION constexpr auto remove_dims_of(
-        StorageDiscreteDomain<DDimsA...> const& DDom_a,
-        [[maybe_unused]] StorageDiscreteDomain<DDimsB...> const& DDom_b) noexcept
+        SparseDiscreteDomain<DDimsA...> const& DDom_a,
+        [[maybe_unused]] SparseDiscreteDomain<DDimsB...> const& DDom_b) noexcept
 {
     using TagSeqA = detail::TypeSeq<DDimsA...>;
     using TagSeqB = detail::TypeSeq<DDimsB...>;
 
     using type_seq_r = type_seq_remove_t<TagSeqA, TagSeqB>;
-    return detail::convert_type_seq_to_storage_discrete_domain_t<type_seq_r>(DDom_a);
+    return detail::convert_type_seq_to_sparse_discrete_domain_t<type_seq_r>(DDom_a);
 }
 
 //! Remove the dimensions DDimsB from DDom_a
@@ -548,13 +546,13 @@ KOKKOS_FUNCTION constexpr auto remove_dims_of(
 //! @return The discrete domain without DDimsB dimensions
 template <class... DDimsB, class... DDimsA>
 KOKKOS_FUNCTION constexpr auto remove_dims_of(
-        StorageDiscreteDomain<DDimsA...> const& DDom_a) noexcept
+        SparseDiscreteDomain<DDimsA...> const& DDom_a) noexcept
 {
     using TagSeqA = detail::TypeSeq<DDimsA...>;
     using TagSeqB = detail::TypeSeq<DDimsB...>;
 
     using type_seq_r = type_seq_remove_t<TagSeqA, TagSeqB>;
-    return detail::convert_type_seq_to_storage_discrete_domain_t<type_seq_r>(DDom_a);
+    return detail::convert_type_seq_to_sparse_discrete_domain_t<type_seq_r>(DDom_a);
 }
 
 namespace detail {
@@ -563,14 +561,14 @@ namespace detail {
 template <typename DDim1, typename DDim2, typename DDimA, typename... DDimsB>
 KOKKOS_FUNCTION constexpr std::conditional_t<
         std::is_same_v<DDimA, DDim1>,
-        ddc::StorageDiscreteDomain<DDim2>,
-        ddc::StorageDiscreteDomain<DDimA>>
+        ddc::SparseDiscreteDomain<DDim2>,
+        ddc::SparseDiscreteDomain<DDimA>>
 replace_dim_of_1d(
-        StorageDiscreteDomain<DDimA> const& DDom_a,
-        [[maybe_unused]] StorageDiscreteDomain<DDimsB...> const& DDom_b) noexcept
+        SparseDiscreteDomain<DDimA> const& DDom_a,
+        [[maybe_unused]] SparseDiscreteDomain<DDimsB...> const& DDom_b) noexcept
 {
     if constexpr (std::is_same_v<DDimA, DDim1>) {
-        return ddc::StorageDiscreteDomain<DDim2>(DDom_b);
+        return ddc::SparseDiscreteDomain<DDim2>(DDom_b);
     } else {
         return DDom_a;
     }
@@ -581,8 +579,8 @@ replace_dim_of_1d(
 // Replace in DDom_a the dimension Dim1 by the dimension Dim2 of DDom_b
 template <typename DDim1, typename DDim2, typename... DDimsA, typename... DDimsB>
 KOKKOS_FUNCTION constexpr auto replace_dim_of(
-        StorageDiscreteDomain<DDimsA...> const& DDom_a,
-        [[maybe_unused]] StorageDiscreteDomain<DDimsB...> const& DDom_b) noexcept
+        SparseDiscreteDomain<DDimsA...> const& DDom_a,
+        [[maybe_unused]] SparseDiscreteDomain<DDimsB...> const& DDom_b) noexcept
 {
     // TODO : static_asserts
     using TagSeqA = detail::TypeSeq<DDimsA...>;
@@ -590,33 +588,33 @@ KOKKOS_FUNCTION constexpr auto replace_dim_of(
     using TagSeqC = detail::TypeSeq<DDim2>;
 
     using type_seq_r = ddc::type_seq_replace_t<TagSeqA, TagSeqB, TagSeqC>;
-    return ddc::detail::convert_type_seq_to_storage_discrete_domain_t<type_seq_r>(
+    return ddc::detail::convert_type_seq_to_sparse_discrete_domain_t<type_seq_r>(
             detail::replace_dim_of_1d<
                     DDim1,
                     DDim2,
                     DDimsA,
-                    DDimsB...>(ddc::StorageDiscreteDomain<DDimsA>(DDom_a), DDom_b)...);
+                    DDimsB...>(ddc::SparseDiscreteDomain<DDimsA>(DDom_a), DDom_b)...);
 }
 
 template <class... QueryDDims, class... DDims>
 KOKKOS_FUNCTION constexpr DiscreteVector<QueryDDims...> extents(
-        StorageDiscreteDomain<DDims...> const& domain) noexcept
+        SparseDiscreteDomain<DDims...> const& domain) noexcept
 {
-    return DiscreteVector<QueryDDims...>(StorageDiscreteDomain<QueryDDims>(domain).size()...);
+    return DiscreteVector<QueryDDims...>(SparseDiscreteDomain<QueryDDims>(domain).size()...);
 }
 
 template <class... QueryDDims, class... DDims>
 KOKKOS_FUNCTION constexpr DiscreteElement<QueryDDims...> front(
-        StorageDiscreteDomain<DDims...> const& domain) noexcept
+        SparseDiscreteDomain<DDims...> const& domain) noexcept
 {
-    return DiscreteElement<QueryDDims...>(StorageDiscreteDomain<QueryDDims>(domain).front()...);
+    return DiscreteElement<QueryDDims...>(SparseDiscreteDomain<QueryDDims>(domain).front()...);
 }
 
 template <class... QueryDDims, class... DDims>
 KOKKOS_FUNCTION constexpr DiscreteElement<QueryDDims...> back(
-        StorageDiscreteDomain<DDims...> const& domain) noexcept
+        SparseDiscreteDomain<DDims...> const& domain) noexcept
 {
-    return DiscreteElement<QueryDDims...>(StorageDiscreteDomain<QueryDDims>(domain).back()...);
+    return DiscreteElement<QueryDDims...>(SparseDiscreteDomain<QueryDDims>(domain).back()...);
 }
 
 } // namespace ddc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ add_executable(
     relocatable_device_code.cpp
     relocatable_device_code_initialization.cpp
     single_discretization.cpp
-    storage_discrete_domain.cpp
+    sparse_discrete_domain.cpp
     strided_discrete_domain.cpp
     tagged_vector.cpp
     transform_reduce.cpp

--- a/tests/sparse_discrete_domain.cpp
+++ b/tests/sparse_discrete_domain.cpp
@@ -13,7 +13,7 @@ struct DDimX
 };
 using DElemX = ddc::DiscreteElement<DDimX>;
 using DVectX = ddc::DiscreteVector<DDimX>;
-using DDomX = ddc::StorageDiscreteDomain<DDimX>;
+using DDomX = ddc::SparseDiscreteDomain<DDimX>;
 
 
 struct DDimY
@@ -21,7 +21,7 @@ struct DDimY
 };
 using DElemY = ddc::DiscreteElement<DDimY>;
 using DVectY = ddc::DiscreteVector<DDimY>;
-using DDomY = ddc::StorageDiscreteDomain<DDimY>;
+using DDomY = ddc::SparseDiscreteDomain<DDimY>;
 
 
 struct DDimZ
@@ -29,34 +29,34 @@ struct DDimZ
 };
 using DElemZ = ddc::DiscreteElement<DDimZ>;
 using DVectZ = ddc::DiscreteVector<DDimZ>;
-using DDomZ = ddc::StorageDiscreteDomain<DDimZ>;
+using DDomZ = ddc::SparseDiscreteDomain<DDimZ>;
 
 
 using DElemXY = ddc::DiscreteElement<DDimX, DDimY>;
 using DVectXY = ddc::DiscreteVector<DDimX, DDimY>;
-using DDomXY = ddc::StorageDiscreteDomain<DDimX, DDimY>;
+using DDomXY = ddc::SparseDiscreteDomain<DDimX, DDimY>;
 
 
 using DElemYX = ddc::DiscreteElement<DDimY, DDimX>;
 using DVectYX = ddc::DiscreteVector<DDimY, DDimX>;
-using DDomYX = ddc::StorageDiscreteDomain<DDimY, DDimX>;
+using DDomYX = ddc::SparseDiscreteDomain<DDimY, DDimX>;
 
 using DElemXZ = ddc::DiscreteElement<DDimX, DDimZ>;
 using DVectXZ = ddc::DiscreteVector<DDimX, DDimZ>;
-using DDomXZ = ddc::StorageDiscreteDomain<DDimX, DDimZ>;
+using DDomXZ = ddc::SparseDiscreteDomain<DDimX, DDimZ>;
 
 using DElemZY = ddc::DiscreteElement<DDimZ, DDimY>;
 using DVectZY = ddc::DiscreteVector<DDimZ, DDimY>;
-using DDomZY = ddc::StorageDiscreteDomain<DDimZ, DDimY>;
+using DDomZY = ddc::SparseDiscreteDomain<DDimZ, DDimY>;
 
 
 using DElemXYZ = ddc::DiscreteElement<DDimX, DDimY, DDimZ>;
 using DVectXYZ = ddc::DiscreteVector<DDimX, DDimY, DDimZ>;
-using DDomXYZ = ddc::StorageDiscreteDomain<DDimX, DDimY, DDimZ>;
+using DDomXYZ = ddc::SparseDiscreteDomain<DDimX, DDimY, DDimZ>;
 
 using DElemZYX = ddc::DiscreteElement<DDimZ, DDimY, DDimX>;
 using DVectZYX = ddc::DiscreteVector<DDimZ, DDimY, DDimX>;
-using DDomZYX = ddc::StorageDiscreteDomain<DDimZ, DDimY, DDimX>;
+using DDomZYX = ddc::SparseDiscreteDomain<DDimZ, DDimY, DDimX>;
 
 DElemX constexpr lbound_x(50);
 // DVectX constexpr nelems_x(3);
@@ -81,7 +81,7 @@ DElemY constexpr lbound_y(4);
 
 } // namespace anonymous_namespace_workaround_discrete_domain_cpp
 
-TEST(StorageDiscreteDomainTest, Constructor)
+TEST(SparseDiscreteDomainTest, Constructor)
 {
     Kokkos::View<DElemX*, Kokkos::SharedSpace> const view_x("view_x", 2);
     view_x(0) = lbound_x + 0;


### PR DESCRIPTION
This PR renames `StorageDiscreteDomain` to `SparseDiscreteDomain`, no deprecation as it is not used by downstream applications.