### PR TITLE
Add spline compatibility check helper

### DIFF
--- a/include/ddc/kernels/splines.hpp
+++ b/include/ddc/kernels/splines.hpp
@@ -20,6 +20,7 @@
 #include "splines/spline_builder_2d.hpp"
 #include "splines/spline_evaluator.hpp"
 #include "splines/spline_evaluator_2d.hpp"
+#include "splines/spline_traits.hpp"
 #include "splines/splines_linear_problem.hpp"
 #include "splines/splines_linear_problem_2x2_blocks.hpp"
 #include "splines/splines_linear_problem_3x3_blocks.hpp"

--- a/include/ddc/kernels/splines/spline_traits.hpp
+++ b/include/ddc/kernels/splines/spline_traits.hpp
@@ -4,14 +4,7 @@
 
 #pragma once
 
-#include <cassert>
-#include <cstddef>
-#include <memory>
-#include <optional>
-#include <stdexcept>
-#include <tuple>
 #include <type_traits>
-#include <utility>
 
 #include <ddc/ddc.hpp>
 
@@ -21,6 +14,7 @@
 #include "spline_evaluator_2d.hpp"
 
 namespace ddc {
+
 template <class T>
 struct is_spline_builder : std::false_type
 {
@@ -53,7 +47,7 @@ template <class T>
 inline constexpr bool is_spline_builder_v = is_spline_builder<T>::value;
 
 template <class T>
-struct is_spline_builder2D : std::false_type
+struct is_spline_builder2d : std::false_type
 {
 };
 
@@ -69,7 +63,7 @@ template <
         ddc::BoundCond BcLower2,
         ddc::BoundCond BcUpper2,
         ddc::SplineSolver Solver>
-struct is_spline_builder2D<SplineBuilder2D<
+struct is_spline_builder2d<SplineBuilder2D<
         ExecSpace,
         MemorySpace,
         BSpline1,
@@ -89,7 +83,7 @@ struct is_spline_builder2D<SplineBuilder2D<
  *  @tparam T The type to be checked if is a SplineBuilder2D
  */
 template <class T>
-inline constexpr bool is_spline_builder2D_v = is_spline_builder2D<T>::value;
+inline constexpr bool is_spline_builder2d_v = is_spline_builder2d<T>::value;
 
 template <class T>
 struct is_spline_evaluator : std::false_type
@@ -121,7 +115,7 @@ template <class T>
 inline constexpr bool is_spline_evaluator_v = is_spline_evaluator<T>::value;
 
 template <class T>
-struct is_spline_evaluator2D : std::false_type
+struct is_spline_evaluator2d : std::false_type
 {
 };
 
@@ -136,7 +130,7 @@ template <
         class UpperExtrapolationRule1,
         class LowerExtrapolationRule2,
         class UpperExtrapolationRule2>
-struct is_spline_evaluator2D<SplineEvaluator2D<
+struct is_spline_evaluator2d<SplineEvaluator2D<
         ExecSpace,
         MemorySpace,
         BSpline1,
@@ -155,7 +149,7 @@ struct is_spline_evaluator2D<SplineEvaluator2D<
  *  @tparam T The type to be checked if is a SplineEvaluator2D
  */
 template <class T>
-inline constexpr bool is_spline_evaluator2D_v = is_spline_evaluator2D<T>::value;
+inline constexpr bool is_spline_evaluator2d_v = is_spline_evaluator2d<T>::value;
 
 template <class Builder, class Evaluator>
 struct is_evaluator_admissible : std::false_type

--- a/include/ddc/kernels/splines/spline_traits.hpp
+++ b/include/ddc/kernels/splines/spline_traits.hpp
@@ -14,6 +14,7 @@
 #include <utility>
 
 #include <ddc/ddc.hpp>
+
 #include "spline_builder.hpp"
 #include "spline_builder_2d.hpp"
 #include "spline_evaluator.hpp"
@@ -21,7 +22,9 @@
 
 namespace ddc {
 template <class T>
-struct is_spline_builder : std::false_type {};
+struct is_spline_builder : std::false_type
+{
+};
 
 template <
         class ExecSpace,
@@ -31,7 +34,16 @@ template <
         ddc::BoundCond BcLower,
         ddc::BoundCond BcUpper,
         SplineSolver Solver>
-struct is_spline_builder<SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, BcLower, BcUpper, Solver>> : std::true_type {};
+struct is_spline_builder<SplineBuilder<
+        ExecSpace,
+        MemorySpace,
+        BSplines,
+        InterpolationDDim,
+        BcLower,
+        BcUpper,
+        Solver>> : std::true_type
+{
+};
 
 /**
  *  @brief A helper to check if T is a SplineBuilder
@@ -41,7 +53,9 @@ template <class T>
 inline constexpr bool is_spline_builder_v = is_spline_builder<T>::value;
 
 template <class T>
-struct is_spline_builder2D : std::false_type {};
+struct is_spline_builder2D : std::false_type
+{
+};
 
 template <
         class ExecSpace,
@@ -55,7 +69,20 @@ template <
         ddc::BoundCond BcLower2,
         ddc::BoundCond BcUpper2,
         ddc::SplineSolver Solver>
-struct is_spline_builder2D<SplineBuilder2D<ExecSpace, MemorySpace, BSpline1, BSpline2, DDimI1, DDimI2, BcLower1, BcUpper1, BcLower2, BcUpper2, Solver>> : std::true_type {};
+struct is_spline_builder2D<SplineBuilder2D<
+        ExecSpace,
+        MemorySpace,
+        BSpline1,
+        BSpline2,
+        DDimI1,
+        DDimI2,
+        BcLower1,
+        BcUpper1,
+        BcLower2,
+        BcUpper2,
+        Solver>> : std::true_type
+{
+};
 
 /**
  *  @brief A helper to check if T is a SplineBuilder2D
@@ -65,7 +92,9 @@ template <class T>
 inline constexpr bool is_spline_builder2D_v = is_spline_builder2D<T>::value;
 
 template <class T>
-struct is_spline_evaluator : std::false_type {};
+struct is_spline_evaluator : std::false_type
+{
+};
 
 template <
         class ExecSpace,
@@ -74,7 +103,15 @@ template <
         class EvaluationDDim,
         class LowerExtrapolationRule,
         class UpperExtrapolationRule>
-struct is_spline_evaluator<SplineEvaluator<ExecSpace, MemorySpace, BSplines, EvaluationDDim, LowerExtrapolationRule, UpperExtrapolationRule>> : std::true_type {};
+struct is_spline_evaluator<SplineEvaluator<
+        ExecSpace,
+        MemorySpace,
+        BSplines,
+        EvaluationDDim,
+        LowerExtrapolationRule,
+        UpperExtrapolationRule>> : std::true_type
+{
+};
 
 /**
  *  @brief A helper to check if T is a SplineEvaluator
@@ -84,7 +121,9 @@ template <class T>
 inline constexpr bool is_spline_evaluator_v = is_spline_evaluator<T>::value;
 
 template <class T>
-struct is_spline_evaluator2D : std::false_type {};
+struct is_spline_evaluator2D : std::false_type
+{
+};
 
 template <
         class ExecSpace,
@@ -97,7 +136,19 @@ template <
         class UpperExtrapolationRule1,
         class LowerExtrapolationRule2,
         class UpperExtrapolationRule2>
-struct is_spline_evaluator2D<SplineEvaluator2D<ExecSpace, MemorySpace, BSpline1, BSpline2, EvaluationDDim1, EvaluationDDim2, LowerExtrapolationRule1, UpperExtrapolationRule1, LowerExtrapolationRule2, UpperExtrapolationRule2>> : std::true_type {};
+struct is_spline_evaluator2D<SplineEvaluator2D<
+        ExecSpace,
+        MemorySpace,
+        BSpline1,
+        BSpline2,
+        EvaluationDDim1,
+        EvaluationDDim2,
+        LowerExtrapolationRule1,
+        UpperExtrapolationRule1,
+        LowerExtrapolationRule2,
+        UpperExtrapolationRule2>> : std::true_type
+{
+};
 
 /**
  *  @brief A helper to check if T is a SplineEvaluator2D
@@ -107,7 +158,9 @@ template <class T>
 inline constexpr bool is_spline_evaluator2D_v = is_spline_evaluator2D<T>::value;
 
 template <class Builder, class Evaluator>
-struct is_evaluator_admissible : std::false_type {};
+struct is_evaluator_admissible : std::false_type
+{
+};
 
 template <
         class ExecSpace,
@@ -119,7 +172,24 @@ template <
         SplineSolver Solver,
         class LowerExtrapolationRule,
         class UpperExtrapolationRule>
-struct is_evaluator_admissible<SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, BcLower, BcUpper, Solver>, SplineEvaluator<ExecSpace, MemorySpace, BSplines, InterpolationDDim, LowerExtrapolationRule, UpperExtrapolationRule>> : std::true_type {};
+struct is_evaluator_admissible<
+        SplineBuilder<
+                ExecSpace,
+                MemorySpace,
+                BSplines,
+                InterpolationDDim,
+                BcLower,
+                BcUpper,
+                Solver>,
+        SplineEvaluator<
+                ExecSpace,
+                MemorySpace,
+                BSplines,
+                InterpolationDDim,
+                LowerExtrapolationRule,
+                UpperExtrapolationRule>> : std::true_type
+{
+};
 
 template <
         class ExecSpace,
@@ -137,8 +207,32 @@ template <
         class UpperExtrapolationRule1,
         class LowerExtrapolationRule2,
         class UpperExtrapolationRule2>
-struct is_evaluator_admissible<SplineBuilder2D<ExecSpace, MemorySpace, BSplines1, BSplines2, DDimI1, DDimI2, BcLower1, BcUpper1, BcLower2, BcUpper2, Solver>,
-                               SplineEvaluator2D<ExecSpace, MemorySpace, BSplines1, BSplines2, DDimI1, DDimI2, LowerExtrapolationRule1, UpperExtrapolationRule1, LowerExtrapolationRule2, UpperExtrapolationRule2>> : std::true_type {};
+struct is_evaluator_admissible<
+        SplineBuilder2D<
+                ExecSpace,
+                MemorySpace,
+                BSplines1,
+                BSplines2,
+                DDimI1,
+                DDimI2,
+                BcLower1,
+                BcUpper1,
+                BcLower2,
+                BcUpper2,
+                Solver>,
+        SplineEvaluator2D<
+                ExecSpace,
+                MemorySpace,
+                BSplines1,
+                BSplines2,
+                DDimI1,
+                DDimI2,
+                LowerExtrapolationRule1,
+                UpperExtrapolationRule1,
+                LowerExtrapolationRule2,
+                UpperExtrapolationRule2>> : std::true_type
+{
+};
 
 /**
  *  @brief A helper to check if SplineEvaluator is admissible for SplineBuilder
@@ -146,7 +240,7 @@ struct is_evaluator_admissible<SplineBuilder2D<ExecSpace, MemorySpace, BSplines1
  *  @tparam Evaluator The evaluator type to be checked if it is admissible for Builder
  */
 template <class Builder, class Evaluator>
-inline constexpr bool is_evaluator_admissible_v = is_evaluator_admissible<Builder, Evaluator>::value;
+inline constexpr bool is_evaluator_admissible_v
+        = is_evaluator_admissible<Builder, Evaluator>::value;
 
 } // namespace ddc
-

--- a/include/ddc/kernels/splines/spline_traits.hpp
+++ b/include/ddc/kernels/splines/spline_traits.hpp
@@ -1,0 +1,119 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+#include <ddc/ddc.hpp>
+#include "spline_builder.hpp"
+#include "spline_builder_2d.hpp"
+#include "spline_evaluator.hpp"
+#include "spline_evaluator_2d.hpp"
+
+namespace ddc {
+template <class T>
+struct is_spline_builder : std::false_type {};
+
+template <
+        class ExecSpace,
+        class MemorySpace,
+        class BSplines,
+        class InterpolationDDim,
+        ddc::BoundCond BcLower,
+        ddc::BoundCond BcUpper,
+        SplineSolver Solver>
+struct is_spline_builder<SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, BcLower, BcUpper, Solver>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_spline_builder_v = is_spline_builder<T>::value;
+
+template <class T>
+struct is_spline_builder2D : std::false_type {};
+
+template <
+        class ExecSpace,
+        class MemorySpace,
+        class BSpline1,
+        class BSpline2,
+        class DDimI1,
+        class DDimI2,
+        ddc::BoundCond BcLower1,
+        ddc::BoundCond BcUpper1,
+        ddc::BoundCond BcLower2,
+        ddc::BoundCond BcUpper2,
+        ddc::SplineSolver Solver>
+struct is_spline_builder2D<SplineBuilder2D<ExecSpace, MemorySpace, BSpline1, BSpline2, DDimI1, DDimI2, BcLower1, BcUpper1, BcLower2, BcUpper2, Solver>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_spline_builder2D_v = is_spline_builder2D<T>::value;
+
+template <class T>
+struct is_spline_evaluator : std::false_type {};
+
+template <
+        class ExecSpace,
+        class MemorySpace,
+        class BSplines,
+        class EvaluationDDim,
+        class LowerExtrapolationRule,
+        class UpperExtrapolationRule>
+struct is_spline_evaluator<SplineEvaluator<ExecSpace, MemorySpace, BSplines, EvaluationDDim, LowerExtrapolationRule, UpperExtrapolationRule>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_spline_evaluator_v = is_spline_evaluator<T>::value;
+
+template <class T>
+struct is_spline_evaluator2D : std::false_type {};
+
+template <
+        class ExecSpace,
+        class MemorySpace,
+        class BSpline1,
+        class BSpline2,
+        class EvaluationDDim1,
+        class EvaluationDDim2,
+        class LowerExtrapolationRule1,
+        class UpperExtrapolationRule1,
+        class LowerExtrapolationRule2,
+        class UpperExtrapolationRule2>
+struct is_spline_evaluator2D<SplineEvaluator2D<ExecSpace, MemorySpace, BSpline1, BSpline2, EvaluationDDim1, EvaluationDDim2, LowerExtrapolationRule1, UpperExtrapolationRule1, LowerExtrapolationRule2, UpperExtrapolationRule2>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool is_spline_evaluator2D_v = is_spline_evaluator2D<T>::value;
+
+template <class Builder, class Evaluator, class Enable = void>
+struct is_spline_compatible : std::false_type {};
+
+template <class Builder, class Evaluator>
+struct is_spline_compatible<Builder, Evaluator,
+       std::enable_if_t<is_spline_builder_v<Builder> && is_spline_evaluator_v<Evaluator>
+                        || is_spline_builder_v<Evaluator> && is_spline_evaluator_v<Builder> >> {
+       static constexpr bool value = std::is_same_v<typename Builder::exec_space, typename Evaluator::exec_space> && 
+                                     std::is_same_v<typename Builder::memory_space, typename Evaluator::memory_space> &&
+                                     std::is_same_v<typename Builder::bsplines_type, typename Evaluator::bsplines_type>;
+};
+
+template <class Builder, class Evaluator>
+struct is_spline_compatible<Builder, Evaluator,
+       std::enable_if_t<is_spline_builder2D_v<Builder> && is_spline_evaluator2D_v<Evaluator>
+                        || is_spline_builder2D_v<Evaluator> && is_spline_evaluator2D_v<Builder> >> {
+       static constexpr bool value = std::is_same_v<typename Builder::exec_space, typename Evaluator::exec_space> && 
+                                     std::is_same_v<typename Builder::memory_space, typename Evaluator::memory_space> &&
+                                     std::is_same_v<typename Builder::bsplines_type1, typename Evaluator::bsplines_type1> &&
+                                     std::is_same_v<typename Builder::bsplines_type2, typename Evaluator::bsplines_type2>;
+};
+
+template <class Builder, class Evaluator>
+inline constexpr bool is_spline_compatible_v = is_spline_compatible<Builder, Evaluator>::value;
+
+} // namespace ddc
+

--- a/include/ddc/kernels/splines/spline_traits.hpp
+++ b/include/ddc/kernels/splines/spline_traits.hpp
@@ -33,7 +33,11 @@ template <
         SplineSolver Solver>
 struct is_spline_builder<SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, BcLower, BcUpper, Solver>> : std::true_type {};
 
-template <typename T>
+/**
+ *  @brief A helper to check if T is a SplineBuilder
+ *  @tparam T The type to be checked if is a SplineBuilder
+ */
+template <class T>
 inline constexpr bool is_spline_builder_v = is_spline_builder<T>::value;
 
 template <class T>
@@ -53,7 +57,11 @@ template <
         ddc::SplineSolver Solver>
 struct is_spline_builder2D<SplineBuilder2D<ExecSpace, MemorySpace, BSpline1, BSpline2, DDimI1, DDimI2, BcLower1, BcUpper1, BcLower2, BcUpper2, Solver>> : std::true_type {};
 
-template <typename T>
+/**
+ *  @brief A helper to check if T is a SplineBuilder2D
+ *  @tparam T The type to be checked if is a SplineBuilder2D
+ */
+template <class T>
 inline constexpr bool is_spline_builder2D_v = is_spline_builder2D<T>::value;
 
 template <class T>
@@ -68,7 +76,11 @@ template <
         class UpperExtrapolationRule>
 struct is_spline_evaluator<SplineEvaluator<ExecSpace, MemorySpace, BSplines, EvaluationDDim, LowerExtrapolationRule, UpperExtrapolationRule>> : std::true_type {};
 
-template <typename T>
+/**
+ *  @brief A helper to check if T is a SplineEvaluator
+ *  @tparam T The type to be checked if is a SplineEvalutor
+ */
+template <class T>
 inline constexpr bool is_spline_evaluator_v = is_spline_evaluator<T>::value;
 
 template <class T>
@@ -87,33 +99,54 @@ template <
         class UpperExtrapolationRule2>
 struct is_spline_evaluator2D<SplineEvaluator2D<ExecSpace, MemorySpace, BSpline1, BSpline2, EvaluationDDim1, EvaluationDDim2, LowerExtrapolationRule1, UpperExtrapolationRule1, LowerExtrapolationRule2, UpperExtrapolationRule2>> : std::true_type {};
 
-template <typename T>
+/**
+ *  @brief A helper to check if T is a SplineEvaluator2D
+ *  @tparam T The type to be checked if is a SplineEvalutor2D
+ */
+template <class T>
 inline constexpr bool is_spline_evaluator2D_v = is_spline_evaluator2D<T>::value;
 
-template <class Builder, class Evaluator, class Enable = void>
-struct is_spline_compatible : std::false_type {};
-
 template <class Builder, class Evaluator>
-struct is_spline_compatible<Builder, Evaluator,
-       std::enable_if_t<is_spline_builder_v<Builder> && is_spline_evaluator_v<Evaluator>
-                        || is_spline_builder_v<Evaluator> && is_spline_evaluator_v<Builder> >> {
-       static constexpr bool value = std::is_same_v<typename Builder::exec_space, typename Evaluator::exec_space> && 
-                                     std::is_same_v<typename Builder::memory_space, typename Evaluator::memory_space> &&
-                                     std::is_same_v<typename Builder::bsplines_type, typename Evaluator::bsplines_type>;
-};
+struct is_evaluator_admissible : std::false_type {};
 
-template <class Builder, class Evaluator>
-struct is_spline_compatible<Builder, Evaluator,
-       std::enable_if_t<is_spline_builder2D_v<Builder> && is_spline_evaluator2D_v<Evaluator>
-                        || is_spline_builder2D_v<Evaluator> && is_spline_evaluator2D_v<Builder> >> {
-       static constexpr bool value = std::is_same_v<typename Builder::exec_space, typename Evaluator::exec_space> && 
-                                     std::is_same_v<typename Builder::memory_space, typename Evaluator::memory_space> &&
-                                     std::is_same_v<typename Builder::bsplines_type1, typename Evaluator::bsplines_type1> &&
-                                     std::is_same_v<typename Builder::bsplines_type2, typename Evaluator::bsplines_type2>;
-};
+template <
+        class ExecSpace,
+        class MemorySpace,
+        class BSplines,
+        class InterpolationDDim,
+        ddc::BoundCond BcLower,
+        ddc::BoundCond BcUpper,
+        SplineSolver Solver,
+        class LowerExtrapolationRule,
+        class UpperExtrapolationRule>
+struct is_evaluator_admissible<SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, BcLower, BcUpper, Solver>, SplineEvaluator<ExecSpace, MemorySpace, BSplines, InterpolationDDim, LowerExtrapolationRule, UpperExtrapolationRule>> : std::true_type {};
 
+template <
+        class ExecSpace,
+        class MemorySpace,
+        class BSplines1,
+        class BSplines2,
+        class DDimI1,
+        class DDimI2,
+        ddc::BoundCond BcLower1,
+        ddc::BoundCond BcUpper1,
+        ddc::BoundCond BcLower2,
+        ddc::BoundCond BcUpper2,
+        SplineSolver Solver,
+        class LowerExtrapolationRule1,
+        class UpperExtrapolationRule1,
+        class LowerExtrapolationRule2,
+        class UpperExtrapolationRule2>
+struct is_evaluator_admissible<SplineBuilder2D<ExecSpace, MemorySpace, BSplines1, BSplines2, DDimI1, DDimI2, BcLower1, BcUpper1, BcLower2, BcUpper2, Solver>,
+                               SplineEvaluator2D<ExecSpace, MemorySpace, BSplines1, BSplines2, DDimI1, DDimI2, LowerExtrapolationRule1, UpperExtrapolationRule1, LowerExtrapolationRule2, UpperExtrapolationRule2>> : std::true_type {};
+
+/**
+ *  @brief A helper to check if SplineEvalutor is admissible for SplineBuilder
+ *  @tparam Builder The builder type to be checked if it is admissible for Evaluator
+ *  @tparam Evaluator The evaluator type to be checked if it is admissible for Builder
+ */
 template <class Builder, class Evaluator>
-inline constexpr bool is_spline_compatible_v = is_spline_compatible<Builder, Evaluator>::value;
+inline constexpr bool is_evaluator_admissible_v = is_evaluator_admissible<Builder, Evaluator>::value;
 
 } // namespace ddc
 

--- a/include/ddc/kernels/splines/spline_traits.hpp
+++ b/include/ddc/kernels/splines/spline_traits.hpp
@@ -78,7 +78,7 @@ struct is_spline_evaluator<SplineEvaluator<ExecSpace, MemorySpace, BSplines, Eva
 
 /**
  *  @brief A helper to check if T is a SplineEvaluator
- *  @tparam T The type to be checked if is a SplineEvalutor
+ *  @tparam T The type to be checked if is a SplineEvaluator
  */
 template <class T>
 inline constexpr bool is_spline_evaluator_v = is_spline_evaluator<T>::value;
@@ -101,7 +101,7 @@ struct is_spline_evaluator2D<SplineEvaluator2D<ExecSpace, MemorySpace, BSpline1,
 
 /**
  *  @brief A helper to check if T is a SplineEvaluator2D
- *  @tparam T The type to be checked if is a SplineEvalutor2D
+ *  @tparam T The type to be checked if is a SplineEvaluator2D
  */
 template <class T>
 inline constexpr bool is_spline_evaluator2D_v = is_spline_evaluator2D<T>::value;
@@ -141,7 +141,7 @@ struct is_evaluator_admissible<SplineBuilder2D<ExecSpace, MemorySpace, BSplines1
                                SplineEvaluator2D<ExecSpace, MemorySpace, BSplines1, BSplines2, DDimI1, DDimI2, LowerExtrapolationRule1, UpperExtrapolationRule1, LowerExtrapolationRule2, UpperExtrapolationRule2>> : std::true_type {};
 
 /**
- *  @brief A helper to check if SplineEvalutor is admissible for SplineBuilder
+ *  @brief A helper to check if SplineEvaluator is admissible for SplineBuilder
  *  @tparam Builder The builder type to be checked if it is admissible for Evaluator
  *  @tparam Evaluator The evaluator type to be checked if it is admissible for Builder
  */

--- a/tests/splines/CMakeLists.txt
+++ b/tests/splines/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
     knots_as_interpolation_points.cpp
     splines_linear_problem.cpp
     spline_builder.cpp
+    spline_traits.cpp
     view.cpp
 )
 target_compile_features(splines_tests PUBLIC cxx_std_17)

--- a/tests/splines/spline_traits.cpp
+++ b/tests/splines/spline_traits.cpp
@@ -2,10 +2,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-#include <cstddef>
-#include <stdexcept>
-#include <vector>
-
 #include <ddc/ddc.hpp>
 #include <ddc/kernels/splines.hpp>
 
@@ -14,6 +10,8 @@
 #include <Kokkos_Core.hpp>
 
 #include "test_utils.hpp"
+
+inline namespace anonymous_namespace_workaround_spline_traits_cpp {
 
 struct DimX
 {
@@ -163,6 +161,8 @@ using TestTypes = tuple_to_types_t<cartesian_product_t<
         execution_space_types,
         spline_degrees>>;
 
+} // namespace anonymous_namespace_workaround_spline_traits_cpp
+
 TYPED_TEST_SUITE(BSplinesTraits, TestTypes, );
 
 TYPED_TEST(BSplinesTraits, IsSplineBuilder)
@@ -183,10 +183,10 @@ TYPED_TEST(BSplinesTraits, IsSplineBuilder2D)
     using Evaluator1D = typename TestFixture::Evaluator1D_1;
     using Builder2D = typename TestFixture::Builder2D_1;
     using Evaluator2D = typename TestFixture::Evaluator2D_1;
-    ASSERT_FALSE(ddc::is_spline_builder2D_v<Builder1D>);
-    ASSERT_TRUE(ddc::is_spline_builder2D_v<Builder2D>);
-    ASSERT_FALSE(ddc::is_spline_builder2D_v<Evaluator1D>);
-    ASSERT_FALSE(ddc::is_spline_builder2D_v<Evaluator2D>);
+    ASSERT_FALSE(ddc::is_spline_builder2d_v<Builder1D>);
+    ASSERT_TRUE(ddc::is_spline_builder2d_v<Builder2D>);
+    ASSERT_FALSE(ddc::is_spline_builder2d_v<Evaluator1D>);
+    ASSERT_FALSE(ddc::is_spline_builder2d_v<Evaluator2D>);
 }
 
 TYPED_TEST(BSplinesTraits, IsSplineEvaluator)
@@ -207,10 +207,10 @@ TYPED_TEST(BSplinesTraits, IsSplineEvaluator2D)
     using Evaluator1D = typename TestFixture::Evaluator1D_1;
     using Builder2D = typename TestFixture::Builder2D_1;
     using Evaluator2D = typename TestFixture::Evaluator2D_1;
-    ASSERT_FALSE(ddc::is_spline_evaluator2D_v<Builder1D>);
-    ASSERT_FALSE(ddc::is_spline_evaluator2D_v<Builder2D>);
-    ASSERT_FALSE(ddc::is_spline_evaluator2D_v<Evaluator1D>);
-    ASSERT_TRUE(ddc::is_spline_evaluator2D_v<Evaluator2D>);
+    ASSERT_FALSE(ddc::is_spline_evaluator2d_v<Builder1D>);
+    ASSERT_FALSE(ddc::is_spline_evaluator2d_v<Builder2D>);
+    ASSERT_FALSE(ddc::is_spline_evaluator2d_v<Evaluator1D>);
+    ASSERT_TRUE(ddc::is_spline_evaluator2d_v<Evaluator2D>);
 }
 
 TYPED_TEST(BSplinesTraits, IsAdmissible1D)

--- a/tests/splines/spline_traits.cpp
+++ b/tests/splines/spline_traits.cpp
@@ -1,0 +1,281 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+#include <ddc/ddc.hpp>
+#include <ddc/kernels/splines.hpp>
+
+#include <gtest/gtest.h>
+
+#include <Kokkos_Core.hpp>
+#include "test_utils.hpp"
+
+struct DimX
+{
+    static constexpr bool PERIODIC = true;
+};
+
+struct DDimX : ddc::NonUniformPointSampling<DimX>
+{
+};
+
+struct DimY
+{
+    static constexpr bool PERIODIC = true;
+};
+
+struct DDimY : ddc::NonUniformPointSampling<DimY>
+{
+};
+
+template <typename T>
+struct BSplinesTraits;
+
+template <typename ExecSpace1, std::size_t D1, typename ExecSpace2, std::size_t D2>
+struct BSplinesTraits<std::tuple<ExecSpace1, std::integral_constant<std::size_t, D1>, ExecSpace2, std::integral_constant<std::size_t, D2>>> : public ::testing::Test {
+  using execution_space1 = ExecSpace1;
+  using execution_space2 = ExecSpace2;
+  using memory_space1 = typename ExecSpace1::memory_space;
+  using memory_space2 = typename ExecSpace2::memory_space;
+  static constexpr std::size_t m_spline_degree1 = D1;
+  static constexpr std::size_t m_spline_degree2 = D2;
+
+  struct BSplinesX1 : ddc::UniformBSplines<DimX, D1>
+  {
+  };
+
+  struct BSplinesX2 : ddc::UniformBSplines<DimX, D2>
+  {
+  };
+
+  struct BSplinesY : ddc::UniformBSplines<DimY, D1>
+  {
+  };
+  
+  using Builder1D_1 = ddc::SplineBuilder<
+                    execution_space1,
+                    memory_space1,
+                    BSplinesX1,
+                    DDimX,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::SplineSolver::LAPACK>;
+
+  using Evaluator1D_1 = ddc::SplineEvaluator<
+                    execution_space1,
+                    memory_space1,
+                    BSplinesX1,
+                    DDimX,
+                    ddc::PeriodicExtrapolationRule<DimX>,
+                    ddc::PeriodicExtrapolationRule<DimX>>;
+
+  using Builder1D_2 = ddc::SplineBuilder<
+                    execution_space2,
+                    memory_space2,
+                    BSplinesX2,
+                    DDimX,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::SplineSolver::LAPACK>;
+
+  using Evaluator1D_2 = ddc::SplineEvaluator<
+                    execution_space2,
+                    memory_space2,
+                    BSplinesX2,
+                    DDimX,
+                    ddc::PeriodicExtrapolationRule<DimX>,
+                    ddc::PeriodicExtrapolationRule<DimX>>;
+
+  using Builder2D_1 = ddc::SplineBuilder2D<
+                    execution_space1,
+                    memory_space1,
+                    BSplinesX1,
+                    BSplinesY,
+                    DDimX,
+                    DDimY,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::SplineSolver::LAPACK>;
+
+  using Evaluator2D_1 = ddc::SplineEvaluator2D<
+                    execution_space1,
+                    memory_space1,
+                    BSplinesX1,
+                    BSplinesY,
+                    DDimX,
+                    DDimY,
+                    ddc::PeriodicExtrapolationRule<DimX>,
+                    ddc::PeriodicExtrapolationRule<DimX>,
+                    ddc::PeriodicExtrapolationRule<DimY>,
+                    ddc::PeriodicExtrapolationRule<DimY>>;
+
+  using Builder2D_2 = ddc::SplineBuilder2D<
+                    execution_space2,
+                    memory_space2,
+                    BSplinesX2,
+                    BSplinesY,
+                    DDimX,
+                    DDimY,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::BoundCond::PERIODIC,
+                    ddc::SplineSolver::LAPACK>;
+
+  using Evaluator2D_2 = ddc::SplineEvaluator2D<
+                    execution_space2,
+                    memory_space2,
+                    BSplinesX2,
+                    BSplinesY,
+                    DDimX,
+                    DDimY,
+                    ddc::PeriodicExtrapolationRule<DimX>,
+                    ddc::PeriodicExtrapolationRule<DimX>,
+                    ddc::PeriodicExtrapolationRule<DimY>,
+                    ddc::PeriodicExtrapolationRule<DimY>>;
+};
+
+#if defined(KOKKOS_ENABLE_SERIAL)
+using execution_space_types = std::tuple<Kokkos::Serial, Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultExecutionSpace>;
+#else
+using execution_space_types = std::tuple<Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultExecutionSpace>;
+#endif
+
+using spline_degrees = std::integer_sequence<std::size_t, 2, 3>;
+
+using TestTypes = tuple_to_types_t<cartesian_product_t<execution_space_types, spline_degrees, execution_space_types, spline_degrees>>;
+
+TYPED_TEST_SUITE(BSplinesTraits, TestTypes, );
+
+TYPED_TEST(BSplinesTraits, IsSplineBuilder)
+{
+    using Builder1D = typename TestFixture::Builder1D_1;
+    using Evaluator1D = typename TestFixture::Evaluator1D_1;
+    using Builder2D = typename TestFixture::Builder2D_1;
+    using Evaluator2D = typename TestFixture::Evaluator2D_1;
+    ASSERT_TRUE(ddc::is_spline_builder_v<Builder1D>);
+    ASSERT_FALSE(ddc::is_spline_builder_v<Builder2D>);
+    ASSERT_FALSE(ddc::is_spline_builder_v<Evaluator1D>);
+    ASSERT_FALSE(ddc::is_spline_builder_v<Evaluator2D>);
+}
+
+TYPED_TEST(BSplinesTraits, IsSplineBuilder2D)
+{
+    using Builder1D = typename TestFixture::Builder1D_1;
+    using Evaluator1D = typename TestFixture::Evaluator1D_1;
+    using Builder2D = typename TestFixture::Builder2D_1;
+    using Evaluator2D = typename TestFixture::Evaluator2D_1;
+    ASSERT_FALSE(ddc::is_spline_builder2D_v<Builder1D>);
+    ASSERT_TRUE(ddc::is_spline_builder2D_v<Builder2D>);
+    ASSERT_FALSE(ddc::is_spline_builder2D_v<Evaluator1D>);
+    ASSERT_FALSE(ddc::is_spline_builder2D_v<Evaluator2D>);
+}
+
+TYPED_TEST(BSplinesTraits, IsSplineEvaluator)
+{
+    using Builder1D = typename TestFixture::Builder1D_1;
+    using Evaluator1D = typename TestFixture::Evaluator1D_1;
+    using Builder2D = typename TestFixture::Builder2D_1;
+    using Evaluator2D = typename TestFixture::Evaluator2D_1;
+    ASSERT_FALSE(ddc::is_spline_evaluator_v<Builder1D>);
+    ASSERT_FALSE(ddc::is_spline_evaluator_v<Builder2D>);
+    ASSERT_TRUE(ddc::is_spline_evaluator_v<Evaluator1D>);
+    ASSERT_FALSE(ddc::is_spline_evaluator_v<Evaluator2D>);
+}
+
+TYPED_TEST(BSplinesTraits, IsSplineEvaluator2D)
+{
+    using Builder1D = typename TestFixture::Builder1D_1;
+    using Evaluator1D = typename TestFixture::Evaluator1D_1;
+    using Builder2D = typename TestFixture::Builder2D_1;
+    using Evaluator2D = typename TestFixture::Evaluator2D_1;
+    ASSERT_FALSE(ddc::is_spline_evaluator2D_v<Builder1D>);
+    ASSERT_FALSE(ddc::is_spline_evaluator2D_v<Builder2D>);
+    ASSERT_FALSE(ddc::is_spline_evaluator2D_v<Evaluator1D>);
+    ASSERT_TRUE(ddc::is_spline_evaluator2D_v<Evaluator2D>);
+}
+
+TYPED_TEST(BSplinesTraits, IsCompatible1D)
+{
+    using Builder1D_1 = typename TestFixture::Builder1D_1;
+    using Evaluator1D_1 = typename TestFixture::Evaluator1D_1;
+    using Builder1D_2 = typename TestFixture::Builder1D_2;
+    using Evaluator1D_2 = typename TestFixture::Evaluator1D_2;
+
+    // Builders are not compatible
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_1, Builder1D_1>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_1, Builder1D_2>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_2, Builder1D_1>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_2, Builder1D_2>));
+
+    // Evaluators are not compatible
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_1, Evaluator1D_1>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_1, Evaluator1D_2>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_2, Evaluator1D_1>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_2, Evaluator1D_2>));
+
+    // Compatible builder and evaluator pairs
+    ASSERT_TRUE((ddc::is_spline_compatible_v<Builder1D_1, Evaluator1D_1>));
+    ASSERT_TRUE((ddc::is_spline_compatible_v<Evaluator1D_1, Builder1D_1>));
+    ASSERT_TRUE((ddc::is_spline_compatible_v<Builder1D_2, Evaluator1D_2>));
+    ASSERT_TRUE((ddc::is_spline_compatible_v<Evaluator1D_2, Builder1D_2>));
+
+    // Incompatible builder and evaluator pairs
+    using execution_space1 = typename TestFixture::execution_space1;
+    using execution_space2 = typename TestFixture::execution_space2;
+    std::size_t constexpr m_spline_degree1 = TestFixture::m_spline_degree1;
+    std::size_t constexpr m_spline_degree2 = TestFixture::m_spline_degree2;
+
+    if ((!std::is_same_v<execution_space1, execution_space2>) || (m_spline_degree1 != m_spline_degree2)) {
+      ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_1, Evaluator1D_2>));
+      ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_2, Builder1D_1>));
+      ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_2, Evaluator1D_1>));
+      ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_1, Builder1D_2>));
+    }
+}
+
+TYPED_TEST(BSplinesTraits, IsCompatible2D)
+{
+    using Builder2D_1 = typename TestFixture::Builder2D_1;
+    using Evaluator2D_1 = typename TestFixture::Evaluator2D_1;
+    using Builder2D_2 = typename TestFixture::Builder2D_2;
+    using Evaluator2D_2 = typename TestFixture::Evaluator2D_2;
+
+    // Builders are not compatible
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_1, Builder2D_1>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_1, Builder2D_2>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_2, Builder2D_1>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_2, Builder2D_2>));
+
+    // Evaluators are not compatible
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_1, Evaluator2D_1>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_1, Evaluator2D_2>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_2, Evaluator2D_1>));
+    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_2, Evaluator2D_2>));
+
+    // Compatible builder and evaluator pairs
+    ASSERT_TRUE((ddc::is_spline_compatible_v<Builder2D_1, Evaluator2D_1>));
+    ASSERT_TRUE((ddc::is_spline_compatible_v<Evaluator2D_1, Builder2D_1>));
+    ASSERT_TRUE((ddc::is_spline_compatible_v<Builder2D_2, Evaluator2D_2>));
+    ASSERT_TRUE((ddc::is_spline_compatible_v<Evaluator2D_2, Builder2D_2>));
+
+    // Incompatible builder and evaluator pairs
+    using execution_space1 = typename TestFixture::execution_space1;
+    using execution_space2 = typename TestFixture::execution_space2;
+    std::size_t constexpr m_spline_degree1 = TestFixture::m_spline_degree1;
+    std::size_t constexpr m_spline_degree2 = TestFixture::m_spline_degree2;
+
+    if ((!std::is_same_v<execution_space1, execution_space2>) || (m_spline_degree1 != m_spline_degree2)) {
+      ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_1, Evaluator2D_2>));
+      ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_2, Builder2D_1>));
+      ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_2, Evaluator2D_1>));
+      ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_1, Builder2D_2>));
+    }
+}
+

--- a/tests/splines/spline_traits.cpp
+++ b/tests/splines/spline_traits.cpp
@@ -12,6 +12,7 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
+
 #include "test_utils.hpp"
 
 struct DimX
@@ -36,120 +37,131 @@ template <typename T>
 struct BSplinesTraits;
 
 template <typename ExecSpace1, std::size_t D1, typename ExecSpace2, std::size_t D2>
-struct BSplinesTraits<std::tuple<ExecSpace1, std::integral_constant<std::size_t, D1>, ExecSpace2, std::integral_constant<std::size_t, D2>>> : public ::testing::Test {
-  using execution_space1 = ExecSpace1;
-  using execution_space2 = ExecSpace2;
-  using memory_space1 = typename ExecSpace1::memory_space;
-  using memory_space2 = typename ExecSpace2::memory_space;
-  static constexpr std::size_t m_spline_degree1 = D1;
-  static constexpr std::size_t m_spline_degree2 = D2;
+struct BSplinesTraits<std::tuple<
+        ExecSpace1,
+        std::integral_constant<std::size_t, D1>,
+        ExecSpace2,
+        std::integral_constant<std::size_t, D2>>> : public ::testing::Test
+{
+    using execution_space1 = ExecSpace1;
+    using execution_space2 = ExecSpace2;
+    using memory_space1 = typename ExecSpace1::memory_space;
+    using memory_space2 = typename ExecSpace2::memory_space;
+    static constexpr std::size_t m_spline_degree1 = D1;
+    static constexpr std::size_t m_spline_degree2 = D2;
 
-  struct BSplinesX1 : ddc::UniformBSplines<DimX, D1>
-  {
-  };
+    struct BSplinesX1 : ddc::UniformBSplines<DimX, D1>
+    {
+    };
 
-  struct BSplinesX2 : ddc::UniformBSplines<DimX, D2>
-  {
-  };
+    struct BSplinesX2 : ddc::UniformBSplines<DimX, D2>
+    {
+    };
 
-  struct BSplinesY : ddc::UniformBSplines<DimY, D1>
-  {
-  };
-  
-  using Builder1D_1 = ddc::SplineBuilder<
-                    execution_space1,
-                    memory_space1,
-                    BSplinesX1,
-                    DDimX,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::SplineSolver::LAPACK>;
+    struct BSplinesY : ddc::UniformBSplines<DimY, D1>
+    {
+    };
 
-  using Evaluator1D_1 = ddc::SplineEvaluator<
-                    execution_space1,
-                    memory_space1,
-                    BSplinesX1,
-                    DDimX,
-                    ddc::PeriodicExtrapolationRule<DimX>,
-                    ddc::PeriodicExtrapolationRule<DimX>>;
+    using Builder1D_1 = ddc::SplineBuilder<
+            execution_space1,
+            memory_space1,
+            BSplinesX1,
+            DDimX,
+            ddc::BoundCond::PERIODIC,
+            ddc::BoundCond::PERIODIC,
+            ddc::SplineSolver::LAPACK>;
 
-  using Builder1D_2 = ddc::SplineBuilder<
-                    execution_space2,
-                    memory_space2,
-                    BSplinesX2,
-                    DDimX,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::SplineSolver::LAPACK>;
+    using Evaluator1D_1 = ddc::SplineEvaluator<
+            execution_space1,
+            memory_space1,
+            BSplinesX1,
+            DDimX,
+            ddc::PeriodicExtrapolationRule<DimX>,
+            ddc::PeriodicExtrapolationRule<DimX>>;
 
-  using Evaluator1D_2 = ddc::SplineEvaluator<
-                    execution_space2,
-                    memory_space2,
-                    BSplinesX2,
-                    DDimX,
-                    ddc::PeriodicExtrapolationRule<DimX>,
-                    ddc::PeriodicExtrapolationRule<DimX>>;
+    using Builder1D_2 = ddc::SplineBuilder<
+            execution_space2,
+            memory_space2,
+            BSplinesX2,
+            DDimX,
+            ddc::BoundCond::PERIODIC,
+            ddc::BoundCond::PERIODIC,
+            ddc::SplineSolver::LAPACK>;
 
-  using Builder2D_1 = ddc::SplineBuilder2D<
-                    execution_space1,
-                    memory_space1,
-                    BSplinesX1,
-                    BSplinesY,
-                    DDimX,
-                    DDimY,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::SplineSolver::LAPACK>;
+    using Evaluator1D_2 = ddc::SplineEvaluator<
+            execution_space2,
+            memory_space2,
+            BSplinesX2,
+            DDimX,
+            ddc::PeriodicExtrapolationRule<DimX>,
+            ddc::PeriodicExtrapolationRule<DimX>>;
 
-  using Evaluator2D_1 = ddc::SplineEvaluator2D<
-                    execution_space1,
-                    memory_space1,
-                    BSplinesX1,
-                    BSplinesY,
-                    DDimX,
-                    DDimY,
-                    ddc::PeriodicExtrapolationRule<DimX>,
-                    ddc::PeriodicExtrapolationRule<DimX>,
-                    ddc::PeriodicExtrapolationRule<DimY>,
-                    ddc::PeriodicExtrapolationRule<DimY>>;
+    using Builder2D_1 = ddc::SplineBuilder2D<
+            execution_space1,
+            memory_space1,
+            BSplinesX1,
+            BSplinesY,
+            DDimX,
+            DDimY,
+            ddc::BoundCond::PERIODIC,
+            ddc::BoundCond::PERIODIC,
+            ddc::BoundCond::PERIODIC,
+            ddc::BoundCond::PERIODIC,
+            ddc::SplineSolver::LAPACK>;
 
-  using Builder2D_2 = ddc::SplineBuilder2D<
-                    execution_space2,
-                    memory_space2,
-                    BSplinesX2,
-                    BSplinesY,
-                    DDimX,
-                    DDimY,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::BoundCond::PERIODIC,
-                    ddc::SplineSolver::LAPACK>;
+    using Evaluator2D_1 = ddc::SplineEvaluator2D<
+            execution_space1,
+            memory_space1,
+            BSplinesX1,
+            BSplinesY,
+            DDimX,
+            DDimY,
+            ddc::PeriodicExtrapolationRule<DimX>,
+            ddc::PeriodicExtrapolationRule<DimX>,
+            ddc::PeriodicExtrapolationRule<DimY>,
+            ddc::PeriodicExtrapolationRule<DimY>>;
 
-  using Evaluator2D_2 = ddc::SplineEvaluator2D<
-                    execution_space2,
-                    memory_space2,
-                    BSplinesX2,
-                    BSplinesY,
-                    DDimX,
-                    DDimY,
-                    ddc::PeriodicExtrapolationRule<DimX>,
-                    ddc::PeriodicExtrapolationRule<DimX>,
-                    ddc::PeriodicExtrapolationRule<DimY>,
-                    ddc::PeriodicExtrapolationRule<DimY>>;
+    using Builder2D_2 = ddc::SplineBuilder2D<
+            execution_space2,
+            memory_space2,
+            BSplinesX2,
+            BSplinesY,
+            DDimX,
+            DDimY,
+            ddc::BoundCond::PERIODIC,
+            ddc::BoundCond::PERIODIC,
+            ddc::BoundCond::PERIODIC,
+            ddc::BoundCond::PERIODIC,
+            ddc::SplineSolver::LAPACK>;
+
+    using Evaluator2D_2 = ddc::SplineEvaluator2D<
+            execution_space2,
+            memory_space2,
+            BSplinesX2,
+            BSplinesY,
+            DDimX,
+            DDimY,
+            ddc::PeriodicExtrapolationRule<DimX>,
+            ddc::PeriodicExtrapolationRule<DimX>,
+            ddc::PeriodicExtrapolationRule<DimY>,
+            ddc::PeriodicExtrapolationRule<DimY>>;
 };
 
 #if defined(KOKKOS_ENABLE_SERIAL)
-using execution_space_types = std::tuple<Kokkos::Serial, Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultExecutionSpace>;
+using execution_space_types = std::
+        tuple<Kokkos::Serial, Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultExecutionSpace>;
 #else
-using execution_space_types = std::tuple<Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultExecutionSpace>;
+using execution_space_types
+        = std::tuple<Kokkos::DefaultHostExecutionSpace, Kokkos::DefaultExecutionSpace>;
 #endif
 
 using spline_degrees = std::integer_sequence<std::size_t, 2, 3>;
 
-using TestTypes = tuple_to_types_t<cartesian_product_t<execution_space_types, spline_degrees, execution_space_types, spline_degrees>>;
+using TestTypes = tuple_to_types_t<cartesian_product_t<
+        execution_space_types,
+        spline_degrees,
+        execution_space_types,
+        spline_degrees>>;
 
 TYPED_TEST_SUITE(BSplinesTraits, TestTypes, );
 
@@ -232,11 +244,12 @@ TYPED_TEST(BSplinesTraits, IsAdmissible1D)
     std::size_t constexpr m_spline_degree1 = TestFixture::m_spline_degree1;
     std::size_t constexpr m_spline_degree2 = TestFixture::m_spline_degree2;
 
-    if ((!std::is_same_v<execution_space1, execution_space2>) || (m_spline_degree1 != m_spline_degree2)) {
-      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_1, Evaluator1D_2>));
-      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_2, Builder1D_1>));
-      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_2, Evaluator1D_1>));
-      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_1, Builder1D_2>));
+    if ((!std::is_same_v<execution_space1, execution_space2>)
+        || (m_spline_degree1 != m_spline_degree2)) {
+        ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_1, Evaluator1D_2>));
+        ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_2, Builder1D_1>));
+        ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_2, Evaluator1D_1>));
+        ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_1, Builder1D_2>));
     }
 }
 
@@ -271,11 +284,11 @@ TYPED_TEST(BSplinesTraits, IsAdmissible2D)
     std::size_t constexpr m_spline_degree1 = TestFixture::m_spline_degree1;
     std::size_t constexpr m_spline_degree2 = TestFixture::m_spline_degree2;
 
-    if ((!std::is_same_v<execution_space1, execution_space2>) || (m_spline_degree1 != m_spline_degree2)) {
-      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_1, Evaluator2D_2>));
-      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_2, Builder2D_1>));
-      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_2, Evaluator2D_1>));
-      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_1, Builder2D_2>));
+    if ((!std::is_same_v<execution_space1, execution_space2>)
+        || (m_spline_degree1 != m_spline_degree2)) {
+        ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_1, Evaluator2D_2>));
+        ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_2, Builder2D_1>));
+        ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_2, Evaluator2D_1>));
+        ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_1, Builder2D_2>));
     }
 }
-

--- a/tests/splines/spline_traits.cpp
+++ b/tests/splines/spline_traits.cpp
@@ -2,6 +2,10 @@
 //
 // SPDX-License-Identifier: MIT
 
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
 #include <ddc/ddc.hpp>
 #include <ddc/kernels/splines.hpp>
 

--- a/tests/splines/spline_traits.cpp
+++ b/tests/splines/spline_traits.cpp
@@ -201,7 +201,7 @@ TYPED_TEST(BSplinesTraits, IsSplineEvaluator2D)
     ASSERT_TRUE(ddc::is_spline_evaluator2D_v<Evaluator2D>);
 }
 
-TYPED_TEST(BSplinesTraits, IsCompatible1D)
+TYPED_TEST(BSplinesTraits, IsAdmissible1D)
 {
     using Builder1D_1 = typename TestFixture::Builder1D_1;
     using Evaluator1D_1 = typename TestFixture::Evaluator1D_1;
@@ -209,22 +209,22 @@ TYPED_TEST(BSplinesTraits, IsCompatible1D)
     using Evaluator1D_2 = typename TestFixture::Evaluator1D_2;
 
     // Builders are not compatible
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_1, Builder1D_1>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_1, Builder1D_2>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_2, Builder1D_1>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_2, Builder1D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_1, Builder1D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_1, Builder1D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_2, Builder1D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_2, Builder1D_2>));
 
     // Evaluators are not compatible
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_1, Evaluator1D_1>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_1, Evaluator1D_2>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_2, Evaluator1D_1>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_2, Evaluator1D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_1, Evaluator1D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_1, Evaluator1D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_2, Evaluator1D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_2, Evaluator1D_2>));
 
     // Compatible builder and evaluator pairs
-    ASSERT_TRUE((ddc::is_spline_compatible_v<Builder1D_1, Evaluator1D_1>));
-    ASSERT_TRUE((ddc::is_spline_compatible_v<Evaluator1D_1, Builder1D_1>));
-    ASSERT_TRUE((ddc::is_spline_compatible_v<Builder1D_2, Evaluator1D_2>));
-    ASSERT_TRUE((ddc::is_spline_compatible_v<Evaluator1D_2, Builder1D_2>));
+    ASSERT_TRUE((ddc::is_evaluator_admissible_v<Builder1D_1, Evaluator1D_1>));
+    ASSERT_TRUE((ddc::is_evaluator_admissible_v<Builder1D_2, Evaluator1D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_1, Builder1D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_2, Builder1D_2>));
 
     // Incompatible builder and evaluator pairs
     using execution_space1 = typename TestFixture::execution_space1;
@@ -233,14 +233,14 @@ TYPED_TEST(BSplinesTraits, IsCompatible1D)
     std::size_t constexpr m_spline_degree2 = TestFixture::m_spline_degree2;
 
     if ((!std::is_same_v<execution_space1, execution_space2>) || (m_spline_degree1 != m_spline_degree2)) {
-      ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_1, Evaluator1D_2>));
-      ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_2, Builder1D_1>));
-      ASSERT_FALSE((ddc::is_spline_compatible_v<Builder1D_2, Evaluator1D_1>));
-      ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator1D_1, Builder1D_2>));
+      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_1, Evaluator1D_2>));
+      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_2, Builder1D_1>));
+      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder1D_2, Evaluator1D_1>));
+      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator1D_1, Builder1D_2>));
     }
 }
 
-TYPED_TEST(BSplinesTraits, IsCompatible2D)
+TYPED_TEST(BSplinesTraits, IsAdmissible2D)
 {
     using Builder2D_1 = typename TestFixture::Builder2D_1;
     using Evaluator2D_1 = typename TestFixture::Evaluator2D_1;
@@ -248,22 +248,22 @@ TYPED_TEST(BSplinesTraits, IsCompatible2D)
     using Evaluator2D_2 = typename TestFixture::Evaluator2D_2;
 
     // Builders are not compatible
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_1, Builder2D_1>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_1, Builder2D_2>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_2, Builder2D_1>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_2, Builder2D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_1, Builder2D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_1, Builder2D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_2, Builder2D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_2, Builder2D_2>));
 
     // Evaluators are not compatible
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_1, Evaluator2D_1>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_1, Evaluator2D_2>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_2, Evaluator2D_1>));
-    ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_2, Evaluator2D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_1, Evaluator2D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_1, Evaluator2D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_2, Evaluator2D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_2, Evaluator2D_2>));
 
     // Compatible builder and evaluator pairs
-    ASSERT_TRUE((ddc::is_spline_compatible_v<Builder2D_1, Evaluator2D_1>));
-    ASSERT_TRUE((ddc::is_spline_compatible_v<Evaluator2D_1, Builder2D_1>));
-    ASSERT_TRUE((ddc::is_spline_compatible_v<Builder2D_2, Evaluator2D_2>));
-    ASSERT_TRUE((ddc::is_spline_compatible_v<Evaluator2D_2, Builder2D_2>));
+    ASSERT_TRUE((ddc::is_evaluator_admissible_v<Builder2D_1, Evaluator2D_1>));
+    ASSERT_TRUE((ddc::is_evaluator_admissible_v<Builder2D_2, Evaluator2D_2>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_1, Builder2D_1>));
+    ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_2, Builder2D_2>));
 
     // Incompatible builder and evaluator pairs
     using execution_space1 = typename TestFixture::execution_space1;
@@ -272,10 +272,10 @@ TYPED_TEST(BSplinesTraits, IsCompatible2D)
     std::size_t constexpr m_spline_degree2 = TestFixture::m_spline_degree2;
 
     if ((!std::is_same_v<execution_space1, execution_space2>) || (m_spline_degree1 != m_spline_degree2)) {
-      ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_1, Evaluator2D_2>));
-      ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_2, Builder2D_1>));
-      ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_2, Evaluator2D_1>));
-      ASSERT_FALSE((ddc::is_spline_compatible_v<Evaluator2D_1, Builder2D_2>));
+      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_1, Evaluator2D_2>));
+      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_2, Builder2D_1>));
+      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Builder2D_2, Evaluator2D_1>));
+      ASSERT_FALSE((ddc::is_evaluator_admissible_v<Evaluator2D_1, Builder2D_2>));
     }
 }
 


### PR DESCRIPTION
This PR aims at a helper to check the consistency of spline builder and evaluator.
For some reason, I need double parentheses to use `ASSERT_FALSE` like 
`ASSERT_FALSE((ddc::is_spline_compatible_v<Builder2D_1, Builder2D_1>));`