### PR TITLE
Remove direct calls to integer constructor of DiscreteElement

### DIFF
--- a/include/ddc/discrete_domain.hpp
+++ b/include/ddc/discrete_domain.hpp
@@ -190,7 +190,7 @@ public:
     }
 
     template <class... ODDims>
-    KOKKOS_FUNCTION auto restrict_with(DiscreteDomain<ODDims...> const& odomain) const
+    KOKKOS_FUNCTION constexpr auto restrict_with(DiscreteDomain<ODDims...> const& odomain) const
     {
         assert(((DiscreteElement<ODDims>(m_element_begin)
                  <= DiscreteElement<ODDims>(odomain.m_element_begin))

--- a/include/ddc/discrete_element.hpp
+++ b/include/ddc/discrete_element.hpp
@@ -75,11 +75,15 @@ KOKKOS_FUNCTION constexpr DiscreteElementType& uid(DiscreteElement<Tags...>& tup
 }
 
 template <class QueryTag, class... Tags>
-KOKKOS_FUNCTION constexpr DiscreteElementType const& uid_or(
-        DiscreteElement<Tags...> const& tuple,
-        DiscreteElementType const& default_value) noexcept
+KOKKOS_FUNCTION constexpr DiscreteElement<QueryTag> select_or(
+        DiscreteElement<Tags...> const& arr,
+        DiscreteElement<QueryTag> const& default_value) noexcept
 {
-    return tuple.template uid_or<QueryTag>(default_value);
+    if constexpr (in_tags_v<QueryTag, detail::TypeSeq<Tags...>>) {
+        return DiscreteElement<QueryTag>(arr);
+    } else {
+        return default_value;
+    }
 }
 
 template <class... QueryTags, class... Tags>
@@ -140,6 +144,12 @@ KOKKOS_FUNCTION constexpr std::array<DiscreteElementType, sizeof...(Tags)> const
 
 } // namespace detail
 
+template <class DDim>
+constexpr DiscreteElement<DDim> create_reference_discrete_element() noexcept
+{
+    return DiscreteElement<DDim>(0);
+}
+
 /** A DiscreteElement identifies an element of the discrete dimension
  *
  * Each one is tagged by its associated dimensions.
@@ -194,18 +204,6 @@ public:
     KOKKOS_DEFAULTED_FUNCTION DiscreteElement& operator=(DiscreteElement const& other) = default;
 
     KOKKOS_DEFAULTED_FUNCTION DiscreteElement& operator=(DiscreteElement&& other) = default;
-
-    template <class QueryTag>
-    KOKKOS_FUNCTION constexpr value_type const& uid_or(value_type const& default_value) const&
-    {
-        DDC_IF_NVCC_THEN_PUSH_AND_SUPPRESS(implicit_return_from_non_void_function)
-        if constexpr (in_tags_v<QueryTag, tags_seq>) {
-            return m_values[type_seq_rank_v<QueryTag, tags_seq>];
-        } else {
-            return default_value;
-        }
-        DDC_IF_NVCC_THEN_POP
-    }
 
     template <class QueryTag>
     KOKKOS_FUNCTION constexpr value_type& uid() noexcept
@@ -393,7 +391,9 @@ KOKKOS_FUNCTION constexpr DiscreteElement<Tag> operator+(
         DiscreteElement<Tag> const& lhs,
         IntegralType const& rhs)
 {
-    return DiscreteElement<Tag>(uid<Tag>(lhs) + rhs);
+    DiscreteElement<Tag> result(lhs);
+    result += rhs;
+    return result;
 }
 
 template <class... Tags, class... OTags>
@@ -417,7 +417,9 @@ KOKKOS_FUNCTION constexpr DiscreteElement<Tag> operator-(
         DiscreteElement<Tag> const& lhs,
         IntegralType const& rhs)
 {
-    return DiscreteElement<Tag>(uid<Tag>(lhs) - rhs);
+    DiscreteElement<Tag> result(lhs);
+    result -= rhs;
+    return result;
 }
 
 /// binary operator: -

--- a/include/ddc/discrete_vector.hpp
+++ b/include/ddc/discrete_vector.hpp
@@ -69,6 +69,18 @@ KOKKOS_FUNCTION constexpr DiscreteVectorElement const& get_or(
     return tuple.template get_or<QueryTag>(default_value);
 }
 
+template <class QueryTag, class... Tags>
+KOKKOS_FUNCTION constexpr DiscreteVector<QueryTag> select_or(
+        DiscreteVector<Tags...> const& arr,
+        DiscreteVector<QueryTag> const& default_value) noexcept
+{
+    if constexpr (in_tags_v<QueryTag, detail::TypeSeq<Tags...>>) {
+        return DiscreteVector<QueryTag>(arr);
+    } else {
+        return default_value;
+    }
+}
+
 /// Unary operators: +, -
 
 template <class... Tags>

--- a/include/ddc/experimental/single_discretization.hpp
+++ b/include/ddc/experimental/single_discretization.hpp
@@ -52,6 +52,8 @@ public:
         /// origin
         Coordinate<CDim> m_point;
 
+        DiscreteElement<DDim> m_reference;
+
     public:
         using discrete_dimension_type = SingleDiscretization;
 
@@ -61,10 +63,16 @@ public:
 
         using discrete_vector_type = DiscreteVector<DDim>;
 
-        explicit Impl(Coordinate<CDim> origin) noexcept : m_point(std::move(origin)) {}
+        explicit Impl(Coordinate<CDim> origin) noexcept
+            : m_point(std::move(origin))
+            , m_reference(create_reference_discrete_element<DDim>())
+        {
+        }
 
         template <class OriginMemorySpace>
-        explicit Impl(Impl<DDim, OriginMemorySpace> const& impl) : m_point(impl.m_point)
+        explicit Impl(Impl<DDim, OriginMemorySpace> const& impl)
+            : m_point(impl.m_point)
+            , m_reference(impl.m_reference)
         {
         }
 
@@ -83,10 +91,15 @@ public:
             return m_point;
         }
 
+        KOKKOS_FUNCTION discrete_element_type front() const noexcept
+        {
+            return m_reference;
+        }
+
         KOKKOS_FUNCTION Coordinate<CDim> coordinate(
                 [[maybe_unused]] discrete_element_type icoord) const noexcept
         {
-            assert(icoord == discrete_element_type(0));
+            assert(icoord == front());
             return m_point;
         }
     };

--- a/include/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/include/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -107,6 +107,8 @@ public:
         ddc::DiscreteDomain<knot_discrete_dimension_type> m_knot_domain;
         ddc::DiscreteDomain<knot_discrete_dimension_type> m_break_point_domain;
 
+        ddc::DiscreteElement<DDim> m_reference;
+
     public:
         Impl() = default;
 
@@ -163,6 +165,7 @@ public:
         explicit Impl(Impl<DDim, OriginMemorySpace> const& impl)
             : m_knot_domain(impl.m_knot_domain)
             , m_break_point_domain(impl.m_break_point_domain)
+            , m_reference(impl.m_reference)
         {
         }
 
@@ -255,8 +258,7 @@ public:
         KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<knot_discrete_dimension_type>
         get_first_support_knot(discrete_element_type const& ix) const
         {
-            return ddc::DiscreteElement<knot_discrete_dimension_type>(
-                    (ix - discrete_element_type(0)).value());
+            return m_knot_domain.front() + (ix - m_reference).value();
         }
 
         /** @brief Returns the coordinate of the last support knot associated to a DiscreteElement identifying a B-spline.
@@ -321,7 +323,7 @@ public:
          */
         KOKKOS_INLINE_FUNCTION discrete_domain_type full_domain() const
         {
-            return discrete_domain_type(discrete_element_type(0), discrete_vector_type(size()));
+            return discrete_domain_type(m_reference, discrete_vector_type(size()));
         }
 
         /** @brief Returns the discrete domain which describes the break points.
@@ -372,7 +374,7 @@ public:
         KOKKOS_INLINE_FUNCTION discrete_element_type get_first_bspline_in_cell(
                 ddc::DiscreteElement<knot_discrete_dimension_type> const& ic) const
         {
-            return discrete_element_type((ic - m_break_point_domain.front()).value());
+            return m_reference + (ic - m_break_point_domain.front()).value();
         }
 
         /**
@@ -413,6 +415,7 @@ NonUniformBSplines<CDim, D>::Impl<DDim, MemorySpace>::Impl(
               ddc::DiscreteElement<knot_discrete_dimension_type>(degree()),
               ddc::DiscreteVector<knot_discrete_dimension_type>(
                       (breaks_end - breaks_begin))) // Create a mesh of break points
+    , m_reference(ddc::create_reference_discrete_element<DDim>())
 {
     std::vector<ddc::Coordinate<CDim>> knots((breaks_end - breaks_begin) + 2 * degree());
     // Fill the provided knots

--- a/include/ddc/periodic_sampling.hpp
+++ b/include/ddc/periodic_sampling.hpp
@@ -60,6 +60,8 @@ public:
 
         std::size_t m_n_period;
 
+        DiscreteElement<DDim> m_reference;
+
     public:
         using discrete_dimension_type = PeriodicSampling;
 
@@ -69,7 +71,13 @@ public:
 
         using discrete_vector_type = DiscreteVector<DDim>;
 
-        Impl() noexcept : m_origin(0), m_step(1), m_n_period(2) {}
+        Impl() noexcept
+            : m_origin(0)
+            , m_step(1)
+            , m_n_period(2)
+            , m_reference(create_reference_discrete_element<DDim>())
+        {
+        }
 
         Impl(Impl const&) = delete;
 
@@ -78,6 +86,7 @@ public:
             : m_origin(impl.m_origin)
             , m_step(impl.m_step)
             , m_n_period(impl.m_n_period)
+            , m_reference(impl.m_reference)
         {
         }
 
@@ -93,6 +102,7 @@ public:
             : m_origin(origin)
             , m_step(step)
             , m_n_period(n_period)
+            , m_reference(create_reference_discrete_element<DDim>())
         {
             assert(step > 0);
             assert(n_period > 0);
@@ -113,7 +123,7 @@ public:
         /// @brief Lower bound index of the mesh
         KOKKOS_FUNCTION discrete_element_type front() const noexcept
         {
-            return discrete_element_type(0);
+            return m_reference;
         }
 
         /// @brief Spacing step of the mesh
@@ -134,7 +144,7 @@ public:
         {
             return m_origin
                    + Coordinate<CDim>(
-                             static_cast<int>((icoord.uid() + m_n_period / 2) % m_n_period)
+                             static_cast<int>(((icoord - front()) + m_n_period / 2) % m_n_period)
                              - static_cast<int>(m_n_period / 2))
                              * m_step;
         }

--- a/include/ddc/strided_discrete_domain.hpp
+++ b/include/ddc/strided_discrete_domain.hpp
@@ -165,7 +165,7 @@ public:
     template <class QueryDDim>
     KOKKOS_FUNCTION constexpr DiscreteVector<QueryDDim> extent() const noexcept
     {
-        return DiscreteVector<QueryDDim>(uid<QueryDDim>(m_extents));
+        return DiscreteVector<QueryDDim>(m_extents);
     }
 
     KOKKOS_FUNCTION constexpr discrete_element_type front() const noexcept
@@ -176,7 +176,7 @@ public:
     KOKKOS_FUNCTION constexpr discrete_element_type back() const noexcept
     {
         return discrete_element_type(
-                (uid<DDims>(m_element_begin)
+                (DiscreteElement<DDims>(m_element_begin)
                  + (get<DDims>(m_extents) - 1) * get<DDims>(m_strides))...);
     }
 
@@ -612,7 +612,7 @@ public:
 
     KOKKOS_FUNCTION constexpr StridedDiscreteDomainIterator& operator++()
     {
-        m_value.uid() += m_stride.value();
+        m_value += m_stride;
         return *this;
     }
 
@@ -625,7 +625,7 @@ public:
 
     KOKKOS_FUNCTION constexpr StridedDiscreteDomainIterator& operator--()
     {
-        m_value.uid() -= m_stride.value();
+        m_value -= m_stride;
         return *this;
     }
 
@@ -639,9 +639,9 @@ public:
     KOKKOS_FUNCTION constexpr StridedDiscreteDomainIterator& operator+=(difference_type n)
     {
         if (n >= difference_type(0)) {
-            m_value.uid() += static_cast<DiscreteElementType>(n) * m_stride.value();
+            m_value += static_cast<DiscreteElementType>(n) * m_stride;
         } else {
-            m_value.uid() -= static_cast<DiscreteElementType>(-n) * m_stride.value();
+            m_value -= static_cast<DiscreteElementType>(-n) * m_stride;
         }
         return *this;
     }
@@ -649,16 +649,16 @@ public:
     KOKKOS_FUNCTION constexpr StridedDiscreteDomainIterator& operator-=(difference_type n)
     {
         if (n >= difference_type(0)) {
-            m_value.uid() -= static_cast<DiscreteElementType>(n) * m_stride.value();
+            m_value -= static_cast<DiscreteElementType>(n) * m_stride;
         } else {
-            m_value.uid() += static_cast<DiscreteElementType>(-n) * m_stride.value();
+            m_value += static_cast<DiscreteElementType>(-n) * m_stride;
         }
         return *this;
     }
 
     KOKKOS_FUNCTION constexpr DiscreteElement<DDim> operator[](difference_type n) const
     {
-        return m_value + n * m_stride.value();
+        return m_value + n * m_stride;
     }
 
     friend KOKKOS_FUNCTION constexpr bool operator==(

--- a/include/ddc/trivial_space.hpp
+++ b/include/ddc/trivial_space.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ddc/discrete_domain.hpp"
+#include "ddc/discrete_element.hpp"
 #include "ddc/discrete_vector.hpp"
 
 namespace ddc {
@@ -17,7 +18,7 @@ namespace ddc {
 template <class DDim>
 constexpr DiscreteDomain<DDim> init_trivial_bounded_space(DiscreteVector<DDim> const n) noexcept
 {
-    return DiscreteDomain<DDim>(DiscreteElement<DDim>(0), n);
+    return DiscreteDomain<DDim>(create_reference_discrete_element<DDim>(), n);
 }
 
 /** Construct a half bounded dimension without attributes.
@@ -27,7 +28,7 @@ constexpr DiscreteDomain<DDim> init_trivial_bounded_space(DiscreteVector<DDim> c
 template <class DDim>
 constexpr DiscreteElement<DDim> init_trivial_half_bounded_space() noexcept
 {
-    return DiscreteElement<DDim>(0);
+    return create_reference_discrete_element<DDim>();
 }
 
 } // namespace ddc

--- a/include/ddc/uniform_point_sampling.hpp
+++ b/include/ddc/uniform_point_sampling.hpp
@@ -57,6 +57,8 @@ public:
 
         Real m_step;
 
+        DiscreteElement<DDim> m_reference;
+
     public:
         using discrete_dimension_type = UniformPointSampling;
 
@@ -66,7 +68,12 @@ public:
 
         using discrete_vector_type = DiscreteVector<DDim>;
 
-        Impl() noexcept : m_origin(0), m_step(1) {}
+        Impl() noexcept
+            : m_origin(0)
+            , m_step(1)
+            , m_reference(create_reference_discrete_element<DDim>())
+        {
+        }
 
         Impl(Impl const&) = delete;
 
@@ -74,6 +81,7 @@ public:
         explicit Impl(Impl<DDim, OriginMemorySpace> const& impl)
             : m_origin(impl.m_origin)
             , m_step(impl.m_step)
+            , m_reference(impl.m_reference)
         {
         }
 
@@ -84,7 +92,10 @@ public:
          * @param origin the real coordinate of mesh coordinate 0
          * @param step   the real distance between two points of mesh distance 1
          */
-        Impl(Coordinate<CDim> origin, Real step) : m_origin(origin), m_step(step)
+        Impl(Coordinate<CDim> origin, Real step)
+            : m_origin(origin)
+            , m_step(step)
+            , m_reference(create_reference_discrete_element<DDim>())
         {
             assert(step > 0);
         }
@@ -104,7 +115,7 @@ public:
         /// @brief Lower bound index of the mesh
         KOKKOS_FUNCTION discrete_element_type front() const noexcept
         {
-            return discrete_element_type(0);
+            return m_reference;
         }
 
         /// @brief Spacing step of the mesh
@@ -117,7 +128,7 @@ public:
         KOKKOS_FUNCTION Coordinate<CDim> coordinate(
                 discrete_element_type const& icoord) const noexcept
         {
-            return m_origin + Coordinate<CDim>(icoord.uid() * m_step);
+            return m_origin + Coordinate<CDim>((icoord - front()) * m_step);
         }
     };
 

--- a/tests/chunk.cpp
+++ b/tests/chunk.cpp
@@ -75,12 +75,14 @@ DElem0D constexpr lbound_0d {};
 DVect0D constexpr nelems_0d {};
 DDom0D constexpr dom_0d(lbound_0d, nelems_0d);
 
-DElemX constexpr lbound_x(50);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 DVectX constexpr nelems_x(3);
 DDomX constexpr dom_x(lbound_x, nelems_x);
 
-DElemY constexpr lbound_y(4);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
 DVectY constexpr nelems_y(12);
+
+DElemZ constexpr lbound_z = ddc::init_trivial_half_bounded_space<DDimZ>();
 
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
 DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
@@ -123,14 +125,14 @@ TEST(Chunk1DTest, MoveConstructor)
     double const factor = 1.391;
     ChunkX<double> chunk(dom_x);
     for (DElemX const ix : chunk.domain()) {
-        chunk(ix) = factor * ix.uid();
+        chunk(ix) = factor * (ix - lbound_x);
     }
 
     ChunkX<double> const chunk2(std::move(chunk));
     EXPECT_EQ(chunk2.domain(), dom_x);
     for (DElemX const ix : chunk2.domain()) {
         // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
-        EXPECT_EQ(factor * ix.uid(), chunk2(ix));
+        EXPECT_EQ(factor * (ix - lbound_x), chunk2(ix));
     }
 }
 
@@ -151,7 +153,7 @@ TEST(Chunk1DTest, MoveAssignment)
     double const factor = 1.976;
     ChunkX<double> chunk(dom_x);
     for (DElemX const ix : chunk.domain()) {
-        chunk(ix) = factor * ix.uid();
+        chunk(ix) = factor * (ix - lbound_x);
     }
 
     ChunkX<double> chunk2(DDomX(lbound_x, DVectX(0)));
@@ -159,7 +161,7 @@ TEST(Chunk1DTest, MoveAssignment)
     EXPECT_EQ(chunk2.domain(), dom_x);
     for (DElemX const ix : chunk2.domain()) {
         // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
-        EXPECT_EQ(factor * ix.uid(), chunk2(ix));
+        EXPECT_EQ(factor * (ix - lbound_x), chunk2(ix));
     }
 }
 
@@ -183,7 +185,7 @@ TEST(Chunk1DTest, Swap)
     double const factor = 1.976;
     ChunkX<double> chunk(dom_x);
     for (DElemX const ix : chunk.domain()) {
-        chunk(ix) = factor * ix.uid();
+        chunk(ix) = factor * (ix - lbound_x);
     }
 
     DDomX const empty_domain(lbound_x, DVectX(0));
@@ -194,7 +196,7 @@ TEST(Chunk1DTest, Swap)
     EXPECT_EQ(chunk2.domain(), dom_x);
     for (DElemX const ix : chunk2.domain()) {
         // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
-        EXPECT_EQ(factor * ix.uid(), chunk2(ix));
+        EXPECT_EQ(factor * (ix - lbound_x), chunk2(ix));
     }
 }
 
@@ -206,9 +208,9 @@ TEST(Chunk1DTest, AccessConst)
     ChunkX<double> chunk(dom_x);
     ChunkX<double> const& chunk_cref = chunk;
     for (DElemX const ix : chunk.domain()) {
-        chunk(ix) = factor * ix.uid();
+        chunk(ix) = factor * (ix - lbound_x);
         // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
-        EXPECT_EQ(chunk_cref(ix), factor * ix.uid());
+        EXPECT_EQ(chunk_cref(ix), factor * (ix - lbound_x));
     }
 }
 
@@ -217,9 +219,9 @@ TEST(Chunk1DTest, Access)
     double const factor = 1.012;
     ChunkX<double> chunk(dom_x);
     for (DElemX const ix : chunk.domain()) {
-        chunk(ix) = factor * ix.uid();
+        chunk(ix) = factor * (ix - lbound_x);
         // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
-        EXPECT_EQ(chunk(ix), factor * ix.uid());
+        EXPECT_EQ(chunk(ix), factor * (ix - lbound_x));
     }
 }
 
@@ -228,9 +230,9 @@ TEST(Chunk1DTest, SpanCview)
     double const factor = 1.567;
     ChunkX<double> chunk(dom_x);
     for (DElemX const ix : chunk.domain()) {
-        chunk(ix) = factor * ix.uid();
+        chunk(ix) = factor * (ix - lbound_x);
         // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
-        EXPECT_EQ(chunk.span_cview()(ix), factor * ix.uid());
+        EXPECT_EQ(chunk.span_cview()(ix), factor * (ix - lbound_x));
     }
 }
 
@@ -240,9 +242,9 @@ TEST(Chunk1DTest, ViewConst)
     ChunkX<double> chunk(dom_x);
     ChunkX<double> const& chunk_cref = chunk;
     for (DElemX const ix : chunk.domain()) {
-        chunk(ix) = factor * ix.uid();
+        chunk(ix) = factor * (ix - lbound_x);
         // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
-        EXPECT_EQ(chunk_cref.span_view()(ix), factor * ix.uid());
+        EXPECT_EQ(chunk_cref.span_view()(ix), factor * (ix - lbound_x));
     }
 }
 
@@ -251,9 +253,9 @@ TEST(Chunk1DTest, View)
     double const factor = 1.259;
     ChunkX<double> chunk(dom_x);
     for (DElemX const ix : chunk.domain()) {
-        chunk.span_view()(ix) = factor * ix.uid();
+        chunk.span_view()(ix) = factor * (ix - lbound_x);
         // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
-        EXPECT_EQ(chunk(ix), factor * ix.uid());
+        EXPECT_EQ(chunk(ix), factor * (ix - lbound_x));
     }
 }
 
@@ -412,7 +414,7 @@ TEST(Chunk1DTest, Deepcopy)
 {
     ChunkX<double> chunk(dom_x);
     for (DElemX const ix : chunk.domain()) {
-        chunk(ix) = 1.001 * ix.uid();
+        chunk(ix) = 1.001 * (ix - lbound_x);
     }
     ChunkX<double> chunk2(chunk.domain());
     ddc::parallel_deepcopy(chunk2, chunk);
@@ -432,7 +434,7 @@ TEST(Chunk2DTest, Access)
     ChunkXY<double> chunk(dom_x_y);
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1.357 * ix.uid() + 1.159 * iy.uid();
+            chunk(ix, iy) = 1.357 * (ix - lbound_x) + 1.159 * (iy - lbound_y);
             // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
             EXPECT_EQ(chunk(ix, iy), chunk(ix, iy));
         }
@@ -444,7 +446,7 @@ TEST(Chunk2DTest, AccessReordered)
     ChunkXY<double> chunk(dom_x_y);
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1.455 * ix.uid() + 1.522 * iy.uid();
+            chunk(ix, iy) = 1.455 * (ix - lbound_x) + 1.522 * (iy - lbound_y);
             // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
             EXPECT_EQ(chunk(iy, ix), chunk(ix, iy));
         }
@@ -456,7 +458,7 @@ TEST(Chunk2DTest, Cview)
     ChunkXY<double> chunk(dom_x_y);
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+            chunk(ix, iy) = 1. * (ix - lbound_x) + .001 * (iy - lbound_y);
         }
     }
     ddc::ChunkSpan const cview = chunk.span_cview();
@@ -476,7 +478,7 @@ TEST(Chunk2DTest, SliceCoordX)
     ChunkXY<double> const& chunk_cref = chunk;
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+            chunk(ix, iy) = 1. * (ix - lbound_x) + .001 * (iy - lbound_y);
         }
     }
 
@@ -498,7 +500,7 @@ TEST(Chunk2DTest, SliceCoordY)
     ChunkXY<double> const& chunk_cref = chunk;
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+            chunk(ix, iy) = 1. * (ix - lbound_x) + .001 * (iy - lbound_y);
         }
     }
 
@@ -520,7 +522,7 @@ TEST(Chunk2DTest, SliceDomainX)
     ChunkXY<double> const& chunk_cref = chunk;
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+            chunk(ix, iy) = 1. * (ix - lbound_x) + .001 * (iy - lbound_y);
         }
     }
 
@@ -546,7 +548,7 @@ TEST(Chunk2DTest, SliceDomainY)
     ChunkXY<double> const& chunk_cref = chunk;
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1. * ix.uid() + .001 * iy.uid();
+            chunk(ix, iy) = 1. * (ix - lbound_x) + .001 * (iy - lbound_y);
         }
     }
     ddc::ChunkSpan const subchunk_y = chunk_cref[subdomain_y];
@@ -569,7 +571,7 @@ TEST(Chunk2DTest, Deepcopy)
     ChunkXY<double> chunk(dom_x_y);
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1.739 * ix.uid() + 1.412 * iy.uid();
+            chunk(ix, iy) = 1.739 * (ix - lbound_x) + 1.412 * (iy - lbound_y);
         }
     }
     ChunkXY<double> chunk2(chunk.domain());
@@ -587,7 +589,7 @@ TEST(Chunk2DTest, DeepcopyReordered)
     ChunkXY<double> chunk(dom_x_y);
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
-            chunk(ix, iy) = 1.739 * ix.uid() + 1.412 * iy.uid();
+            chunk(ix, iy) = 1.739 * (ix - lbound_x) + 1.412 * (iy - lbound_y);
         }
     }
     ChunkYX<double> chunk2(DDomYX(chunk.domain()));
@@ -606,13 +608,14 @@ TEST(Chunk2DTest, DeepcopyReordered)
 TEST(Chunk3DTest, AccessFromDiscreteElements)
 {
     using DDomXYZ = ddc::DiscreteDomain<DDimX, DDimY, DDimZ>;
-    DDomZ const dom_z(ddc::DiscreteElement<DDimZ>(2), ddc::DiscreteVector<DDimZ>(4));
+    DDomZ const dom_z(lbound_z, ddc::DiscreteVector<DDimZ>(4));
     ddc::Chunk<double, DDomXYZ> chunk(DDomXYZ(dom_x_y, dom_z));
     ddc::ChunkSpan const chunk_span = chunk.span_cview();
     for (DElemX const ix : chunk.domain<DDimX>()) {
         for (DElemY const iy : chunk.domain<DDimY>()) {
             for (DElemZ const iz : chunk.domain<DDimZ>()) {
-                chunk(ix, iy, iz) = 1.357 * ix.uid() + 1.159 * iy.uid() + 3.2 * iz.uid();
+                chunk(ix, iy, iz)
+                        = 1.357 * (ix - lbound_x) + 1.159 * (iy - lbound_y) + 3.2 * (iz - lbound_z);
                 ddc::DiscreteElement<DDimX, DDimZ> const izx(iz, ix);
                 // we expect exact equality, not EXPECT_DOUBLE_EQ: this is the same ref twice
                 EXPECT_EQ(chunk(ix, iy, iz), chunk(iy, izx));

--- a/tests/chunk_span.cpp
+++ b/tests/chunk_span.cpp
@@ -74,8 +74,9 @@ void TestChunkSpan1DTestCtadOnDevice()
 {
     Kokkos::View<int*, Kokkos::LayoutRight> const view("view", 3);
     Kokkos::deep_copy(view, 1);
-    ddc::DiscreteElement<DDimX> const ix(0);
-    ddc::DiscreteDomain<DDimX> const ddom_x(ix, ddc::DiscreteVector<DDimX>(view.extent(0)));
+    ddc::DiscreteDomain<DDimX> const ddom_x
+            = ddc::init_trivial_bounded_space(ddc::DiscreteVector<DDimX>(view.extent(0)));
+    ddc::DiscreteElement<DDimX> const ix = ddom_x.front();
     int sum;
     Kokkos::parallel_reduce(
             view.extent(0),
@@ -97,8 +98,10 @@ TEST(ChunkSpan1DTest, CtadOnDevice)
 TEST(ChunkSpan2DTest, CtorContiguousLayoutRightKokkosView)
 {
     Kokkos::View<int**, Kokkos::LayoutRight> const view("view", 133, 189);
+    ddc::DiscreteElement<DDimX> const delem_x = ddc::init_trivial_half_bounded_space<DDimX>();
+    ddc::DiscreteElement<DDimY> const delem_y = ddc::init_trivial_half_bounded_space<DDimY>();
     ddc::DiscreteDomain<DDimX, DDimY> const
-            ddom_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
+            ddom_xy(ddc::DiscreteElement<DDimX, DDimY>(delem_x, delem_y),
                     ddc::DiscreteVector<DDimX, DDimY>(view.extent(0), view.extent(1)));
     EXPECT_NO_FATAL_FAILURE(ddc::ChunkSpan(view, ddom_xy));
 }
@@ -108,8 +111,10 @@ TEST(ChunkSpan2DTest, CtorNonContiguousLayoutRightKokkosView)
     Kokkos::View<int**, Kokkos::LayoutRight> const
             view(Kokkos::view_alloc("view", Kokkos::AllowPadding), 133, 189);
     if (!view.span_is_contiguous()) {
+        ddc::DiscreteElement<DDimX> const delem_x = ddc::init_trivial_half_bounded_space<DDimX>();
+        ddc::DiscreteElement<DDimY> const delem_y = ddc::init_trivial_half_bounded_space<DDimY>();
         ddc::DiscreteDomain<DDimX, DDimY> const
-                ddom_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
+                ddom_xy(ddc::DiscreteElement<DDimX, DDimY>(delem_x, delem_y),
                         ddc::DiscreteVector<DDimX, DDimY>(view.extent(0), view.extent(1)));
         EXPECT_DEBUG_DEATH(ddc::ChunkSpan(view, ddom_xy), ".*is_kokkos_layout_compatible.*");
     } else {
@@ -122,8 +127,10 @@ TEST(ChunkSpan2DTest, CtorLayoutStrideKokkosView)
     Kokkos::View<int***, Kokkos::LayoutRight> const view("view", 3, 4, 5);
     Kokkos::View<int**, Kokkos::LayoutStride> const subview
             = Kokkos::subview(view, Kokkos::ALL, Kokkos::ALL, 3);
+    ddc::DiscreteElement<DDimX> const delem_x = ddc::init_trivial_half_bounded_space<DDimX>();
+    ddc::DiscreteElement<DDimY> const delem_y = ddc::init_trivial_half_bounded_space<DDimY>();
     ddc::DiscreteDomain<DDimX, DDimY> const
-            ddom_xy(ddc::DiscreteElement<DDimX, DDimY>(0, 0),
+            ddom_xy(ddc::DiscreteElement<DDimX, DDimY>(delem_x, delem_y),
                     ddc::DiscreteVector<DDimX, DDimY>(subview.extent(0), subview.extent(1)));
     ASSERT_TRUE((std::is_same_v<decltype(subview)::array_layout, Kokkos::LayoutStride>));
     EXPECT_NO_FATAL_FAILURE(ddc::ChunkSpan(subview, ddom_xy));

--- a/tests/create_mirror.cpp
+++ b/tests/create_mirror.cpp
@@ -11,7 +11,7 @@
 
 #include <Kokkos_Core.hpp>
 
-inline namespace anonymous_namespace_workaround_chunk_cpp {
+inline namespace anonymous_namespace_workaround_create_mirror_cpp {
 
 struct DDimX
 {
@@ -20,7 +20,7 @@ using DElemX = ddc::DiscreteElement<DDimX>;
 using DVectX = ddc::DiscreteVector<DDimX>;
 using DDomX = ddc::DiscreteDomain<DDimX>;
 
-DElemX constexpr lbound_x(50);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 DVectX constexpr nelems_x(3);
 DDomX constexpr dom_x(lbound_x, nelems_x);
 
@@ -38,7 +38,7 @@ template <class ElementType, class Support, class Layout, class MemorySpace, cla
             KOKKOS_LAMBDA(DElemX elem_x) { return chunk_span(elem_x) == value; });
 }
 
-} // namespace anonymous_namespace_workaround_chunk_cpp
+} // namespace anonymous_namespace_workaround_create_mirror_cpp
 
 TEST(CreateMirror, Host)
 {

--- a/tests/discrete_domain.cpp
+++ b/tests/discrete_domain.cpp
@@ -58,18 +58,18 @@ using DElemZYX = ddc::DiscreteElement<DDimZ, DDimY, DDimX>;
 using DVectZYX = ddc::DiscreteVector<DDimZ, DDimY, DDimX>;
 using DDomZYX = ddc::DiscreteDomain<DDimZ, DDimY, DDimX>;
 
-DElemX constexpr lbound_x(50);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 DVectX constexpr nelems_x(3);
 DElemX constexpr sentinel_x(lbound_x + nelems_x);
 DElemX constexpr ubound_x(sentinel_x - 1);
 
 
-DElemY constexpr lbound_y(4);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
 DVectY constexpr nelems_y(12);
 DElemY constexpr sentinel_y(lbound_y + nelems_y);
 DElemY constexpr ubound_y(sentinel_y - 1);
 
-DElemZ constexpr lbound_z(7);
+DElemZ constexpr lbound_z = ddc::init_trivial_half_bounded_space<DDimZ>();
 DVectZ constexpr nelems_z(15);
 
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
@@ -131,8 +131,8 @@ TEST(DiscreteDomainTest, CompareSameDomains)
 
 TEST(DiscreteDomainTest, CompareDifferentDomains)
 {
-    DDomXY const dom_x_y_1(DElemXY(0, 1), DVectXY(1, 2));
-    DDomXY const dom_x_y_2(DElemXY(2, 3), DVectXY(3, 4));
+    DDomXY const dom_x_y_1(lbound_x_y + DVectXY(0, 1), DVectXY(1, 2));
+    DDomXY const dom_x_y_2(lbound_x_y + DVectXY(2, 3), DVectXY(3, 4));
     EXPECT_FALSE(dom_x_y_1 == dom_x_y_2);
     EXPECT_FALSE(dom_x_y_1 == DDomYX(dom_x_y_2));
     EXPECT_TRUE(dom_x_y_1 != dom_x_y_2);
@@ -141,8 +141,8 @@ TEST(DiscreteDomainTest, CompareDifferentDomains)
 
 TEST(DiscreteDomainTest, CompareEmptyDomains)
 {
-    DDomXY const dom_x_y_1(DElemXY(4, 1), DVectXY(0, 0));
-    DDomXY const dom_x_y_2(DElemXY(3, 9), DVectXY(0, 0));
+    DDomXY const dom_x_y_1(lbound_x_y + DVectXY(4, 1), DVectXY(0, 0));
+    DDomXY const dom_x_y_2(lbound_x_y + DVectXY(3, 9), DVectXY(0, 0));
     EXPECT_TRUE(dom_x_y_1.empty());
     EXPECT_TRUE(dom_x_y_2.empty());
     EXPECT_TRUE(dom_x_y_1 == dom_x_y_2);
@@ -170,7 +170,7 @@ TEST(DiscreteDomainTest, RangeFor)
         EXPECT_LE(lbound_x, ix);
         EXPECT_EQ(ix, ii);
         EXPECT_LE(ix, ubound_x);
-        ++ii.uid<DDimX>();
+        ++ii;
     }
 }
 
@@ -261,12 +261,12 @@ TEST(DiscreteDomainTest, DistanceFromFront)
 TEST(DiscreteDomainTest, SliceDomainXTooearly)
 {
 #ifndef NDEBUG // The assertion is only checked if NDEBUG isn't defined
-    DDomX const subdomain_x(lbound_x - 1, nelems_x);
-    DDomXY const dom_x_y(lbound_x_y, nelems_x_y);
+    DDomX const subdomain_x(lbound_x, nelems_x);
+    DDomXY const dom_x_y(lbound_x_y + DVectXY(1, 1), nelems_x_y);
     // the error message is checked with clang & gcc only
     EXPECT_DEATH(
             dom_x_y.restrict_with(subdomain_x),
-            R"rgx([Aa]ssert.*uid<ODDims>\(m_element_begin\).*uid<ODDims>\(odomain\.m_element_begin\))rgx");
+            R"rgx([Aa]ssert.*DiscreteElement<ODDims>\(m_element_begin\).*DiscreteElement<ODDims>\(odomain\.m_element_begin\))rgx");
 #else
     GTEST_SKIP();
 #endif
@@ -280,7 +280,7 @@ TEST(DiscreteDomainTest, SliceDomainXToolate)
     // the error message is checked with clang & gcc only
     EXPECT_DEATH(
             dom_x_y.restrict_with(subdomain_x),
-            R"rgx([Aa]ssert.*uid<ODDims>\(m_element_end\).*uid<ODDims>\(odomain\.m_element_end\).*)rgx");
+            R"rgx([Aa]ssert.*DiscreteElement<ODDims>\(m_element_end\).*DiscreteElement<ODDims>\(odomain\.m_element_end\).*)rgx");
 #else
     GTEST_SKIP();
 #endif

--- a/tests/fft/fft.cpp
+++ b/tests/fft/fft.cpp
@@ -253,7 +253,10 @@ TEST(FourierMesh, Extents)
     using DDimFx = DFDim<ddc::Fourier<RDimX>>;
     using DDimFy = DFDim<ddc::Fourier<RDimY>>;
 
-    ddc::DiscreteElement<DDimX, DDimY> const delem_xy(0, 0);
+    ddc::DiscreteElement<DDimX> const delem_x = ddc::init_trivial_half_bounded_space<DDimX>();
+    ddc::DiscreteElement<DDimY> const delem_y = ddc::init_trivial_half_bounded_space<DDimY>();
+
+    ddc::DiscreteElement<DDimX, DDimY> const delem_xy(delem_x, delem_y);
 
     ddc::DiscreteVector<DDimX, DDimY> const dvect_xy_odd(10, 11);
     ddc::DiscreteDomain<DDimX, DDimY> const ddom_xy_odd(delem_xy, dvect_xy_odd);

--- a/tests/for_each.cpp
+++ b/tests/for_each.cpp
@@ -34,10 +34,10 @@ using DElemXY = ddc::DiscreteElement<DDimX, DDimY>;
 using DVectXY = ddc::DiscreteVector<DDimX, DDimY>;
 using DDomXY = ddc::DiscreteDomain<DDimX, DDimY>;
 
-DElemX constexpr lbound_x(0);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 DVectX constexpr nelems_x(10);
 
-DElemY constexpr lbound_y(0);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
 DVectY constexpr nelems_y(12);
 
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);

--- a/tests/parallel_deepcopy.cpp
+++ b/tests/parallel_deepcopy.cpp
@@ -28,10 +28,10 @@ using DElemXY = ddc::DiscreteElement<DDimX, DDimY>;
 using DVectXY = ddc::DiscreteVector<DDimX, DDimY>;
 using DDomXY = ddc::DiscreteDomain<DDimX, DDimY>;
 
-DElemX constexpr lbound_x(0);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 DVectX constexpr nelems_x(2);
 
-DElemY constexpr lbound_y(0);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
 DVectY constexpr nelems_y(2);
 
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);

--- a/tests/parallel_fill.cpp
+++ b/tests/parallel_fill.cpp
@@ -31,10 +31,10 @@ using DElemXY = ddc::DiscreteElement<DDimX, DDimY>;
 using DVectXY = ddc::DiscreteVector<DDimX, DDimY>;
 using DDomXY = ddc::DiscreteDomain<DDimX, DDimY>;
 
-DElemX constexpr lbound_x(0);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 DVectX constexpr nelems_x(10);
 
-DElemY constexpr lbound_y(0);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
 DVectY constexpr nelems_y(12);
 
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);

--- a/tests/parallel_for_each.cpp
+++ b/tests/parallel_for_each.cpp
@@ -36,10 +36,10 @@ using DElemXY = ddc::DiscreteElement<DDimX, DDimY>;
 using DVectXY = ddc::DiscreteVector<DDimX, DDimY>;
 using DDomXY = ddc::DiscreteDomain<DDimX, DDimY>;
 
-DElemX constexpr lbound_x(0);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 DVectX constexpr nelems_x(10);
 
-DElemY constexpr lbound_y(0);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
 DVectY constexpr nelems_y(12);
 
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);

--- a/tests/parallel_transform_reduce.cpp
+++ b/tests/parallel_transform_reduce.cpp
@@ -34,10 +34,10 @@ using DElemXY = ddc::DiscreteElement<DDimX, DDimY>;
 using DVectXY = ddc::DiscreteVector<DDimX, DDimY>;
 using DDomXY = ddc::DiscreteDomain<DDimX, DDimY>;
 
-DElemX constexpr lbound_x(0);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 DVectX constexpr nelems_x(10);
 
-DElemY constexpr lbound_y(0);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
 DVectY constexpr nelems_y(12);
 
 DElemXY constexpr lbound_x_y(lbound_x, lbound_y);

--- a/tests/pdi/pdi.cpp
+++ b/tests/pdi/pdi.cpp
@@ -98,9 +98,11 @@ plugins:
     PDI_errhandler(PDI_NULL_HANDLER);
 
     {
-        ddc::DiscreteDomain<DDimX, DDimY> const
-                ddom_xy(ddc::DiscreteElement<DDimX, DDimY>(7, 11),
-                        ddc::DiscreteVector<DDimX, DDimY>(3, 5));
+        ddc::DiscreteDomain<DDimX> const ddom_x
+                = ddc::init_trivial_bounded_space(ddc::DiscreteVector<DDimX>(3));
+        ddc::DiscreteDomain<DDimY> const ddom_y
+                = ddc::init_trivial_bounded_space(ddc::DiscreteVector<DDimY>(5));
+        ddc::DiscreteDomain<DDimX, DDimY> const ddom_xy(ddom_x, ddom_y);
 
         ddc::Chunk chunk("ddc_chunk_label", ddom_xy, ddc::HostAllocator<int>());
         ddc::parallel_fill(chunk, 3);

--- a/tests/relocatable_device_code.cpp
+++ b/tests/relocatable_device_code.cpp
@@ -14,7 +14,7 @@
 
 std::pair<ddc::Coordinate<rdc::DimX>, ddc::Coordinate<rdc::DimX>> read_from_device()
 {
-    rdc::DDomX const dom_x(rdc::DElemX(0), rdc::DVectX(2));
+    rdc::DDomX const dom_x = ddc::init_trivial_bounded_space(rdc::DVectX(2));
     ddc::Chunk allocation_d(dom_x, ddc::DeviceAllocator<double>());
     ddc::ChunkSpan const array = allocation_d.span_view();
     ddc::parallel_for_each(
@@ -27,7 +27,8 @@ std::pair<ddc::Coordinate<rdc::DimX>, ddc::Coordinate<rdc::DimX>> read_from_devi
     ddc::parallel_deepcopy(allocation_h, allocation_d);
     return std::pair<
             ddc::Coordinate<rdc::DimX>,
-            ddc::Coordinate<rdc::DimX>>(allocation_h(rdc::DElemX(0)), allocation_h(rdc::DElemX(1)));
+            ddc::Coordinate<
+                    rdc::DimX>>(allocation_h(dom_x.front()), allocation_h(dom_x.front() + 1));
 }
 
 TEST(RelocatableDeviceCode, ReadFromDevice)

--- a/tests/single_discretization.cpp
+++ b/tests/single_discretization.cpp
@@ -24,23 +24,18 @@ using DElemX = ddc::DiscreteElement<DDimX>;
 
 } // namespace anonymous_namespace_workaround_single_discretization_cpp
 
-TEST(SingleDiscretization, ClassSize)
-{
-    EXPECT_EQ(sizeof(DDimX::Impl<DDimX, Kokkos::HostSpace>), sizeof(ddc::CoordinateElement));
-}
-
 TEST(SingleDiscretization, Constructor)
 {
     CoordX const x(1.);
 
     ddcexp::SingleDiscretization<DimX>::Impl<DDimX, Kokkos::HostSpace> const ddim_x(x);
 
-    EXPECT_EQ(ddim_x.coordinate(DElemX(0)), x);
+    EXPECT_EQ(ddim_x.coordinate(ddim_x.front()), x);
 }
 
 TEST(SingleDiscretization, Coordinate)
 {
     CoordX const x(1.);
     ddc::init_discrete_space<DDimX>(x);
-    EXPECT_EQ(ddcexp::coordinate(DElemX(0)), x);
+    EXPECT_EQ(ddcexp::coordinate(ddc::discrete_space<DDimX>().front()), x);
 }

--- a/tests/sparse_discrete_domain.cpp
+++ b/tests/sparse_discrete_domain.cpp
@@ -6,7 +6,7 @@
 
 #include <gtest/gtest.h>
 
-inline namespace anonymous_namespace_workaround_discrete_domain_cpp {
+inline namespace anonymous_namespace_workaround_sparse_discrete_domain_cpp {
 
 struct DDimX
 {
@@ -58,13 +58,13 @@ using DElemZYX = ddc::DiscreteElement<DDimZ, DDimY, DDimX>;
 using DVectZYX = ddc::DiscreteVector<DDimZ, DDimY, DDimX>;
 using DDomZYX = ddc::SparseDiscreteDomain<DDimZ, DDimY, DDimX>;
 
-DElemX constexpr lbound_x(50);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 // DVectX constexpr nelems_x(3);
 // DElemX constexpr sentinel_x(lbound_x + nelems_x);
 // DElemX constexpr ubound_x(sentinel_x - 1);
 
 
-DElemY constexpr lbound_y(4);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
 // DVectY constexpr nelems_y(10);
 // DElemY constexpr sentinel_y(lbound_y);
 // DElemY constexpr ubound_y(sentinel_y - 1);
@@ -79,7 +79,7 @@ DElemY constexpr lbound_y(4);
 // DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
 // DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
 
-} // namespace anonymous_namespace_workaround_discrete_domain_cpp
+} // namespace anonymous_namespace_workaround_sparse_discrete_domain_cpp
 
 TEST(SparseDiscreteDomainTest, Constructor)
 {

--- a/tests/strided_discrete_domain.cpp
+++ b/tests/strided_discrete_domain.cpp
@@ -6,7 +6,7 @@
 
 #include <gtest/gtest.h>
 
-inline namespace anonymous_namespace_workaround_discrete_domain_cpp {
+inline namespace anonymous_namespace_workaround_strided_discrete_domain_cpp {
 
 struct DDimX
 {
@@ -58,20 +58,20 @@ using DElemZYX = ddc::DiscreteElement<DDimZ, DDimY, DDimX>;
 using DVectZYX = ddc::DiscreteVector<DDimZ, DDimY, DDimX>;
 using DDomZYX = ddc::StridedDiscreteDomain<DDimZ, DDimY, DDimX>;
 
-DElemX constexpr lbound_x(50);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
 DVectX constexpr nelems_x(3);
 DVectX constexpr strides_x(10);
 DElemX constexpr sentinel_x(lbound_x + nelems_x * strides_x);
 DElemX constexpr ubound_x(sentinel_x - strides_x);
 
 
-DElemY constexpr lbound_y(4);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
 DVectY constexpr nelems_y(12);
 DVectY constexpr strides_y(10);
 DElemY constexpr sentinel_y(lbound_y + nelems_y * strides_y);
 DElemY constexpr ubound_y(sentinel_y - strides_y);
 
-DElemZ constexpr lbound_z(7);
+DElemZ constexpr lbound_z = ddc::init_trivial_half_bounded_space<DDimZ>();
 DVectZ constexpr nelems_z(15);
 DVectZ constexpr strides_z(3);
 
@@ -84,7 +84,7 @@ DElemXZ constexpr lbound_x_z(lbound_x, lbound_z);
 DVectXZ constexpr nelems_x_z(nelems_x, nelems_z);
 DVectXZ constexpr strides_x_z(strides_x, strides_z);
 
-} // namespace anonymous_namespace_workaround_discrete_domain_cpp
+} // namespace anonymous_namespace_workaround_strided_discrete_domain_cpp
 
 TEST(StridedDiscreteDomainTest, Constructor)
 {
@@ -136,8 +136,8 @@ TEST(StridedDiscreteDomainTest, CompareSameDomains)
 
 TEST(StridedDiscreteDomainTest, CompareDifferentDomains)
 {
-    DDomXY const dom_x_y_1(DElemXY(0, 1), DVectXY(1, 2), strides_x_y);
-    DDomXY const dom_x_y_2(DElemXY(2, 3), DVectXY(3, 4), strides_x_y);
+    DDomXY const dom_x_y_1(lbound_x_y + DVectXY(0, 1), DVectXY(1, 2), strides_x_y);
+    DDomXY const dom_x_y_2(lbound_x_y + DVectXY(2, 3), DVectXY(3, 4), strides_x_y);
     EXPECT_FALSE(dom_x_y_1 == dom_x_y_2);
     EXPECT_FALSE(dom_x_y_1 == DDomYX(dom_x_y_2));
     EXPECT_TRUE(dom_x_y_1 != dom_x_y_2);
@@ -146,8 +146,8 @@ TEST(StridedDiscreteDomainTest, CompareDifferentDomains)
 
 TEST(StridedDiscreteDomainTest, CompareEmptyDomains)
 {
-    DDomXY const dom_x_y_1(DElemXY(4, 1), DVectXY(0, 0), strides_x_y);
-    DDomXY const dom_x_y_2(DElemXY(3, 9), DVectXY(0, 0), strides_x_y);
+    DDomXY const dom_x_y_1(lbound_x_y + DVectXY(4, 1), DVectXY(0, 0), strides_x_y);
+    DDomXY const dom_x_y_2(lbound_x_y + DVectXY(3, 9), DVectXY(0, 0), strides_x_y);
     EXPECT_TRUE(dom_x_y_1.empty());
     EXPECT_TRUE(dom_x_y_2.empty());
     EXPECT_TRUE(dom_x_y_1 == dom_x_y_2);
@@ -175,7 +175,7 @@ TEST(StridedDiscreteDomainTest, RangeFor)
         EXPECT_LE(lbound_x, ix);
         EXPECT_EQ(ix, ii);
         EXPECT_LE(ix, ubound_x);
-        ii.uid<DDimX>() += strides_x.value();
+        ii += strides_x;
     }
 }
 
@@ -279,7 +279,7 @@ TEST(StridedDiscreteDomainTest, DistanceFromFront)
 //     // the error message is checked with clang & gcc only
 //     EXPECT_DEATH(
 //             dom_x_y.restrict_with(subdomain_x),
-//             R"rgx([Aa]ssert.*uid<ODDims>\(m_element_begin\).*uid<ODDims>\(odomain\.m_element_begin\))rgx");
+//             R"rgx([Aa]ssert.*DiscreteElement<ODDims>\(m_element_begin\).*DiscreteElement<ODDims>\(odomain\.m_element_begin\))rgx");
 // #else
 //     GTEST_SKIP();
 // #endif
@@ -293,7 +293,7 @@ TEST(StridedDiscreteDomainTest, DistanceFromFront)
 //     // the error message is checked with clang & gcc only
 //     EXPECT_DEATH(
 //             dom_x_y.restrict_with(subdomain_x),
-//             R"rgx([Aa]ssert.*uid<ODDims>\(m_element_end\).*uid<ODDims>\(odomain\.m_element_end\).*)rgx");
+//             R"rgx([Aa]ssert.*DiscreteElement<ODDims>\(m_element_end\).*DiscreteElement<ODDims>\(odomain\.m_element_end\).*)rgx");
 // #else
 //     GTEST_SKIP();
 // #endif

--- a/tests/transform_reduce.cpp
+++ b/tests/transform_reduce.cpp
@@ -8,6 +8,8 @@
 
 #include <gtest/gtest.h>
 
+inline namespace anonymous_namespace_workaround_transform_reduce_cpp {
+
 using DElem0D = ddc::DiscreteElement<>;
 using DVect0D = ddc::DiscreteVector<>;
 using DDom0D = ddc::DiscreteDomain<>;
@@ -30,14 +32,16 @@ using DElemXY = ddc::DiscreteElement<DDimX, DDimY>;
 using DVectXY = ddc::DiscreteVector<DDimX, DDimY>;
 using DDomXY = ddc::DiscreteDomain<DDimX, DDimY>;
 
-static DElemX constexpr lbound_x(0);
-static DVectX constexpr nelems_x(10);
+DElemX constexpr lbound_x = ddc::init_trivial_half_bounded_space<DDimX>();
+DVectX constexpr nelems_x(10);
 
-static DElemY constexpr lbound_y(0);
-static DVectY constexpr nelems_y(12);
+DElemY constexpr lbound_y = ddc::init_trivial_half_bounded_space<DDimY>();
+DVectY constexpr nelems_y(12);
 
-static DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
-static DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
+DElemXY constexpr lbound_x_y(lbound_x, lbound_y);
+DVectXY constexpr nelems_x_y(nelems_x, nelems_y);
+
+} // namespace anonymous_namespace_workaround_transform_reduce_cpp
 
 TEST(TransformReduce, ZeroDimension)
 {


### PR DESCRIPTION
- Remove some `uid`
- Replace calls to `DiscreteElement` constructor with integer

Some are remaining in the splines builder and evaluator. The `DiscreteElement` tests also rely on it, not sure this is needed.