### PR TITLE
Prefer stride(i) instead of stride_i()

### DIFF
--- a/include/ddc/kernels/splines/kokkos-kernels-ext/KokkosBatched_Gbtrs_Serial_Impl.hpp
+++ b/include/ddc/kernels/splines/kokkos-kernels-ext/KokkosBatched_Gbtrs_Serial_Impl.hpp
@@ -148,8 +148,8 @@ struct SerialGbtrs<Trans::Transpose, Algo::Level3::Unblocked> {
 
         [[maybe_unused]] auto info_gemv =
             KokkosBlas::Impl::SerialGemvInternal<Algo::Gemv::Unblocked>::invoke(
-                1, a.extent(0), -1.0, a.data(), a.stride_0(), a.stride_0(),
-                x.data(), x.stride_0(), 1.0, y.data(), y.stride_0());
+                1, a.extent(0), -1.0, a.data(), a.stride(0), a.stride(0),
+                x.data(), x.stride(0), 1.0, y.data(), y.stride(0));
 
         // If pivot index is not j, swap rows l and j in b
         auto l = piv(j);

--- a/include/ddc/kernels/splines/splines_linear_problem_sparse.hpp
+++ b/include/ddc/kernels/splines/splines_linear_problem_sparse.hpp
@@ -34,7 +34,7 @@ auto to_gko_dense(std::shared_ptr<const gko::Executor> const& gko_exec, KokkosVi
     static_assert((Kokkos::is_view_v<KokkosViewType> && KokkosViewType::rank == 2));
     using value_type = typename KokkosViewType::traits::value_type;
 
-    if (view.stride_1() != 1) {
+    if (view.stride(1) != 1) {
         throw std::runtime_error("The view needs to be contiguous in the second dimension");
     }
 
@@ -42,7 +42,7 @@ auto to_gko_dense(std::shared_ptr<const gko::Executor> const& gko_exec, KokkosVi
             create(gko_exec,
                    gko::dim<2>(view.extent(0), view.extent(1)),
                    gko::array<value_type>::view(gko_exec, view.span(), view.data()),
-                   view.stride_0());
+                   view.stride(0));
 }
 
 /**


### PR DESCRIPTION
I made a quick review, I think we don't have dangerous calls to `stride(i)`. We don't have functions that allow multiple ranks.