### PR TITLE
Remove Ginkgo workaround and set minimum requirement to 1.9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ endif()
 
 if("${DDC_BUILD_KERNELS_SPLINES}")
     # Ginkgo
-    find_package(Ginkgo 1.8 REQUIRED)
+    find_package(Ginkgo 1.9 REQUIRED)
 
     # Lapacke
     find_package(LAPACKE REQUIRED)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To use DDC components, one needs the following dependencies:
 * (optional, IO interface) DDC::pdi
   * PDI 1.10.1...<2
 * (optional, spline interpolation) DDC::splines
-  * Ginkgo 1.8...<2
+  * Ginkgo 1.9...<2
   * Kokkos Kernels 4.7...<6
 
 ## Getting the code and basic configuration

--- a/docker/oldest/spack-env/spack-cpu.yaml
+++ b/docker/oldest/spack-env/spack-cpu.yaml
@@ -31,7 +31,7 @@ spack:
     - 'gcc@11'
     - 'benchmark@1.9 ~performance_counters'
     - 'cmake@3.25'
-    - 'ginkgo@1.8'
+    - 'ginkgo@1.9'
     - 'googletest@1.14 +gmock'
     - 'kokkos@4.7'
     - 'kokkos-fft@0.3 host_backend=fftw-serial'

--- a/docker/oldest/spack-env/spack-cuda.yaml
+++ b/docker/oldest/spack-env/spack-cuda.yaml
@@ -36,7 +36,7 @@ spack:
     - 'gcc@11'
     - 'benchmark@1.9 ~performance_counters'
     - 'cmake@3.25'
-    - 'ginkgo@1.8'
+    - 'ginkgo@1.9'
     - 'googletest@1.14 +gmock'
     - 'kokkos@4.7 +cuda_constexpr +cuda_relocatable_device_code'
     - 'kokkos-fft@0.3 host_backend=fftw-serial device_backend=cufft'

--- a/docker/oldest/spack-env/spack-hip.yaml
+++ b/docker/oldest/spack-env/spack-hip.yaml
@@ -113,7 +113,7 @@ spack:
     - 'gcc@11'
     - 'benchmark@1.9 ~performance_counters'
     - 'cmake@3.25'
-    - 'ginkgo@1.8 +rocm amdgpu_target=gfx90a'
+    - 'ginkgo@1.9 +rocm amdgpu_target=gfx90a'
     - 'googletest@1.14 +gmock'
     - 'kokkos@4.7 +hip_relocatable_device_code +rocm amdgpu_target=gfx90a'
     - 'kokkos-fft@0.3 host_backend=fftw-serial device_backend=hipfft'

--- a/src/ddc/kernels/splines/splines_linear_problem_sparse.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_sparse.cpp
@@ -136,14 +136,7 @@ public:
 
 private:
     using matrix_sparse_type = gko::matrix::Csr<double, gko::int32>;
-#if defined(KOKKOS_ENABLE_OPENMP)
-    using solver_type = std::conditional_t<
-            std::is_same_v<ExecSpace, Kokkos::OpenMP>,
-            gko::solver::Gmres<double>,
-            gko::solver::Bicgstab<double>>;
-#else
     using solver_type = gko::solver::Bicgstab<double>;
-#endif
 
 private:
     std::size_t m_mat_size;
@@ -223,7 +216,7 @@ public:
     /**
      * @brief Solve the multiple right-hand sides linear problem Ax=b or its transposed version A^tx=b inplace.
      *
-     * The solver method is currently Bicgstab on CPU Serial and GPU and Gmres on OMP (because of Ginkgo issue #1563).
+     * The solver method is currently BiCGSTAB.
      *
      * Multiple right-hand sides are sliced in chunks of size cols_per_chunk which are passed one-after-the-other to Ginkgo.
      *

--- a/src/ddc/kernels/splines/splines_linear_problem_sparse.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_sparse.hpp
@@ -75,7 +75,7 @@ public:
     /**
      * @brief Solve the multiple right-hand sides linear problem Ax=b or its transposed version A^tx=b inplace.
      *
-     * The solver method is currently Bicgstab on CPU Serial and GPU and Gmres on OMP (because of Ginkgo issue #1563).
+     * The solver method is currently BiCGSTAB.
      *
      * Multiple right-hand sides are sliced in chunks of size cols_per_chunk which are passed one-after-the-other to Ginkgo.
      *


### PR DESCRIPTION
I think it is now safe to set the minimum requirement to version 1.9 as versions 1.10 and 1.11 are released.