### PR TITLE
Remove `Kokkos::Experimental` symbols

### DIFF
--- a/src/ddc/chunk_span.hpp
+++ b/src/ddc/chunk_span.hpp
@@ -282,13 +282,22 @@ public:
         Slicer<to_type_seq_t<SupportType>> const slicer;
         auto subview = slicer(this->allocation_mdspan(), slice_spec);
         using layout_type = decltype(subview)::layout_type;
+        using mapping_type = decltype(subview)::mapping_type;
         using extents_type = decltype(subview)::extents_type;
         using OutTypeSeqDDims
                 = type_seq_remove_t<to_type_seq_t<SupportType>, TypeSeq<QueryDDims...>>;
         using OutDDom = detail::Rebind<SupportType, OutTypeSeqDDims>::type;
         if constexpr (
-                std::is_same_v<layout_type, Kokkos::Experimental::layout_left_padded<>>
-                || std::is_same_v<layout_type, Kokkos::Experimental::layout_right_padded<>>) {
+                std::is_same_v<layout_type, Kokkos::layout_left>
+                || std::is_same_v<layout_type, Kokkos::layout_right>
+                || std::is_same_v<layout_type, Kokkos::layout_stride>) {
+            return ChunkSpan<
+                    ElementType,
+                    OutDDom,
+                    layout_type,
+                    memory_space>(subview, OutDDom(this->m_domain));
+        } else {
+            static_assert(mapping_type::is_always_strided() && mapping_type::is_always_unique());
             Kokkos::layout_stride::mapping<extents_type> const mapping_stride(subview.mapping());
             Kokkos::mdspan<ElementType, extents_type, Kokkos::layout_stride> const
                     a(subview.data_handle(), mapping_stride);
@@ -297,12 +306,6 @@ public:
                     OutDDom,
                     Kokkos::layout_stride,
                     memory_space>(a, OutDDom(this->m_domain));
-        } else {
-            return ChunkSpan<
-                    ElementType,
-                    OutDDom,
-                    layout_type,
-                    memory_space>(subview, OutDDom(this->m_domain));
         }
     }
 
@@ -330,10 +333,19 @@ public:
         Slicer<to_type_seq_t<SupportType>> const slicer;
         auto subview = slicer(this->allocation_mdspan(), odomain, this->m_domain);
         using layout_type = decltype(subview)::layout_type;
+        using mapping_type = decltype(subview)::mapping_type;
         using extents_type = decltype(subview)::extents_type;
         if constexpr (
-                std::is_same_v<layout_type, Kokkos::Experimental::layout_left_padded<>>
-                || std::is_same_v<layout_type, Kokkos::Experimental::layout_right_padded<>>) {
+                std::is_same_v<layout_type, Kokkos::layout_left>
+                || std::is_same_v<layout_type, Kokkos::layout_right>
+                || std::is_same_v<layout_type, Kokkos::layout_stride>) {
+            return ChunkSpan<
+                    ElementType,
+                    decltype(this->m_domain.restrict_with(odomain)),
+                    layout_type,
+                    memory_space>(subview, this->m_domain.restrict_with(odomain));
+        } else {
+            static_assert(mapping_type::is_always_strided() && mapping_type::is_always_unique());
             Kokkos::layout_stride::mapping<extents_type> const mapping_stride(subview.mapping());
             Kokkos::mdspan<ElementType, extents_type, Kokkos::layout_stride> const
                     a(subview.data_handle(), mapping_stride);
@@ -342,12 +354,6 @@ public:
                     decltype(this->m_domain.restrict_with(odomain)),
                     Kokkos::layout_stride,
                     memory_space>(a, this->m_domain.restrict_with(odomain));
-        } else {
-            return ChunkSpan<
-                    ElementType,
-                    decltype(this->m_domain.restrict_with(odomain)),
-                    layout_type,
-                    memory_space>(subview, this->m_domain.restrict_with(odomain));
         }
     }
 

--- a/tests/for_each.cpp
+++ b/tests/for_each.cpp
@@ -10,7 +10,8 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_StdAlgorithms.hpp>
+
+#include "helper_count.hpp"
 
 inline namespace anonymous_namespace_workaround_for_each_cpp {
 
@@ -110,13 +111,7 @@ TEST(DeviceForEachSerialDevice, OneDimension)
             Kokkos::layout_right,
             Kokkos::DefaultExecutionSpace::memory_space> const view(storage.data(), dom);
     TestDeviceForEachSerialDevice1D(view);
-    EXPECT_EQ(
-            Kokkos::Experimental::
-                    count(Kokkos::DefaultExecutionSpace(),
-                          Kokkos::Experimental::begin(storage),
-                          Kokkos::Experimental::end(storage),
-                          1),
-            dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 void TestDeviceForEachSerialDevice2D(
@@ -145,11 +140,5 @@ TEST(DeviceForEachSerialDevice, TwoDimensions)
             Kokkos::layout_right,
             Kokkos::DefaultExecutionSpace::memory_space> const view(storage.data(), dom);
     TestDeviceForEachSerialDevice2D(view);
-    EXPECT_EQ(
-            Kokkos::Experimental::
-                    count(Kokkos::DefaultExecutionSpace(),
-                          Kokkos::Experimental::begin(storage),
-                          Kokkos::Experimental::end(storage),
-                          1),
-            dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }

--- a/tests/helper_count.hpp
+++ b/tests/helper_count.hpp
@@ -1,0 +1,54 @@
+// Copyright (C) The DDC development team, see COPYRIGHT.md file
+//
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <cstddef>
+#include <utility>
+
+#include <Kokkos_Core.hpp>
+
+namespace ddc::testing {
+
+template <class View, class T>
+class CountFn
+{
+    View m_view;
+
+    T m_value;
+
+public:
+    using index_type = std::size_t;
+
+    using result_type = std::ptrdiff_t;
+
+    CountFn(View view, T value) : m_view(std::move(view)), m_value(std::move(value)) {}
+
+    KOKKOS_FUNCTION
+    void operator()(index_type i, result_type& local_sum) const noexcept
+    {
+        if (m_view(i) == m_value) {
+            ++local_sum;
+        }
+    }
+};
+
+template <class ExecutionSpace, class DataType, class... Properties, class T>
+    requires(Kokkos::is_execution_space_v<ExecutionSpace>)
+auto count(
+        ExecutionSpace const& ex,
+        Kokkos::View<DataType*, Properties...> const& view,
+        T const& value) -> std::ptrdiff_t
+{
+    using result_type = std::ptrdiff_t;
+    using index_type = std::size_t;
+
+    result_type sum = 0;
+    Kokkos::RangePolicy<ExecutionSpace, Kokkos::IndexType<index_type>> const
+            policy(ex, 0, view.extent(0));
+    Kokkos::parallel_reduce(policy, CountFn(view, value), sum);
+    return sum;
+}
+
+} // namespace ddc::testing

--- a/tests/parallel_copy.cpp
+++ b/tests/parallel_copy.cpp
@@ -7,7 +7,8 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_StdAlgorithms.hpp>
+
+#include "helper_count.hpp"
 
 inline namespace anonymous_namespace_workaround_parallel_copy_cpp {
 
@@ -109,7 +110,7 @@ TEST(ParallelCopy, BroadcastScalar2XY)
 
     ddc::parallel_copy(exec_space, chunk_x_y, chunk);
 
-    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 1), dom_x_y.size());
+    EXPECT_EQ(ddc::testing::count(exec_space, storage, 1), dom_x_y.size());
 }
 
 TEST(ParallelCopy, BroadcastX2XY)
@@ -126,7 +127,7 @@ TEST(ParallelCopy, BroadcastX2XY)
 
     ddc::parallel_copy(exec_space, chunk_x_y, chunk_x);
 
-    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 1), dom_x_y.size());
+    EXPECT_EQ(ddc::testing::count(exec_space, storage, 1), dom_x_y.size());
 }
 
 TEST(ParallelCopy, TransposeYX2XY)
@@ -144,7 +145,7 @@ TEST(ParallelCopy, TransposeYX2XY)
 
     ddc::parallel_copy(exec_space, chunk_x_y_out, chunk_y_x_in);
 
-    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 1), dom_x_y.size());
+    EXPECT_EQ(ddc::testing::count(exec_space, storage, 1), dom_x_y.size());
 }
 
 TEST(ParallelCopy, BroadcastAndTransposeYX2XYZ)
@@ -163,5 +164,5 @@ TEST(ParallelCopy, BroadcastAndTransposeYX2XYZ)
 
     ddc::parallel_copy(exec_space, chunk_x_y_z, chunk_y_x);
 
-    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 1), dom_x_y_z.size());
+    EXPECT_EQ(ddc::testing::count(exec_space, storage, 1), dom_x_y_z.size());
 }

--- a/tests/parallel_fill.cpp
+++ b/tests/parallel_fill.cpp
@@ -7,7 +7,8 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_StdAlgorithms.hpp>
+
+#include "helper_count.hpp"
 
 inline namespace anonymous_namespace_workaround_parallel_fill_cpp {
 
@@ -47,7 +48,7 @@ TEST(ParallelFill, OneDimension)
     ddc::ChunkSpan const view(storage, dom);
 
     ddc::parallel_fill(view, 1);
-    EXPECT_EQ(Kokkos::Experimental::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 TEST(ParallelFill, TwoDimensions)
@@ -57,7 +58,7 @@ TEST(ParallelFill, TwoDimensions)
     ddc::ChunkSpan const view(Kokkos::View<int**>(storage.data(), nelems_x, nelems_y), dom);
 
     ddc::parallel_fill(view, 1);
-    EXPECT_EQ(Kokkos::Experimental::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 TEST(ParallelFill, OneDimensionWithExecutionSpace)
@@ -68,7 +69,7 @@ TEST(ParallelFill, OneDimensionWithExecutionSpace)
     ddc::ChunkSpan const view(storage, dom);
 
     ddc::parallel_fill(exec_space, view, 1);
-    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(exec_space, storage, 1), dom.size());
 }
 
 TEST(ParallelFill, TwoDimensionsWithExecutionSpace)
@@ -79,5 +80,5 @@ TEST(ParallelFill, TwoDimensionsWithExecutionSpace)
     ddc::ChunkSpan const view(Kokkos::View<int**>(storage.data(), nelems_x, nelems_y), dom);
 
     ddc::parallel_fill(exec_space, view, 1);
-    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(exec_space, storage, 1), dom.size());
 }

--- a/tests/parallel_for_each.cpp
+++ b/tests/parallel_for_each.cpp
@@ -9,7 +9,8 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_StdAlgorithms.hpp>
+
+#include "helper_count.hpp"
 
 inline namespace anonymous_namespace_workaround_parallel_for_each_cpp {
 
@@ -71,7 +72,7 @@ TEST(ParallelForEachParallelHost, ZeroDimension)
 
     ddc::parallel_for_each(Kokkos::DefaultHostExecutionSpace(), dom, IncrementFn(view));
     EXPECT_EQ(
-            Kokkos::Experimental::
+            ddc::testing::
                     count(Kokkos::DefaultHostExecutionSpace(),
                           Kokkos::View<int*, Kokkos::HostSpace>(storage.data(), 1),
                           1),
@@ -85,9 +86,7 @@ TEST(ParallelForEachParallelHost, OneDimension)
     ddc::ChunkSpan const view(storage, dom);
 
     ddc::parallel_for_each(Kokkos::DefaultHostExecutionSpace(), dom, IncrementFn(view));
-    EXPECT_EQ(
-            Kokkos::Experimental::count(Kokkos::DefaultHostExecutionSpace(), storage, 1),
-            dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultHostExecutionSpace(), storage, 1), dom.size());
 }
 
 TEST(ParallelForEachParallelHost, TwoDimensions)
@@ -98,9 +97,7 @@ TEST(ParallelForEachParallelHost, TwoDimensions)
             view(Kokkos::View<int**, Kokkos::HostSpace>(storage.data(), nelems_x, nelems_y), dom);
 
     ddc::parallel_for_each(Kokkos::DefaultHostExecutionSpace(), dom, IncrementFn(view));
-    EXPECT_EQ(
-            Kokkos::Experimental::count(Kokkos::DefaultHostExecutionSpace(), storage, 1),
-            dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultHostExecutionSpace(), storage, 1), dom.size());
 }
 
 TEST(ParallelForEachParallelDevice, ZeroDimension)
@@ -111,7 +108,7 @@ TEST(ParallelForEachParallelDevice, ZeroDimension)
 
     ddc::parallel_for_each(dom, IncrementFn(view));
     EXPECT_EQ(
-            Kokkos::Experimental::
+            ddc::testing::
                     count(Kokkos::DefaultExecutionSpace(),
                           Kokkos::View<int*>(storage.data(), 1),
                           1),
@@ -125,7 +122,7 @@ TEST(ParallelForEachParallelDevice, OneDimension)
     ddc::ChunkSpan const view(storage, dom);
 
     ddc::parallel_for_each(dom, IncrementFn(view));
-    EXPECT_EQ(Kokkos::Experimental::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 TEST(ParallelForEachParallelDevice, TwoDimensions)
@@ -135,7 +132,7 @@ TEST(ParallelForEachParallelDevice, TwoDimensions)
     ddc::ChunkSpan const view(Kokkos::View<int**>(storage.data(), nelems_x, nelems_y), dom);
 
     ddc::parallel_for_each(dom, IncrementFn(view));
-    EXPECT_EQ(Kokkos::Experimental::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 TEST(ParallelForEachParallelDevice, TwoDimensionsStrided)
@@ -146,5 +143,5 @@ TEST(ParallelForEachParallelDevice, TwoDimensionsStrided)
     ddc::ChunkSpan const view(Kokkos::View<int**>(storage.data(), nelems_x, nelems_y), dom);
 
     ddc::parallel_for_each(dom, IncrementFn(view));
-    EXPECT_EQ(Kokkos::Experimental::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }

--- a/tests/parallel_transform.cpp
+++ b/tests/parallel_transform.cpp
@@ -7,7 +7,8 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_StdAlgorithms.hpp>
+
+#include "helper_count.hpp"
 
 inline namespace anonymous_namespace_workaround_parallel_transform_cpp {
 
@@ -57,7 +58,7 @@ TEST(ParallelTransform, OneDimension)
     ddc::ChunkSpan const view(storage, dom);
 
     ddc::parallel_transform(view, increment);
-    EXPECT_EQ(Kokkos::Experimental::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 TEST(ParallelTransform, TwoDimensions)
@@ -67,7 +68,7 @@ TEST(ParallelTransform, TwoDimensions)
     ddc::ChunkSpan const view(Kokkos::View<int**>(storage.data(), nelems_x, nelems_y), dom);
 
     ddc::parallel_transform(view, increment);
-    EXPECT_EQ(Kokkos::Experimental::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 TEST(ParallelTransform, OneDimensionWithExecutionSpace)
@@ -78,7 +79,7 @@ TEST(ParallelTransform, OneDimensionWithExecutionSpace)
     ddc::ChunkSpan const view(storage, dom);
 
     ddc::parallel_transform(exec_space, view, increment);
-    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(exec_space, storage, 1), dom.size());
 }
 
 TEST(ParallelTransform, TwoDimensionsWithExecutionSpace)
@@ -89,5 +90,5 @@ TEST(ParallelTransform, TwoDimensionsWithExecutionSpace)
     ddc::ChunkSpan const view(Kokkos::View<int**>(storage.data(), nelems_x, nelems_y), dom);
 
     ddc::parallel_transform(exec_space, view, increment);
-    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 1), dom.size());
+    EXPECT_EQ(ddc::testing::count(exec_space, storage, 1), dom.size());
 }

--- a/tests/parallel_transform_reduce.cpp
+++ b/tests/parallel_transform_reduce.cpp
@@ -7,7 +7,8 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_StdAlgorithms.hpp>
+
+#include "helper_count.hpp"
 
 inline namespace anonymous_namespace_workaround_parallel_transform_reduce_cpp {
 
@@ -184,5 +185,5 @@ TEST(ParallelTransformReduceDevice, SumXY2X)
             ddc::reducer::sum<int>(),
             chunk_x_y.span_cview());
 
-    EXPECT_EQ(Kokkos::Experimental::count(exec_space, storage, 12), dom_x.size());
+    EXPECT_EQ(ddc::testing::count(exec_space, storage, 12), dom_x.size());
 }

--- a/tests/sparse_discrete_domain.cpp
+++ b/tests/sparse_discrete_domain.cpp
@@ -7,7 +7,8 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_StdAlgorithms.hpp>
+
+#include "helper_count.hpp"
 
 inline namespace anonymous_namespace_workaround_sparse_discrete_domain_cpp {
 
@@ -191,13 +192,7 @@ TEST(DeviceForEachSparseDevice, TwoDimensions)
             Kokkos::DefaultExecutionSpace::memory_space> const view(storage.data(), dom);
 
     TestDeviceForEachSparseDevice2D(view);
-    EXPECT_EQ(
-            Kokkos::Experimental::
-                    count(Kokkos::DefaultExecutionSpace(),
-                          Kokkos::Experimental::begin(storage),
-                          Kokkos::Experimental::end(storage),
-                          1),
-            dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 int TestDeviceTransformReduceSparse(

--- a/tests/strided_discrete_domain.cpp
+++ b/tests/strided_discrete_domain.cpp
@@ -7,7 +7,8 @@
 #include <gtest/gtest.h>
 
 #include <Kokkos_Core.hpp>
-#include <Kokkos_StdAlgorithms.hpp>
+
+#include "helper_count.hpp"
 
 inline namespace anonymous_namespace_workaround_strided_discrete_domain_cpp {
 
@@ -340,13 +341,7 @@ TEST(DeviceForEachStritedSerialDevice, OneDimension)
             Kokkos::layout_right,
             Kokkos::DefaultExecutionSpace::memory_space> const view(storage.data(), dom);
     TestDeviceForEachStritedSerialDevice1D(view);
-    EXPECT_EQ(
-            Kokkos::Experimental::
-                    count(Kokkos::DefaultExecutionSpace(),
-                          Kokkos::Experimental::begin(storage),
-                          Kokkos::Experimental::end(storage),
-                          1),
-            dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 void TestDeviceForEachStritedSerialDevice2D(
@@ -375,13 +370,7 @@ TEST(DeviceForEachStritedSerialDevice, TwoDimensions)
             Kokkos::layout_right,
             Kokkos::DefaultExecutionSpace::memory_space> const view(storage.data(), dom);
     TestDeviceForEachStritedSerialDevice2D(view);
-    EXPECT_EQ(
-            Kokkos::Experimental::
-                    count(Kokkos::DefaultExecutionSpace(),
-                          Kokkos::Experimental::begin(storage),
-                          Kokkos::Experimental::end(storage),
-                          1),
-            dom.size());
+    EXPECT_EQ(ddc::testing::count(Kokkos::DefaultExecutionSpace(), storage, 1), dom.size());
 }
 
 int TestDeviceTransformReduceStrided(


### PR DESCRIPTION
As described in #1226 this PR removes all symbols from `Kokkos::Experimental`. It will help keeping a lower minimal version requirement of Kokkos in the future. Nevertheless DDC versions <0.16 will likely be incompatible with Kokkos >=5.4 (due padded layouts being out of the `Kokkos::Experimental` namespace).