### PR TITLE
Explicit use of macos-15

### DIFF
--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -127,7 +127,7 @@ jobs:
         run: |
           cmake \
             -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
-            -D CMAKE_CXX_FLAGS="-undefined dynamic_lookup" \
+            -D CMAKE_SHARED_LINKER_FLAGS="-undefined dynamic_lookup" \
             -D GINKGO_BUILD_BENCHMARKS=OFF \
             -D GINKGO_BUILD_EXAMPLES=OFF \
             -D GINKGO_BUILD_MPI=OFF \

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -121,12 +121,13 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: ginkgo-project/ginkgo
-          ref: v1.9.0
+          ref: v1.8.0
           path: ginkgo
       - name: Install Ginkgo
         run: |
           cmake \
             -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
+            -D CMAKE_CXX_FLAGS="-undefined dynamic_lookup" \
             -D GINKGO_BUILD_BENCHMARKS=OFF \
             -D GINKGO_BUILD_EXAMPLES=OFF \
             -D GINKGO_BUILD_MPI=OFF \

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -60,7 +60,7 @@ jobs:
             cxx_compiler: 'clang++'
             ddc_extra_cxx_flags: '-Wextra-semi -Wextra-semi-stmt -Wold-style-cast'
             kokkos_extra_cmake_flags: ''
-        cxx_version: ['17', '20', '23']
+        cxx_version: ['17', '20']  # Kokkos 4.6 is not compatible with C++ 23
         cmake_build_type: ['Debug', 'Release']
     runs-on: macos-15
     needs: [id_repo]
@@ -125,6 +125,7 @@ jobs:
           path: ginkgo
       - name: Install Ginkgo
         run: |
+          # Ginkgo 1.8 needs the flags "-undefined dynamic_lookup" to link, recent versions should not need it
           cmake \
             -D CMAKE_CXX_STANDARD=${{matrix.cxx_version}} \
             -D CMAKE_SHARED_LINKER_FLAGS="-undefined dynamic_lookup" \

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           repository: ginkgo-project/ginkgo
-          ref: v1.8.0
+          ref: v1.9.0
           path: ginkgo
       - name: Install Ginkgo
         run: |

--- a/.github/workflows/tests-macos.yaml
+++ b/.github/workflows/tests-macos.yaml
@@ -41,7 +41,7 @@ permissions:
 
 jobs:
   id_repo:
-    runs-on: macos-latest
+    runs-on: macos-15
     steps:
       - name: Identify repository
         id: identify_repo
@@ -62,7 +62,7 @@ jobs:
             kokkos_extra_cmake_flags: ''
         cxx_version: ['17', '20', '23']
         cmake_build_type: ['Debug', 'Release']
-    runs-on: macos-latest
+    runs-on: macos-15
     needs: [id_repo]
     env:
       DDC_ROOT: ${{github.workspace}}/opt/ddc


### PR DESCRIPTION
The image macos-latest is about to change definition. Let us be explicit about the tested version.

This leads to disable C++23 build as recent versions of libc++ implement `std::mdspan` and Kokkos does not handle it correctly.