### PR TITLE
Set commit sha instead of version of github actions

### DIFF
--- a/.github/workflows/cmake-checks.yaml
+++ b/.github/workflows/cmake-checks.yaml
@@ -30,7 +30,7 @@ jobs:
     name: CMake format check using gersemi
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Install gersemi
         run: pipx install gersemi~=0.19
       - name: Run gersemi

--- a/.github/workflows/early_integration.yaml
+++ b/.github/workflows/early_integration.yaml
@@ -21,12 +21,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with: {tool-cache: true, large-packages: false}
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ghcr.io
           username: ${{github.actor}}
@@ -85,10 +85,10 @@ jobs:
     needs: [docker-build]
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with: {tool-cache: true, large-packages: false}
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with: {submodules: true}
       - name: Checkout Kokkos devel branch
         run: |
@@ -222,7 +222,7 @@ jobs:
           else echo "with_report=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857  # v5.5.1
         if: ( success() || failure() ) && steps.test.outputs.with_report == 'true'  # always run even if the previous step fails
         with:
           report_paths: '/home/runner/work/ddc/ddc/tests.xml'

--- a/.github/workflows/general-checks.yaml
+++ b/.github/workflows/general-checks.yaml
@@ -19,23 +19,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: REUSE Compliance Check
-        uses: fsfe/reuse-action@v5
+        uses: fsfe/reuse-action@bb774aa972c2a89ff34781233d275075cbddf542  # v5.0.0
 
   spelling-check:
     name: Spell check using typos
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Spell Check Repo
-        uses: crate-ci/typos@v1.31.1
+        uses: crate-ci/typos@b1a1ef3893ff35ade0cfa71523852a49bfd05d19  # v1.31.1
 
   trailing-whitespaces-check:
     name: Trailing whitespaces check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - run: ./bin/trailing_spaces $(git ls-files ':!docs/images/*' ':!docs/_template/*' ':!vendor')

--- a/.github/workflows/gyselalibxx.yaml
+++ b/.github/workflows/gyselalibxx.yaml
@@ -18,12 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gyselalibxx
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: gyselax/gyselalibxx
           submodules: true
       - name: Checkout ddc
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           submodules: true
           path: vendor/ddc

--- a/.github/workflows/markdown-checks.yaml
+++ b/.github/workflows/markdown-checks.yaml
@@ -24,5 +24,5 @@ jobs:
     name: Markdown lint using markdownlint-cli2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: DavidAnson/markdownlint-cli2-action@v19
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: DavidAnson/markdownlint-cli2-action@05f32210e84442804257b2a6f20b273450ec8265  # v19.1.0

--- a/.github/workflows/packages-cleanup.yaml
+++ b/.github/workflows/packages-cleanup.yaml
@@ -14,37 +14,37 @@ jobs:
     name: Delete old packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55  # v5.0.0
         with:
           package-name: 'ddc/doxygen'
           package-type: 'container'
           min-versions-to-keep: 10
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55  # v5.0.0
         with:
           package-name: 'ddc/latest_cpu'
           package-type: 'container'
           min-versions-to-keep: 10
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55  # v5.0.0
         with:
           package-name: 'ddc/latest_cuda'
           package-type: 'container'
           min-versions-to-keep: 10
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55  # v5.0.0
         with:
           package-name: 'ddc/latest_hip'
           package-type: 'container'
           min-versions-to-keep: 10
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55  # v5.0.0
         with:
           package-name: 'ddc/oldest_cpu'
           package-type: 'container'
           min-versions-to-keep: 10
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55  # v5.0.0
         with:
           package-name: 'ddc/oldest_cuda'
           package-type: 'container'
           min-versions-to-keep: 10
-      - uses: actions/delete-package-versions@v5
+      - uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55  # v5.0.0
         with:
           package-name: 'ddc/oldest_hip'
           package-type: 'container'

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with: {tool-cache: true, large-packages: false}
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ghcr.io
           username: ${{github.actor}}
@@ -63,7 +63,7 @@ jobs:
           docker save ghcr.io/cexa-project/ddc/doxygen:${GITHUB_SHA:0:7} > doxygen.tar
       - name: Generate docker artifact from image
         if: needs.id_repo.outputs.in_base_repo == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: doxygen-artifact
           path: doxygen.tar
@@ -74,16 +74,16 @@ jobs:
     needs: [docker-build, id_repo]
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with: {tool-cache: true, large-packages: false}
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           fetch-depth: 0
           submodules: true
       - name: Collect image artifact
         if: needs.id_repo.outputs.in_base_repo == 'false'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with: {name: 'doxygen-artifact'}
       - name: Load image artifact into docker
         if: needs.id_repo.outputs.in_base_repo == 'false'
@@ -135,14 +135,14 @@ jobs:
     needs: [docker-build, id_repo]
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with: {tool-cache: true, large-packages: false}
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with: {submodules: true}
       - name: Collect image artifact
         if: needs.id_repo.outputs.in_base_repo == 'false'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with: {name: 'doxygen-artifact'}
       - name: Load image artifact into docker
         if: needs.id_repo.outputs.in_base_repo == 'false'

--- a/.github/workflows/python-checks.yaml
+++ b/.github/workflows/python-checks.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Python format using black
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Install dependencies
         run: |
           pipx install black
@@ -38,7 +38,7 @@ jobs:
     name: Python lint using pylint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Install dependencies
         run: |
           pipx install pylint

--- a/.github/workflows/shell-checks.yaml
+++ b/.github/workflows/shell-checks.yaml
@@ -20,9 +20,9 @@ jobs:
     name: Shell lint using shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@2.0.0
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38  # 2.0.0
         env:
           SHELLCHECK_OPTS: -e SC1091
         with:

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -81,8 +81,8 @@ jobs:
       CMAKE_BUILD_TYPE: ${{matrix.cmake_build_type}}
     steps:
       - name: Checkout built branch
-        uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: pdidev/pdi
           ref: 1.8.3
@@ -121,7 +121,7 @@ jobs:
         run: brew install googletest
       - name: Install Google benchmark
         run: brew install google-benchmark
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: ginkgo-project/ginkgo
           ref: v1.8.0
@@ -140,7 +140,7 @@ jobs:
           cmake --build build
           cmake --install build --prefix $Ginkgo_ROOT
           rm -rf build
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: kokkos/kokkos
           ref: 4.5.01
@@ -158,7 +158,7 @@ jobs:
           cmake --build build
           cmake --install build --prefix $Kokkos_ROOT
           rm -rf build
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: kokkos/kokkos-fft
           ref: v0.2.1
@@ -173,7 +173,7 @@ jobs:
           cmake --build build
           cmake --install build --prefix $KokkosFFT_ROOT
           rm -rf build
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: kokkos/kokkos-kernels
           ref: 4.5.01
@@ -211,7 +211,7 @@ jobs:
       - name: Run unit tests
         run: ctest --test-dir build --output-on-failure --timeout 10 --output-junit tests.xml
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857  # v5.5.1
         if: ( success() || failure() )  # always run even if the previous step fails
         with:
           report_paths: '${{github.workspace}}/build/tests.xml'

--- a/.github/workflows/tests-ubuntu.yaml
+++ b/.github/workflows/tests-ubuntu.yaml
@@ -42,8 +42,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: jidicula/clang-format-action@v4.15.0
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: jidicula/clang-format-action@4726374d1aa3c6aecf132e5197e498979588ebc8  # v4.15.0
         with:
           clang-format-version: '20'
       - name: Prefer 'if defined'/'if !defined' over 'ifdef'/'ifndef'
@@ -72,12 +72,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with: {tool-cache: true, large-packages: false}
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ghcr.io
           username: ${{github.actor}}
@@ -105,7 +105,7 @@ jobs:
           docker save ghcr.io/cexa-project/ddc/${{matrix.image}}_${{matrix.backend}}:${GITHUB_SHA:0:7} > ${{matrix.image}}_${{matrix.backend}}.tar
       - name: Generate docker artifact from image
         if: needs.id_repo.outputs.in_base_repo == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: ${{matrix.image}}_${{matrix.backend}}-artifact
           path: ${{matrix.image}}_${{matrix.backend}}.tar
@@ -161,14 +161,14 @@ jobs:
     needs: [docker-build, id_repo]
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with: {tool-cache: true, large-packages: false}
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with: {submodules: true}
       - name: Collect image artifact
         if: needs.id_repo.outputs.in_base_repo == 'false'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           name: |
             ${{matrix.image}}_${{matrix.backend.name}}-artifact
@@ -295,7 +295,7 @@ jobs:
           else echo "with_report=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857  # v5.5.1
         if: ( success() || failure() ) && steps.test.outputs.with_report == 'true'  # always run even if the previous step fails
         with:
           report_paths: '${{github.workspace}}/tests.xml'
@@ -317,14 +317,14 @@ jobs:
     needs: [docker-build, id_repo]
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with: {tool-cache: true, large-packages: false}
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with: {submodules: true}
       - name: Collect image artifact
         if: needs.id_repo.outputs.in_base_repo == 'false'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           name: |
             ${{matrix.image}}_${{matrix.backend.name}}-artifact
@@ -391,7 +391,7 @@ jobs:
           else echo "with_report=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857  # v5.5.1
         if: ( success() || failure() ) && steps.test.outputs.with_report == 'true'  # always run even if the previous step fails
         with:
           report_paths: '${{github.workspace}}/tests.xml'
@@ -412,14 +412,14 @@ jobs:
     needs: [docker-build, id_repo]
     steps:
       - name: Free Disk Space (Ubuntu)
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with: {tool-cache: true, large-packages: false}
       - name: Checkout built branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with: {submodules: true}
       - name: Collect image artifact
         if: needs.id_repo.outputs.in_base_repo == 'false'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e  # v4.2.1
         with:
           name: |
             ${{matrix.image}}_${{matrix.backend.name}}-artifact

--- a/.github/workflows/tests-windows.yaml
+++ b/.github/workflows/tests-windows.yaml
@@ -62,8 +62,8 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
     steps:
       - name: Checkout built branch
-        uses: actions/checkout@v4
-      - uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: google/googletest
           ref: v1.16.0
@@ -79,7 +79,7 @@ jobs:
           cmake --build build --config ${{matrix.config}}
           cmake --install build --config ${{matrix.config}} --prefix $GTest_ROOT
           rm -rf build
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: kokkos/kokkos
           ref: 4.6.00
@@ -113,7 +113,7 @@ jobs:
           cmake --build build --config ${{matrix.config}}
           ctest --test-dir build --build-config ${{matrix.config}} --output-on-failure --timeout 10 --output-junit tests.xml
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v5
+        uses: mikepenz/action-junit-report@cf701569b05ccdd861a76b8607a66d76f6fd4857  # v5.5.1
         if: ( success() || failure() )  # always run even if the previous step fails
         with:
           report_paths: '${{github.workspace}}/build/tests.xml'

--- a/.github/workflows/website-checks.yaml
+++ b/.github/workflows/website-checks.yaml
@@ -16,7 +16,7 @@ jobs:
     name: Links check using linkchecker
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           ref: gh-pages
       - name: Install linkchecker

--- a/.github/workflows/yaml-checks.yaml
+++ b/.github/workflows/yaml-checks.yaml
@@ -32,7 +32,7 @@ jobs:
     name: YAML lint using yamllint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       - name: Install yamllint
         run: pipx install yamllint~=1.35
       - run: |


### PR DESCRIPTION
This PR aims to harden security following [github recommendations](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
>Pin actions to a full length commit SHA

Note that as a consequence, this will increase the number of dependabot PRs.