### PR TITLE
Allow different precisions for spline calculations splines

### DIFF
--- a/src/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -467,8 +467,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     std::array<Real, degree()> left;
     std::array<Real, degree()> right;
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
     KOKKOS_ASSERT(values.size() == degree() + 1)
 
     // 1. Compute cell index 'icell'
@@ -476,8 +476,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * std::numeric_limits<Real>::epsilon())
-    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
 
     // 2. Compute values of B-splines with support over cell 'icell'
     Real temp;
@@ -505,8 +505,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     std::array<Real, degree()> left;
     std::array<Real, degree()> right;
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
     KOKKOS_ASSERT(derivs.size() == degree() + 1)
 
     // 1. Compute cell index 'icell'
@@ -514,8 +514,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * std::numeric_limits<Real>::epsilon())
-    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
 
     // 2. Compute values of derivatives of B-splines with support over cell 'icell'
 
@@ -575,8 +575,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     Kokkos::mdspan<Real, Kokkos::extents<std::size_t, degree() + 1, degree() + 1>> const ndu(
             ndu_ptr.data());
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
     // KOKKOS_ASSERT(n >= 0) as long as n is unsigned
     KOKKOS_ASSERT(n <= degree())
     KOKKOS_ASSERT(derivs.extent(0) == 1 + degree())
@@ -587,8 +587,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * std::numeric_limits<Real>::epsilon())
-    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
 
     // 2. Compute nonzero basis functions and knot differences for splines
     //    up to degree (degree-1) which are needed to compute derivative
@@ -670,8 +670,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<NonUniformBsplinesKnots<DDim>> NonUn
         CDim,
         D>::Impl<DDim, MemorySpace>::find_cell_start(ddc::Coordinate<CDim> const& x) const
 {
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
 
     if (x <= rmin()) {
         return m_break_point_domain.front();

--- a/src/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -467,8 +467,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     std::array<Real, degree()> left;
     std::array<Real, degree()> right;
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
     KOKKOS_ASSERT(values.size() == degree() + 1)
 
     // 1. Compute cell index 'icell'
@@ -477,10 +477,9 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
     KOKKOS_ASSERT(
-            ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+            ddc::coordinate(icell) - x <= length() * 100 * std::numeric_limits<Real>::epsilon())
     KOKKOS_ASSERT(
-            x - ddc::coordinate(icell + 1)
-            <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+            x - ddc::coordinate(icell + 1) <= length() * 100 * std::numeric_limits<Real>::epsilon())
 
     // 2. Compute values of B-splines with support over cell 'icell'
     Real temp;
@@ -508,8 +507,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     std::array<Real, degree()> left;
     std::array<Real, degree()> right;
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
     KOKKOS_ASSERT(derivs.size() == degree() + 1)
 
     // 1. Compute cell index 'icell'
@@ -518,10 +517,9 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
     KOKKOS_ASSERT(
-            ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+            ddc::coordinate(icell) - x <= length() * 100 * std::numeric_limits<Real>::epsilon())
     KOKKOS_ASSERT(
-            x - ddc::coordinate(icell + 1)
-            <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+            x - ddc::coordinate(icell + 1) <= length() * 100 * std::numeric_limits<Real>::epsilon())
 
     // 2. Compute values of derivatives of B-splines with support over cell 'icell'
 
@@ -581,8 +579,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     Kokkos::mdspan<Real, Kokkos::extents<std::size_t, degree() + 1, degree() + 1>> const ndu(
             ndu_ptr.data());
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
     // KOKKOS_ASSERT(n >= 0) as long as n is unsigned
     KOKKOS_ASSERT(n <= degree())
     KOKKOS_ASSERT(derivs.extent(0) == 1 + degree())
@@ -594,10 +592,9 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
     KOKKOS_ASSERT(
-            ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+            ddc::coordinate(icell) - x <= length() * 100 * std::numeric_limits<Real>::epsilon())
     KOKKOS_ASSERT(
-            x - ddc::coordinate(icell + 1)
-            <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+            x - ddc::coordinate(icell + 1) <= length() * 100 * std::numeric_limits<Real>::epsilon())
 
     // 2. Compute nonzero basis functions and knot differences for splines
     //    up to degree (degree-1) which are needed to compute derivative
@@ -679,8 +676,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<NonUniformBsplinesKnots<DDim>> NonUn
         CDim,
         D>::Impl<DDim, MemorySpace>::find_cell_start(ddc::Coordinate<CDim> const& x) const
 {
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
 
     if (x <= rmin()) {
         return m_break_point_domain.front();

--- a/src/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -303,7 +303,7 @@ public:
          *
          * @return The length of the domain.
          */
-        KOKKOS_INLINE_FUNCTION double length() const noexcept
+        KOKKOS_INLINE_FUNCTION Real length() const noexcept
         {
             return rmax() - rmin();
         }
@@ -441,7 +441,7 @@ NonUniformBSplines<CDim, D>::Impl<DDim, MemorySpace>::Impl(
 
     // Fill out the extra knots
     if constexpr (is_periodic()) {
-        double const period = rmax - rmin;
+        Real const period = rmax - rmin;
         for (std::size_t i = 1; i < degree() + 1; ++i) {
             knots[degree() + -i] = knots[degree() + ncells() - i] - period;
             knots[degree() + ncells() + i] = knots[degree() + i] + period;
@@ -463,8 +463,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 {
     KOKKOS_ASSERT(values.size() == D + 1)
 
-    std::array<double, degree()> left;
-    std::array<double, degree()> right;
+    std::array<Real, degree()> left;
+    std::array<Real, degree()> right;
 
     KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
     KOKKOS_ASSERT(rmax() - x >= -length() * 1e-14)
@@ -479,12 +479,12 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 1e-14)
 
     // 2. Compute values of B-splines with support over cell 'icell'
-    double temp;
+    Real temp;
     values[0] = 1.0;
     for (std::size_t j = 0; j < degree(); ++j) {
         left[j] = x - ddc::coordinate(icell - j);
         right[j] = ddc::coordinate(icell + j + 1) - x;
-        double saved = 0.0;
+        Real saved = 0.0;
         for (std::size_t r = 0; r < j + 1; ++r) {
             temp = values[r] / (right[r] + left[j - r]);
             values[r] = saved + right[r] * temp;
@@ -501,8 +501,8 @@ template <class DDim, class MemorySpace>
 KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
         Impl<DDim, MemorySpace>::eval_deriv(DSpan1D derivs, ddc::Coordinate<CDim> const& x) const
 {
-    std::array<double, degree()> left;
-    std::array<double, degree()> right;
+    std::array<Real, degree()> left;
+    std::array<Real, degree()> right;
 
     KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
     KOKKOS_ASSERT(rmax() - x >= -length() * 1e-14)
@@ -523,8 +523,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
      * for splines up to degree degree-1 which are needed to compute derivative
      * First part of Algorithm  A3.2 of NURBS book
      */
-    double saved;
-    double temp;
+    Real saved;
+    Real temp;
     derivs[0] = 1.0;
     for (std::size_t j = 0; j < degree() - 1; ++j) {
         left[j] = x - ddc::coordinate(icell - j);
@@ -564,14 +564,14 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
                 ddc::Coordinate<CDim> const& x,
                 std::size_t const n) const
 {
-    std::array<double, degree()> left;
-    std::array<double, degree()> right;
+    std::array<Real, degree()> left;
+    std::array<Real, degree()> right;
 
-    std::array<double, 2 * (degree() + 1)> a_ptr;
-    Kokkos::mdspan<double, Kokkos::extents<std::size_t, degree() + 1, 2>> const a(a_ptr.data());
+    std::array<Real, 2 * (degree() + 1)> a_ptr;
+    Kokkos::mdspan<Real, Kokkos::extents<std::size_t, degree() + 1, 2>> const a(a_ptr.data());
 
-    std::array<double, (degree() + 1) * (degree() + 1)> ndu_ptr;
-    Kokkos::mdspan<double, Kokkos::extents<std::size_t, degree() + 1, degree() + 1>> const ndu(
+    std::array<Real, (degree() + 1) * (degree() + 1)> ndu_ptr;
+    Kokkos::mdspan<Real, Kokkos::extents<std::size_t, degree() + 1, degree() + 1>> const ndu(
             ndu_ptr.data());
 
     KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
@@ -597,8 +597,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     //    divisions
     //                [Yaman Güçlü, Edoardo Zoni]
 
-    double saved;
-    double temp;
+    Real saved;
+    Real temp;
     DDC_MDSPAN_ACCESS_OP(ndu, 0, 0) = 1.0;
     for (std::size_t j = 0; j < degree(); ++j) {
         left[j] = x - ddc::coordinate(icell - j);
@@ -626,7 +626,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
         int s2 = 1;
         DDC_MDSPAN_ACCESS_OP(a, 0, 0) = 1.0;
         for (int k = 1; k < static_cast<int>(n + 1); ++k) {
-            double d = 0.0;
+            Real d = 0.0;
             int const rk = r - k;
             int const pk = degree() - k;
             if (r >= k) {

--- a/src/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -476,8 +476,11 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
-    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(
+            ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(
+            x - ddc::coordinate(icell + 1)
+            <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
 
     // 2. Compute values of B-splines with support over cell 'icell'
     Real temp;
@@ -514,8 +517,11 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
-    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(
+            ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(
+            x - ddc::coordinate(icell + 1)
+            <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
 
     // 2. Compute values of derivatives of B-splines with support over cell 'icell'
 
@@ -587,8 +593,11 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
-    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(
+            ddc::coordinate(icell) - x <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(
+            x - ddc::coordinate(icell + 1)
+            <= length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
 
     // 2. Compute nonzero basis functions and knot differences for splines
     //    up to degree (degree-1) which are needed to compute derivative

--- a/src/ddc/kernels/splines/bsplines_non_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_non_uniform.hpp
@@ -8,6 +8,7 @@
 #include <cassert>
 #include <cstddef>
 #include <initializer_list>
+#include <limits>
 #include <type_traits>
 #include <vector>
 
@@ -466,8 +467,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     std::array<Real, degree()> left;
     std::array<Real, degree()> right;
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 1e-14)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
     KOKKOS_ASSERT(values.size() == degree() + 1)
 
     // 1. Compute cell index 'icell'
@@ -475,8 +476,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 1e-14)
-    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 1e-14)
+    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * std::numeric_limits<Real>::epsilon())
 
     // 2. Compute values of B-splines with support over cell 'icell'
     Real temp;
@@ -504,8 +505,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     std::array<Real, degree()> left;
     std::array<Real, degree()> right;
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 1e-14)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
     KOKKOS_ASSERT(derivs.size() == degree() + 1)
 
     // 1. Compute cell index 'icell'
@@ -513,8 +514,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 1e-14)
-    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 1e-14)
+    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * std::numeric_limits<Real>::epsilon())
 
     // 2. Compute values of derivatives of B-splines with support over cell 'icell'
 
@@ -574,8 +575,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
     Kokkos::mdspan<Real, Kokkos::extents<std::size_t, degree() + 1, degree() + 1>> const ndu(
             ndu_ptr.data());
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 1e-14)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
     // KOKKOS_ASSERT(n >= 0) as long as n is unsigned
     KOKKOS_ASSERT(n <= degree())
     KOKKOS_ASSERT(derivs.extent(0) == 1 + degree())
@@ -586,8 +587,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> NonUniformBSplines<CDim, D>::
 
     KOKKOS_ASSERT(icell >= m_break_point_domain.front())
     KOKKOS_ASSERT(icell <= m_break_point_domain.back())
-    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 1e-14)
-    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 1e-14)
+    KOKKOS_ASSERT(ddc::coordinate(icell) - x <= length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(x - ddc::coordinate(icell + 1) <= length() * 100 * std::numeric_limits<Real>::epsilon())
 
     // 2. Compute nonzero basis functions and knot differences for splines
     //    up to degree (degree-1) which are needed to compute derivative
@@ -669,8 +670,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<NonUniformBsplinesKnots<DDim>> NonUn
         CDim,
         D>::Impl<DDim, MemorySpace>::find_cell_start(ddc::Coordinate<CDim> const& x) const
 {
-    KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 1e-14)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
 
     if (x <= rmin()) {
         return m_break_point_domain.front();

--- a/src/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_uniform.hpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cassert>
 #include <cstddef>
+#include <limits>
 #include <tuple>
 #include <type_traits>
 
@@ -486,8 +487,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     Real offset;
     int jmin;
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 1e-14)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
     // KOKKOS_ASSERT(n >= 0) as long as n is unsigned
     KOKKOS_ASSERT(n <= degree())
     KOKKOS_ASSERT(derivs.extent(0) == 1 + degree())
@@ -570,8 +571,8 @@ KOKKOS_INLINE_FUNCTION void UniformBSplines<CDim, D>::Impl<DDim, MemorySpace>::g
         Real& offset,
         ddc::Coordinate<CDim> const& x) const
 {
-    KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 1e-14)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
 
     Real const inv_dx = inv_step();
     if (x <= rmin()) {

--- a/src/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_uniform.hpp
@@ -487,8 +487,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     Real offset;
     int jmin;
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
     // KOKKOS_ASSERT(n >= 0) as long as n is unsigned
     KOKKOS_ASSERT(n <= degree())
     KOKKOS_ASSERT(derivs.extent(0) == 1 + degree())
@@ -571,8 +571,8 @@ KOKKOS_INLINE_FUNCTION void UniformBSplines<CDim, D>::Impl<DDim, MemorySpace>::g
         Real& offset,
         ddc::Coordinate<CDim> const& x) const
 {
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
 
     Real const inv_dx = inv_step();
     if (x <= rmin()) {

--- a/src/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_uniform.hpp
@@ -487,8 +487,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     Real offset;
     int jmin;
 
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
     // KOKKOS_ASSERT(n >= 0) as long as n is unsigned
     KOKKOS_ASSERT(n <= degree())
     KOKKOS_ASSERT(derivs.extent(0) == 1 + degree())
@@ -571,8 +571,8 @@ KOKKOS_INLINE_FUNCTION void UniformBSplines<CDim, D>::Impl<DDim, MemorySpace>::g
         Real& offset,
         ddc::Coordinate<CDim> const& x) const
 {
-    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * std::numeric_limits<Real>::epsilon())
-    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * std::numeric_limits<Real>::epsilon())
+    KOKKOS_ASSERT(x - rmin() >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
+    KOKKOS_ASSERT(rmax() - x >= -length() * 100 * Kokkos::Experimental::epsilon_v<Real>)
 
     Real const inv_dx = inv_step();
     if (x <= rmin()) {

--- a/src/ddc/kernels/splines/bsplines_uniform.hpp
+++ b/src/ddc/kernels/splines/bsplines_uniform.hpp
@@ -27,7 +27,7 @@ struct UniformBSplinesBase
 template <class ExecSpace, class ODDim, class Layout, class OMemorySpace>
 void uniform_bsplines_integrals(
         ExecSpace const& execution_space,
-        ddc::ChunkSpan<double, ddc::DiscreteDomain<ODDim>, Layout, OMemorySpace> int_vals);
+        ddc::ChunkSpan<Real, ddc::DiscreteDomain<ODDim>, Layout, OMemorySpace> int_vals);
 
 } // namespace detail
 
@@ -98,7 +98,7 @@ public:
         template <class ExecSpace, class ODDim, class Layout, class OMemorySpace>
         friend void detail::uniform_bsplines_integrals(
                 ExecSpace const& execution_space,
-                ddc::ChunkSpan<double, ddc::DiscreteDomain<ODDim>, Layout, OMemorySpace> int_vals);
+                ddc::ChunkSpan<Real, ddc::DiscreteDomain<ODDim>, Layout, OMemorySpace> int_vals);
 
     public:
         /// @brief The type of the knots defining the B-splines.
@@ -293,7 +293,7 @@ public:
          *
          * @return The length of the domain.
          */
-        KOKKOS_INLINE_FUNCTION double length() const noexcept
+        KOKKOS_INLINE_FUNCTION Real length() const noexcept
         {
             return rmax() - rmin();
         }
@@ -354,7 +354,7 @@ public:
         }
 
     private:
-        KOKKOS_INLINE_FUNCTION double inv_step() const noexcept
+        KOKKOS_INLINE_FUNCTION Real inv_step() const noexcept
         {
             return 1.0 / ddc::step<knot_discrete_dimension_type>();
         }
@@ -364,7 +364,7 @@ public:
 
         KOKKOS_INLINE_FUNCTION void get_icell_and_offset(
                 int& icell,
-                double& offset,
+                Real& offset,
                 ddc::Coordinate<CDim> const& x) const;
     };
 };
@@ -399,16 +399,16 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
 {
     KOKKOS_ASSERT(values.size() == degree + 1)
 
-    double offset;
+    Real offset;
     int jmin;
     // 1. Compute cell index 'icell' and x_offset
     // 2. Compute index range of B-splines with support over cell 'icell'
     get_icell_and_offset(jmin, offset, x);
 
     // 3. Compute values of aforementioned B-splines
-    double xx;
-    double temp;
-    double saved;
+    Real xx;
+    Real temp;
+    Real saved;
     DDC_MDSPAN_ACCESS_OP(values, 0) = 1.0;
     for (std::size_t j = 1; j < values.size(); ++j) {
         xx = -offset;
@@ -432,7 +432,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
 {
     KOKKOS_ASSERT(derivs.size() == degree() + 1)
 
-    double offset;
+    Real offset;
     int jmin;
     // 1. Compute cell index 'icell' and x_offset
     // 2. Compute index range of B-splines with support over cell 'icell'
@@ -440,9 +440,9 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
 
     // 3. Compute derivatives of aforementioned B-splines
     //    Derivatives are normalized, hence they should be divided by dx
-    double xx;
-    double temp;
-    double saved;
+    Real xx;
+    Real temp;
+    Real saved;
     DDC_MDSPAN_ACCESS_OP(derivs, 0) = 1.0 / ddc::step<knot_discrete_dimension_type>();
     for (std::size_t j = 1; j < degree(); ++j) {
         xx = -offset;
@@ -457,8 +457,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     }
 
     // Compute derivatives
-    double bjm1 = derivs[0];
-    double bj = bjm1;
+    Real bjm1 = derivs[0];
+    Real bj = bjm1;
     DDC_MDSPAN_ACCESS_OP(derivs, 0) = -bjm1;
     for (std::size_t j = 1; j < degree(); ++j) {
         bj = DDC_MDSPAN_ACCESS_OP(derivs, j);
@@ -478,12 +478,12 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
                 ddc::Coordinate<CDim> const& x,
                 std::size_t const n) const
 {
-    std::array<double, (degree() + 1) * (degree() + 1)> ndu_ptr;
-    Kokkos::mdspan<double, Kokkos::extents<std::size_t, degree() + 1, degree() + 1>> const ndu(
+    std::array<Real, (degree() + 1) * (degree() + 1)> ndu_ptr;
+    Kokkos::mdspan<Real, Kokkos::extents<std::size_t, degree() + 1, degree() + 1>> const ndu(
             ndu_ptr.data());
-    std::array<double, 2 * (degree() + 1)> a_ptr;
-    Kokkos::mdspan<double, Kokkos::extents<std::size_t, degree() + 1, 2>> const a(a_ptr.data());
-    double offset;
+    std::array<Real, 2 * (degree() + 1)> a_ptr;
+    Kokkos::mdspan<Real, Kokkos::extents<std::size_t, degree() + 1, 2>> const a(a_ptr.data());
+    Real offset;
     int jmin;
 
     KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
@@ -500,9 +500,9 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     // 3. Recursively evaluate B-splines (eval_basis)
     //    up to self%degree, and store them all in the upper-right triangle of
     //    ndu
-    double xx;
-    double temp;
-    double saved;
+    Real xx;
+    Real temp;
+    Real saved;
     DDC_MDSPAN_ACCESS_OP(ndu, 0, 0) = 1.0;
     for (std::size_t j = 1; j < degree() + 1; ++j) {
         xx = -offset;
@@ -524,7 +524,7 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
         int s2 = 1;
         DDC_MDSPAN_ACCESS_OP(a, 0, 0) = 1.0;
         for (int k = 1; k < static_cast<int>(n + 1); ++k) {
-            double d = 0.0;
+            Real d = 0.0;
             int const rk = r - k;
             int const pk = degree() - k;
             if (r >= k) {
@@ -551,8 +551,8 @@ KOKKOS_INLINE_FUNCTION ddc::DiscreteElement<DDim> UniformBSplines<CDim, D>::
     // Multiply result by correct factors:
     // degree!/(degree-n)! = degree*(degree-1)*...*(degree-n+1)
     // k-th derivatives are normalized, hence they should be divided by dx^k
-    double const inv_dx = inv_step();
-    double d = degree() * inv_dx;
+    Real const inv_dx = inv_step();
+    Real d = degree() * inv_dx;
     for (int k = 1; k < static_cast<int>(n + 1); ++k) {
         for (std::size_t i = 0; i < derivs.extent(0); ++i) {
             DDC_MDSPAN_ACCESS_OP(derivs, i, k) *= d;
@@ -567,13 +567,13 @@ template <class CDim, std::size_t D>
 template <class DDim, class MemorySpace>
 KOKKOS_INLINE_FUNCTION void UniformBSplines<CDim, D>::Impl<DDim, MemorySpace>::get_icell_and_offset(
         int& icell,
-        double& offset,
+        Real& offset,
         ddc::Coordinate<CDim> const& x) const
 {
     KOKKOS_ASSERT(x - rmin() >= -length() * 1e-14)
     KOKKOS_ASSERT(rmax() - x >= -length() * 1e-14)
 
-    double const inv_dx = inv_step();
+    Real const inv_dx = inv_step();
     if (x <= rmin()) {
         icell = 0;
         offset = 0.0;

--- a/src/ddc/kernels/splines/constant_extrapolation_rule.hpp
+++ b/src/ddc/kernels/splines/constant_extrapolation_rule.hpp
@@ -46,25 +46,25 @@ public:
      * @param[in] pos The coordinate where we want to evaluate the function on B-splines.
      * @param[in] spline_coef The coefficients of the function on B-splines.
      *
-     * @return A double with the value of the function on B-splines evaluated at the coordinate.
+     * @return A Real with the value of the function on B-splines evaluated at the coordinate.
      */
     template <class CoordType, class BSplines, class Layout, class MemorySpace>
-    KOKKOS_FUNCTION double operator()(
+    KOKKOS_FUNCTION Real operator()(
             [[maybe_unused]] CoordType pos,
-            ddc::ChunkSpan<double const, ddc::DiscreteDomain<BSplines>, Layout, MemorySpace> const
+            ddc::ChunkSpan<Real const, ddc::DiscreteDomain<BSplines>, Layout, MemorySpace> const
                     spline_coef) const
     {
         // `pos` is always unused, but needed for Doxygen
         static_assert(in_tags_v<DimI, to_type_seq_t<CoordType>>);
 
-        std::array<double, BSplines::degree() + 1> vals_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, BSplines::degree() + 1>> const vals(
+        std::array<Real, BSplines::degree() + 1> vals_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, BSplines::degree() + 1>> const vals(
                 vals_ptr.data());
 
         ddc::DiscreteElement<BSplines> const idx
                 = ddc::discrete_space<BSplines>().eval_basis(vals, m_eval_pos);
 
-        double y = 0.0;
+        Real y = 0.0;
         for (std::size_t i = 0; i < BSplines::degree() + 1; ++i) {
             y += spline_coef(idx + i) * vals[i];
         }
@@ -141,13 +141,13 @@ public:
      * @param[in] coord_extrap The coordinates where we want to evaluate the function on B-splines
      * @param[in] spline_coef The coefficients of the function on B-splines.
      *
-     *@return A double with the value of the function on B-splines evaluated at the coordinate.
+     *@return A Real with the value of the function on B-splines evaluated at the coordinate.
      */
     template <class CoordType, class BSplines1, class BSplines2, class Layout, class MemorySpace>
-    KOKKOS_FUNCTION double operator()(
+    KOKKOS_FUNCTION Real operator()(
             CoordType coord_extrap,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     ddc::DiscreteDomain<BSplines1, BSplines2>,
                     Layout,
                     MemorySpace> const spline_coef) const
@@ -169,11 +169,11 @@ public:
                                   m_eval_pos_not_interest_max));
         }
 
-        std::array<double, BSplines1::degree() + 1> vals1_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, BSplines1::degree() + 1>> const vals1(
+        std::array<Real, BSplines1::degree() + 1> vals1_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, BSplines1::degree() + 1>> const vals1(
                 vals1_ptr.data());
-        std::array<double, BSplines2::degree() + 1> vals2_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, BSplines2::degree() + 1>> const vals2(
+        std::array<Real, BSplines2::degree() + 1> vals2_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, BSplines2::degree() + 1>> const vals2(
                 vals2_ptr.data());
 
         ddc::DiscreteElement<BSplines1> const idx1 = ddc::discrete_space<BSplines1>().eval_basis(
@@ -183,7 +183,7 @@ public:
                 vals2,
                 ddc::Coordinate<typename BSplines2::continuous_dimension_type>(eval_pos));
 
-        double y = 0.0;
+        Real y = 0.0;
         for (std::size_t i = 0; i < BSplines1::degree() + 1; ++i) {
             for (std::size_t j = 0; j < BSplines2::degree() + 1; ++j) {
                 y += spline_coef(idx1 + i, idx2 + j) * vals1[i] * vals2[j];

--- a/src/ddc/kernels/splines/greville_interpolation_points.hpp
+++ b/src/ddc/kernels/splines/greville_interpolation_points.hpp
@@ -49,8 +49,8 @@ class GrevilleInterpolationPoints
     {
         using SamplingImpl = Sampling::template Impl<Sampling, Kokkos::HostSpace>;
 
-        double constexpr shift = (BSplines::degree() % 2 == 0) ? 0.5 : 0.0;
-        double const dx
+        Real constexpr shift = (BSplines::degree() % 2 == 0) ? 0.5 : 0.0;
+        Real const dx
                 = (ddc::discrete_space<BSplines>().rmax() - ddc::discrete_space<BSplines>().rmin())
                   / ddc::discrete_space<BSplines>().ncells();
         if constexpr (ddc::is_uniform_point_sampling_v<Sampling>) {
@@ -81,7 +81,7 @@ class GrevilleInterpolationPoints
             n_greville_points = ddc::discrete_space<BSplines>().nbasis();
         }
 
-        std::vector<double> greville_points(n_greville_points);
+        std::vector<Real> greville_points(n_greville_points);
         ddc::DiscreteDomain<BSplines> const bspline_domain
                 = ddc::discrete_space<BSplines>().full_domain().take_first(
                         ddc::DiscreteVector<BSplines>(ddc::discrete_space<BSplines>().nbasis()));
@@ -105,7 +105,7 @@ class GrevilleInterpolationPoints
 
         // Use periodicity to ensure all points are in the domain
         if constexpr (BSplines::is_periodic()) {
-            std::vector<double> temp_knots(BSplines::degree());
+            std::vector<Real> temp_knots(BSplines::degree());
             std::size_t npoints = 0;
             // Count the number of interpolation points that need shifting to preserve the ordering
             while (greville_points[npoints] < ddc::discrete_space<BSplines>().rmin()) {
@@ -177,7 +177,7 @@ public:
                 assert(ddc::discrete_space<BSplines>().nbasis() >= N_BE);
             }
             std::size_t const npoints = ddc::discrete_space<BSplines>().nbasis() - N_BE;
-            std::vector<double> points_with_bcs(npoints);
+            std::vector<Real> points_with_bcs(npoints);
 
             // Construct Greville-like points at the edge
             if constexpr (SBCLower == ddc::SplineBuilderClosure::GREVILLE) {
@@ -247,7 +247,7 @@ public:
             } else {
                 auto points_wo_bcs = non_uniform_greville_points<IntermediateSampling>();
                 // All points are Greville points. Extract unnecessary points near the boundary
-                std::vector<double> points_with_bcs(points_wo_bcs.size() - N_BE);
+                std::vector<Real> points_with_bcs(points_wo_bcs.size() - N_BE);
                 std::size_t constexpr n_start = N_BE_MIN;
 
                 using length = ddc::DiscreteVector<IntermediateSampling>;

--- a/src/ddc/kernels/splines/integrals.hpp
+++ b/src/ddc/kernels/splines/integrals.hpp
@@ -30,7 +30,7 @@ namespace detail {
 template <class ExecSpace, class DDim, class Layout, class MemorySpace>
 void uniform_bsplines_integrals(
         ExecSpace const& execution_space,
-        ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>, Layout, MemorySpace> int_vals)
+        ddc::ChunkSpan<Real, ddc::DiscreteDomain<DDim>, Layout, MemorySpace> int_vals)
 {
     static_assert(is_uniform_bsplines_v<DDim>);
     static_assert(
@@ -78,8 +78,8 @@ void uniform_bsplines_integrals(
                         ExecSpace,
                         Kokkos::IndexType<std::size_t>>(execution_space, 0, DDim::degree()),
                 KOKKOS_LAMBDA(std::size_t i) {
-                    std::array<double, DDim::degree() + 2> edge_vals_ptr;
-                    Kokkos::mdspan<double, Kokkos::extents<std::size_t, DDim::degree() + 2>> const
+                    std::array<Real, DDim::degree() + 2> edge_vals_ptr;
+                    Kokkos::mdspan<Real, Kokkos::extents<std::size_t, DDim::degree() + 2>> const
                             edge_vals(edge_vals_ptr.data());
 
                     ddc::discrete_space<DDim>().eval_basis(
@@ -87,11 +87,11 @@ void uniform_bsplines_integrals(
                             ddc::discrete_space<DDim>().rmin(),
                             DDim::degree() + 1);
 
-                    double const d_eval = ddc::detail::sum(edge_vals);
+                    Real const d_eval = ddc::detail::sum(edge_vals);
 
-                    double const c_eval = ddc::detail::sum(edge_vals, 0, DDim::degree() - i);
+                    Real const c_eval = ddc::detail::sum(edge_vals, 0, DDim::degree() - i);
 
-                    double const edge_value
+                    Real const edge_value
                             = ddc::step<UniformBsplinesKnots<DDim>>() * (d_eval - c_eval);
 
                     int_vals(first_bspline + i) = edge_value;
@@ -110,7 +110,7 @@ void uniform_bsplines_integrals(
 template <class ExecSpace, class DDim, class Layout, class MemorySpace>
 void non_uniform_bsplines_integrals(
         ExecSpace const& execution_space,
-        ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>, Layout, MemorySpace> int_vals)
+        ddc::ChunkSpan<Real, ddc::DiscreteDomain<DDim>, Layout, MemorySpace> int_vals)
 {
     static_assert(is_non_uniform_bsplines_v<DDim>);
     static_assert(
@@ -128,7 +128,7 @@ void non_uniform_bsplines_integrals(
 
     ddc::DiscreteDomain<DDim> const full_dom_splines(ddc::discrete_space<DDim>().full_domain());
 
-    double const inv_deg = 1.0 / (DDim::degree() + 1);
+    Real const inv_deg = 1.0 / (DDim::degree() + 1);
 
     ddc::DiscreteDomain<DDim> const dom_bsplines(full_dom_splines.take_first(
             ddc::DiscreteVector<DDim> {ddc::discrete_space<DDim>().nbasis()}));
@@ -163,9 +163,9 @@ void non_uniform_bsplines_integrals(
  * @return The values of the integrals.
  */
 template <class ExecSpace, class DDim, class Layout, class MemorySpace>
-ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>, Layout, MemorySpace> integrals(
+ddc::ChunkSpan<Real, ddc::DiscreteDomain<DDim>, Layout, MemorySpace> integrals(
         ExecSpace const& execution_space,
-        ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>, Layout, MemorySpace> int_vals)
+        ddc::ChunkSpan<Real, ddc::DiscreteDomain<DDim>, Layout, MemorySpace> int_vals)
 {
     static_assert(is_uniform_bsplines_v<DDim> || is_non_uniform_bsplines_v<DDim>);
     if constexpr (is_uniform_bsplines_v<DDim>) {

--- a/src/ddc/kernels/splines/knots_as_interpolation_points.hpp
+++ b/src/ddc/kernels/splines/knots_as_interpolation_points.hpp
@@ -60,7 +60,7 @@ public:
             using SamplingImpl = Sampling::template Impl<Sampling, Kokkos::HostSpace>;
             ddc::DiscreteDomain<knot_discrete_dimension_t<BSplines>> break_point_domain
                     = ddc::discrete_space<BSplines>().break_point_domain();
-            std::vector<double> break_points(break_point_domain.size());
+            std::vector<Real> break_points(break_point_domain.size());
             ddc::host_for_each(
                     break_point_domain,
                     [&](ddc::DiscreteElement<knot_discrete_dimension_t<BSplines>> ik) {

--- a/src/ddc/kernels/splines/math_tools.hpp
+++ b/src/ddc/kernels/splines/math_tools.hpp
@@ -9,6 +9,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <ddc/real_type.hpp>
+
 namespace ddc::detail {
 
 template <typename T>
@@ -59,18 +61,18 @@ KOKKOS_INLINE_FUNCTION T modulo(T x, T y)
     return x - y * Kokkos::floor(double(x) / y);
 }
 
-KOKKOS_INLINE_FUNCTION double ipow(double a, std::size_t i)
+KOKKOS_INLINE_FUNCTION Real ipow(Real a, std::size_t i)
 {
-    double r(1.0);
+    Real r(1.0);
     for (std::size_t j(0); j < i; ++j) {
         r *= a;
     }
     return r;
 }
 
-KOKKOS_INLINE_FUNCTION double ipow(double a, int i)
+KOKKOS_INLINE_FUNCTION Real ipow(Real a, int i)
 {
-    double r(1.0);
+    Real r(1.0);
     if (i > 0) {
         for (int j(0); j < i; ++j) {
             r *= a;

--- a/src/ddc/kernels/splines/math_tools.hpp
+++ b/src/ddc/kernels/splines/math_tools.hpp
@@ -7,9 +7,9 @@
 #include <array>
 #include <cstddef>
 
-#include <Kokkos_Core.hpp>
-
 #include <ddc/real_type.hpp>
+
+#include <Kokkos_Core.hpp>
 
 namespace ddc::detail {
 

--- a/src/ddc/kernels/splines/null_extrapolation_rule.hpp
+++ b/src/ddc/kernels/splines/null_extrapolation_rule.hpp
@@ -6,6 +6,8 @@
 
 #include <Kokkos_Macros.hpp>
 
+#include <ddc/real_type.hpp>
+
 namespace ddc {
 
 /**
@@ -16,10 +18,10 @@ struct NullExtrapolationRule
     /**
      * @brief Evaluates the spline at a coordinate outside of the domain.
      *
-     * @return A double with the value of the function outside the domain (here, 0.).
+     * @return A Real with the value of the function outside the domain (here, 0.).
      */
     template <class CoordType, class ChunkSpan>
-    KOKKOS_FUNCTION double operator()(CoordType, ChunkSpan) const
+    KOKKOS_FUNCTION Real operator()(CoordType, ChunkSpan) const
     {
         return 0.0;
     }

--- a/src/ddc/kernels/splines/null_extrapolation_rule.hpp
+++ b/src/ddc/kernels/splines/null_extrapolation_rule.hpp
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include <Kokkos_Macros.hpp>
-
 #include <ddc/real_type.hpp>
+
+#include <Kokkos_Macros.hpp>
 
 namespace ddc {
 

--- a/src/ddc/kernels/splines/periodic_extrapolation_rule.hpp
+++ b/src/ddc/kernels/splines/periodic_extrapolation_rule.hpp
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include <ddc/real_type.hpp>
+
 #include <Kokkos_Assert.hpp>
 #include <Kokkos_Macros.hpp>
-
-#include <ddc/real_type.hpp>
 
 namespace ddc {
 

--- a/src/ddc/kernels/splines/periodic_extrapolation_rule.hpp
+++ b/src/ddc/kernels/splines/periodic_extrapolation_rule.hpp
@@ -7,6 +7,8 @@
 #include <Kokkos_Assert.hpp>
 #include <Kokkos_Macros.hpp>
 
+#include <ddc/real_type.hpp>
+
 namespace ddc {
 
 template <class DimI>
@@ -15,7 +17,7 @@ struct PeriodicExtrapolationRule
     static_assert(DimI::PERIODIC, "PeriodicExtrapolationRule requires periodic dimension");
 
     template <class CoordType, class ChunkSpan>
-    KOKKOS_FUNCTION double operator()(CoordType, ChunkSpan) const
+    KOKKOS_FUNCTION Real operator()(CoordType, ChunkSpan) const
     {
         KOKKOS_ASSERT("PeriodicExtrapolationRule::operator() should never be called")
 

--- a/src/ddc/kernels/splines/periodic_extrapolation_rule.hpp
+++ b/src/ddc/kernels/splines/periodic_extrapolation_rule.hpp
@@ -11,11 +11,28 @@
 
 namespace ddc {
 
+/**
+ * @brief A functor for describing a spline boundary value by a periodic extrapolation for 1D evaluator.
+ *
+ * For a periodic domain, any position outside the domain should be equivalent to a point inside the
+ * domain. As a result boundary conditions should never be called.
+ */
 template <class DimI>
 struct PeriodicExtrapolationRule
 {
     static_assert(DimI::PERIODIC, "PeriodicExtrapolationRule requires periodic dimension");
 
+    /**
+     * @brief Get the value of the function on B-splines at a coordinate outside the domain.
+     *
+     * As all coordinates outside the domain are equivalent to coordinates inside the domain,
+     * this function raises an assertion error if it is ever called.
+     *
+     * @param[in] pos The coordinate where we want to evaluate the function on B-splines.
+     * @param[in] spline_coef The coefficients of the function on B-splines.
+     *
+     * @return A Real with the value of the function on B-splines evaluated at the coordinate.
+     */
     template <class CoordType, class ChunkSpan>
     KOKKOS_FUNCTION Real operator()(CoordType, ChunkSpan) const
     {

--- a/src/ddc/kernels/splines/periodic_extrapolation_rule.hpp
+++ b/src/ddc/kernels/splines/periodic_extrapolation_rule.hpp
@@ -34,7 +34,8 @@ struct PeriodicExtrapolationRule
      * @return A Real with the value of the function on B-splines evaluated at the coordinate.
      */
     template <class CoordType, class ChunkSpan>
-    KOKKOS_FUNCTION Real operator()(CoordType, ChunkSpan) const
+    KOKKOS_FUNCTION Real
+    operator()([[maybe_unused]] CoordType pos, [[maybe_unused]] ChunkSpan spline_coef) const
     {
         KOKKOS_ASSERT("PeriodicExtrapolationRule::operator() should never be called")
 

--- a/src/ddc/kernels/splines/spline_builder.hpp
+++ b/src/ddc/kernels/splines/spline_builder.hpp
@@ -1144,14 +1144,12 @@ SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, SBCLower, SBC
                     1);
 
     // Extract relevant subview
-    Kokkos::View<Real*, Kokkos::LayoutRight, MemorySpace> const integral_bsplines_mirror
-            = Kokkos::
-                    subview(integral_bsplines_mirror_with_additional_allocation,
-                            std::
-                                    pair {static_cast<std::size_t>(0),
-                                          integral_bsplines_without_periodic_additional_bsplines
-                                                  .size()},
-                            0);
+    Kokkos::View<Real*, Kokkos::LayoutRight, MemorySpace> const integral_bsplines_mirror = Kokkos::
+            subview(integral_bsplines_mirror_with_additional_allocation,
+                    std::
+                            pair {static_cast<std::size_t>(0),
+                                  integral_bsplines_without_periodic_additional_bsplines.size()},
+                    0);
 
     // Solve matrix equation A^t*X=integral_bsplines
     Kokkos::deep_copy(

--- a/src/ddc/kernels/splines/spline_builder.hpp
+++ b/src/ddc/kernels/splines/spline_builder.hpp
@@ -195,7 +195,7 @@ private:
 
     int m_offset = 0;
 
-    double m_dx; // average cell size for normalization of derivatives
+    Real m_dx; // average cell size for normalization of derivatives
 
     // interpolator specific
     std::unique_ptr<ddc::detail::SplinesLinearProblem<exec_space>> m_matrix;
@@ -538,19 +538,19 @@ public:
     template <class Layout, class BatchedInterpolationDDom>
     void operator()(
             ddc::ChunkSpan<
-                    double,
+                    Real,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space> spline,
-            ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
+            ddc::ChunkSpan<Real const, BatchedInterpolationDDom, Layout, memory_space> vals,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_xmin
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_xmax
@@ -582,19 +582,19 @@ public:
     template <class OutMemorySpace = MemorySpace>
     std::tuple<
             ddc::Chunk<
-                    double,
+                    Real,
                     ddc::DiscreteDomain<
                             ddc::Deriv<typename InterpolationDDim::continuous_dimension_type>>,
-                    ddc::KokkosAllocator<double, OutMemorySpace>>,
+                    ddc::KokkosAllocator<Real, OutMemorySpace>>,
             ddc::Chunk<
-                    double,
+                    Real,
                     ddc::DiscreteDomain<InterpolationDDim>,
-                    ddc::KokkosAllocator<double, OutMemorySpace>>,
+                    ddc::KokkosAllocator<Real, OutMemorySpace>>,
             ddc::Chunk<
-                    double,
+                    Real,
                     ddc::DiscreteDomain<
                             ddc::Deriv<typename InterpolationDDim::continuous_dimension_type>>,
-                    ddc::KokkosAllocator<double, OutMemorySpace>>>
+                    ddc::KokkosAllocator<Real, OutMemorySpace>>>
     quadrature_coefficients() const;
 
 private:
@@ -635,8 +635,8 @@ void SplineBuilder<
 {
     if constexpr (bsplines_type::is_periodic()) {
         // Calculate offset so that the matrix is diagonally dominant
-        std::array<double, bsplines_type::degree() + 1> values_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, bsplines_type::degree() + 1>> const
+        std::array<Real, bsplines_type::degree() + 1> values_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type::degree() + 1>> const
                 values(values_ptr.data());
         ddc::DiscreteElement<interpolation_discrete_dimension_type> start(
                 interpolation_domain.front());
@@ -794,7 +794,7 @@ void SplineBuilder<
     if constexpr (
             SBCLower == ddc::SplineBuilderClosure::HERMITE
             || SBCLower == ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE) {
-        std::array<double, (bsplines_type::degree() / 2 + 1) * (bsplines_type::degree() + 1)>
+        std::array<Real, (bsplines_type::degree() / 2 + 1) * (bsplines_type::degree() + 1)>
                 derivs_ptr;
         ddc::DSpan2D const
                 derivs(derivs_ptr.data(),
@@ -824,8 +824,8 @@ void SplineBuilder<
     }
 
     // Interpolation points
-    std::array<double, bsplines_type::degree() + 1> values_ptr;
-    Kokkos::mdspan<double, Kokkos::extents<std::size_t, bsplines_type::degree() + 1>> const values(
+    std::array<Real, bsplines_type::degree() + 1> values_ptr;
+    Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type::degree() + 1>> const values(
             values_ptr.data());
 
     int start = interpolation_domain().front().uid();
@@ -848,10 +848,10 @@ void SplineBuilder<
     if constexpr (
             SBCUpper == ddc::SplineBuilderClosure::HERMITE
             || SBCUpper == ddc::SplineBuilderClosure::HOMOGENEOUS_HERMITE) {
-        std::array<double, (bsplines_type::degree() / 2 + 1) * (bsplines_type::degree() + 1)>
+        std::array<Real, (bsplines_type::degree() / 2 + 1) * (bsplines_type::degree() + 1)>
                 derivs_ptr;
         Kokkos::mdspan<
-                double,
+                Real,
                 Kokkos::extents<
                         std::size_t,
                         bsplines_type::degree() + 1,
@@ -904,18 +904,18 @@ void SplineBuilder<
         Solver>::
 operator()(
         ddc::ChunkSpan<
-                double,
+                Real,
                 batched_spline_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space> spline,
-        ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
+        ddc::ChunkSpan<Real const, BatchedInterpolationDDom, Layout, memory_space> vals,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_xmin,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_xmax) const
@@ -1037,7 +1037,7 @@ operator()(
     ddc::Chunk spline_tr_alloc(
             m_label + " > spline_tr (ddc::SplineBuilder::operator())",
             batched_spline_tr_domain(batched_interpolation_domain),
-            ddc::KokkosAllocator<double, memory_space>());
+            ddc::KokkosAllocator<Real, memory_space>());
     ddc::ChunkSpan const spline_tr = spline_tr_alloc.span_view();
     ddc::parallel_for_each(
             m_label + " > ddc_splines_transpose_rhs",
@@ -1051,7 +1051,7 @@ operator()(
                 }
             });
     // Create a 2D Kokkos::View to manage spline_tr as a matrix
-    Kokkos::View<double**, Kokkos::LayoutRight, exec_space> const bcoef_section(
+    Kokkos::View<Real**, Kokkos::LayoutRight, exec_space> const bcoef_section(
             spline_tr.data_handle(),
             static_cast<std::size_t>(spline_tr.template extent<bsplines_type>()),
             batch_domain(batched_interpolation_domain).size());
@@ -1111,24 +1111,24 @@ template <
 template <class OutMemorySpace>
 std::tuple<
         ddc::Chunk<
-                double,
+                Real,
                 ddc::DiscreteDomain<
                         ddc::Deriv<typename InterpolationDDim::continuous_dimension_type>>,
-                ddc::KokkosAllocator<double, OutMemorySpace>>,
+                ddc::KokkosAllocator<Real, OutMemorySpace>>,
         ddc::Chunk<
-                double,
+                Real,
                 ddc::DiscreteDomain<InterpolationDDim>,
-                ddc::KokkosAllocator<double, OutMemorySpace>>,
+                ddc::KokkosAllocator<Real, OutMemorySpace>>,
         ddc::Chunk<
-                double,
+                Real,
                 ddc::DiscreteDomain<
                         ddc::Deriv<typename InterpolationDDim::continuous_dimension_type>>,
-                ddc::KokkosAllocator<double, OutMemorySpace>>>
+                ddc::KokkosAllocator<Real, OutMemorySpace>>>
 SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, SBCLower, SBCUpper, Solver>::
         quadrature_coefficients() const
 {
     // Compute integrals of bsplines
-    ddc::Chunk integral_bsplines(spline_domain(), ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk integral_bsplines(spline_domain(), ddc::KokkosAllocator<Real, MemorySpace>());
     ddc::integrals(ExecSpace(), integral_bsplines.span_view());
 
     // Remove additional B-splines in the periodic case (cf. UniformBSplines::full_domain() documentation)
@@ -1137,14 +1137,14 @@ SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, SBCLower, SBC
                     ddc::DiscreteVector<bsplines_type>(m_matrix->size()))];
 
     // Allocate mirror with additional rows (cf. SplinesLinearProblem3x3Blocks documentation)
-    Kokkos::View<double**, Kokkos::LayoutRight, MemorySpace> const
+    Kokkos::View<Real**, Kokkos::LayoutRight, MemorySpace> const
             integral_bsplines_mirror_with_additional_allocation(
                     m_label + " > integral_bsplines_mirror_with_additional_allocation",
                     m_matrix->required_number_of_rhs_rows(),
                     1);
 
     // Extract relevant subview
-    Kokkos::View<double*, Kokkos::LayoutRight, MemorySpace> const integral_bsplines_mirror
+    Kokkos::View<Real*, Kokkos::LayoutRight, MemorySpace> const integral_bsplines_mirror
             = Kokkos::
                     subview(integral_bsplines_mirror_with_additional_allocation,
                             std::
@@ -1208,16 +1208,16 @@ SplineBuilder<ExecSpace, MemorySpace, BSplines, InterpolationDDim, SBCLower, SBC
     ddc::Chunk coefficients_derivs_xmin_out(
             ddc::DiscreteDomain<
                     deriv_type>(first_deriv, ddc::DiscreteVector<deriv_type>(s_nbv_xmin)),
-            ddc::KokkosAllocator<double, OutMemorySpace>());
+            ddc::KokkosAllocator<Real, OutMemorySpace>());
     ddc::Chunk coefficients_out(
             interpolation_domain().take_first(
                     ddc::DiscreteVector<interpolation_discrete_dimension_type>(
                             coefficients.size())),
-            ddc::KokkosAllocator<double, OutMemorySpace>());
+            ddc::KokkosAllocator<Real, OutMemorySpace>());
     ddc::Chunk coefficients_derivs_xmax_out(
             ddc::DiscreteDomain<
                     deriv_type>(first_deriv, ddc::DiscreteVector<deriv_type>(s_nbv_xmax)),
-            ddc::KokkosAllocator<double, OutMemorySpace>());
+            ddc::KokkosAllocator<Real, OutMemorySpace>());
     Kokkos::deep_copy(
             coefficients_derivs_xmin_out.allocation_kokkos_view(),
             coefficients_derivs_xmin.allocation_kokkos_view());

--- a/src/ddc/kernels/splines/spline_builder_2d.hpp
+++ b/src/ddc/kernels/splines/spline_builder_2d.hpp
@@ -455,55 +455,55 @@ public:
     template <class Layout, class BatchedInterpolationDDom>
     void operator()(
             ddc::ChunkSpan<
-                    double,
+                    Real,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space> spline,
-            ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
+            ddc::ChunkSpan<Real const, BatchedInterpolationDDom, Layout, memory_space> vals,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_min1
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_max1
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_max2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_max2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_max2
@@ -538,48 +538,48 @@ void SplineBuilder2D<
         Solver>::
 operator()(
         ddc::ChunkSpan<
-                double,
+                Real,
                 batched_spline_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space> spline,
-        ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
+        ddc::ChunkSpan<Real const, BatchedInterpolationDDom, Layout, memory_space> vals,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_min1,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_max1,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_min2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const derivs_max2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const mixed_derivs_min1_min2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const mixed_derivs_max1_min2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const mixed_derivs_min1_max2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> const mixed_derivs_max1_max2) const
@@ -607,7 +607,7 @@ operator()(
     ddc::Chunk spline1_deriv_min_alloc(
             m_label + " > spline1_deriv_min (ddc::SplineBuilder2D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline1_deriv_min = spline1_deriv_min_alloc.span_view();
     auto spline1_deriv_min_opt = std::optional(spline1_deriv_min.span_cview());
     if constexpr (SBCLower2 == ddc::SplineBuilderClosure::HERMITE) {
@@ -624,7 +624,7 @@ operator()(
     ddc::Chunk spline1_alloc(
             m_label + " > spline1 (ddc::SplineBuilder2D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_domain),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     ddc::ChunkSpan const spline1 = spline1_alloc.span_view();
 
     m_spline_builder1(spline1, vals, derivs_min1, derivs_max1);
@@ -633,7 +633,7 @@ operator()(
     ddc::Chunk spline1_deriv_max_alloc(
             m_label + " > spline1_deriv_max (ddc::SplineBuilder2D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline1_deriv_max = spline1_deriv_max_alloc.span_view();
     auto spline1_deriv_max_opt = std::optional(spline1_deriv_max.span_cview());
     if constexpr (SBCUpper2 == ddc::SplineBuilderClosure::HERMITE) {

--- a/src/ddc/kernels/splines/spline_builder_3d.hpp
+++ b/src/ddc/kernels/splines/spline_builder_3d.hpp
@@ -596,163 +596,163 @@ public:
     template <class Layout, class BatchedInterpolationDDom>
     void operator()(
             ddc::ChunkSpan<
-                    double,
+                    Real,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space> spline,
-            ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
+            ddc::ChunkSpan<Real const, BatchedInterpolationDDom, Layout, memory_space> vals,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_min1
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_max1
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_max2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_min3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> derivs_max3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_min2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_max2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_max2
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min2_min3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max2_min3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min2_max3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max2_max3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_min3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_min3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_max3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_max3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_min2_min3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_min2_min3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_max2_min3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_max2_min3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_min2_max3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_min2_max3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_min1_max2_max3
             = std::nullopt,
             std::optional<ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_derivs_domain_type<BatchedInterpolationDDom>,
                     Layout,
                     memory_space>> mixed_derivs_max1_max2_max3
@@ -795,138 +795,138 @@ void SplineBuilder3D<
         Solver>::
 operator()(
         ddc::ChunkSpan<
-                double,
+                Real,
                 batched_spline_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space> spline,
-        ddc::ChunkSpan<double const, BatchedInterpolationDDom, Layout, memory_space> vals,
+        ddc::ChunkSpan<Real const, BatchedInterpolationDDom, Layout, memory_space> vals,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> derivs_min1,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> derivs_max1,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> derivs_min2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> derivs_max2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> derivs_min3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> derivs_max3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min1_min2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max1_min2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min1_max2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1_2<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max1_max2,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min2_min3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max2_min3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min2_max3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type2_3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max2_max3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min1_min3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max1_min3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min1_max3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type1_3<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max1_max3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min1_min2_min3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max1_min2_min3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min1_max2_min3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max1_max2_min3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min1_min2_max3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max1_min2_max3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_min1_max2_max3,
         std::optional<ddc::ChunkSpan<
-                double const,
+                Real const,
                 batched_derivs_domain_type<BatchedInterpolationDDom>,
                 Layout,
                 memory_space>> mixed_derivs_max1_max2_max3) const
@@ -952,7 +952,7 @@ operator()(
     ddc::Chunk spline_derivs_min2_alloc(
             m_label + " > spline_derivs_min2 (ddc::SplineBuilder3D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline_derivs_min2 = spline_derivs_min2_alloc.span_view();
     auto spline_derivs_min2_opt = std::optional(spline_derivs_min2.span_cview());
     if constexpr (SBCLower2 == ddc::SplineBuilderClosure::HERMITE) {
@@ -968,7 +968,7 @@ operator()(
     ddc::Chunk spline_derivs_max2_alloc(
             m_label + " > spline_derivs_max2 (ddc::SplineBuilder3D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline_derivs_max2 = spline_derivs_max2_alloc.span_view();
     auto spline_derivs_max2_opt = std::optional(spline_derivs_max2.span_cview());
     if constexpr (SBCUpper2 == ddc::SplineBuilderClosure::HERMITE) {
@@ -992,7 +992,7 @@ operator()(
     ddc::Chunk spline_derivs_min3_alloc(
             m_label + " > spline_derivs_min3 (ddc::SplineBuilder3D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain3),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline_derivs_min3 = spline_derivs_min3_alloc.span_view();
     auto spline_derivs_min3_opt = std::optional(spline_derivs_min3.span_cview());
     if constexpr (SBCLower3 == ddc::SplineBuilderClosure::HERMITE) {
@@ -1008,7 +1008,7 @@ operator()(
     ddc::Chunk spline_derivs_max3_alloc(
             m_label + " > spline_derivs_max3 (ddc::SplineBuilder3D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain3),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline_derivs_max3 = spline_derivs_max3_alloc.span_view();
     auto spline_derivs_max3_opt = std::optional(spline_derivs_max3.span_cview());
     if constexpr (SBCUpper3 == ddc::SplineBuilderClosure::HERMITE) {
@@ -1032,7 +1032,7 @@ operator()(
     ddc::Chunk spline_derivs_min2_min3_alloc(
             m_label + " > spline_derivs_min2_min3 (ddc::SplineBuilder3D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2_3),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline_derivs_min2_min3 = spline_derivs_min2_min3_alloc.span_view();
     auto spline_derivs_min2_min3_opt = std::optional(spline_derivs_min2_min3.span_cview());
     if constexpr (
@@ -1050,7 +1050,7 @@ operator()(
     ddc::Chunk spline_derivs_min2_max3_alloc(
             m_label + " > spline_derivs_min2_max3 (ddc::SplineBuilder3D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2_3),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline_derivs_min2_max3 = spline_derivs_min2_max3_alloc.span_view();
     auto spline_derivs_min2_max3_opt = std::optional(spline_derivs_min2_max3.span_cview());
     if constexpr (
@@ -1068,7 +1068,7 @@ operator()(
     ddc::Chunk spline_derivs_max2_min3_alloc(
             m_label + " > spline_derivs_max2_min3 (ddc::SplineBuilder3D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2_3),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline_derivs_max2_min3 = spline_derivs_max2_min3_alloc.span_view();
     auto spline_derivs_max2_min3_opt = std::optional(spline_derivs_max2_min3.span_cview());
     if constexpr (
@@ -1086,7 +1086,7 @@ operator()(
     ddc::Chunk spline_derivs_max2_max3_alloc(
             m_label + " > spline_derivs_max2_max3 (ddc::SplineBuilder3D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_deriv_domain2_3),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     auto spline_derivs_max2_max3 = spline_derivs_max2_max3_alloc.span_view();
     auto spline_derivs_max2_max3_opt = std::optional(spline_derivs_max2_max3.span_cview());
     if constexpr (
@@ -1105,7 +1105,7 @@ operator()(
     ddc::Chunk spline1_alloc(
             m_label + " > spline1 (ddc::SplineBuilder3D::operator())",
             m_spline_builder1.batched_spline_domain(batched_interpolation_domain),
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<Real, MemorySpace>());
     ddc::ChunkSpan const spline1 = spline1_alloc.span_view();
 
     m_spline_builder1(spline1, vals, derivs_min1, derivs_max1);

--- a/src/ddc/kernels/splines/spline_evaluator.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator.hpp
@@ -228,8 +228,8 @@ public:
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION Real operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         return eval(coord_eval, spline_coef);
     }
@@ -261,8 +261,7 @@ public:
             class BatchedInterpolationDDom,
             class... CoordsDims>
     void operator()(
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
                     BatchedInterpolationDDom,
@@ -313,8 +312,7 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
@@ -355,11 +353,11 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class DElem, class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION Real deriv(
-            DElem const& deriv_order,
-            ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+    KOKKOS_FUNCTION Real
+    deriv(DElem const& deriv_order,
+          ddc::Coordinate<CoordsDims...> const& coord_eval,
+          ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         static_assert(is_discrete_element_v<DElem>);
         return eval_no_bc(deriv_order, coord_eval, spline_coef);
@@ -394,8 +392,7 @@ public:
             class... CoordsDims>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
                     BatchedInterpolationDDom,
@@ -447,8 +444,7 @@ public:
     template <class DElem, class Layout1, class Layout2, class BatchedInterpolationDDom>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
@@ -493,8 +489,8 @@ public:
     template <class Layout1, class Layout2, class BatchedDDom, class BatchedSplineDDom>
     void integrate(
             ddc::ChunkSpan<Real, BatchedDDom, Layout1, memory_space> const integrals,
-            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const spline_coef)
+            const
     {
         static_assert(
                 ddc::in_tags_v<bsplines_type, to_type_seq_t<BatchedSplineDDom>>,
@@ -527,10 +523,10 @@ public:
 
 private:
     template <class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION Real eval(
-            ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+    KOKKOS_INLINE_FUNCTION Real
+    eval(ddc::Coordinate<CoordsDims...> const& coord_eval,
+         ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         ddc::Coordinate<continuous_dimension_type> coord_eval_interest(coord_eval);
         if constexpr (bsplines_type::is_periodic()) {
@@ -557,8 +553,8 @@ private:
     KOKKOS_INLINE_FUNCTION Real eval_no_bc(
             ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         using deriv_dim = ddc::Deriv<continuous_dimension_type>;
         static_assert(
@@ -570,8 +566,8 @@ private:
 
         ddc::DiscreteElement<bsplines_type> jmin;
         std::array<Real, bsplines_type::degree() + 1> vals_ptr;
-        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type::degree() + 1>> const
-                vals(vals_ptr.data());
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type::degree() + 1>> const vals(
+                vals_ptr.data());
         ddc::Coordinate<continuous_dimension_type> const coord_eval_interest(coord_eval);
 
         if constexpr (sizeof...(DerivDims) == 0) {

--- a/src/ddc/kernels/splines/spline_evaluator.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator.hpp
@@ -115,22 +115,22 @@ public:
             "PeriodicExtrapolationRule has to be used if and only if dimension is periodic");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     LowerExtrapolationRule,
                     ddc::Coordinate<continuous_dimension_type>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
             "LowerExtrapolationRule::operator() has to be callable with usual arguments.");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     UpperExtrapolationRule,
                     ddc::Coordinate<continuous_dimension_type>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -226,9 +226,9 @@ public:
      * @return The value of the spline function at the desired coordinate.
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION double operator()(
+    KOKKOS_FUNCTION Real operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         return eval(coord_eval, spline_coef);
@@ -261,7 +261,7 @@ public:
             class BatchedInterpolationDDom,
             class... CoordsDims>
     void operator()(
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
@@ -269,7 +269,7 @@ public:
                     Layout2,
                     memory_space> const coords_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout3,
                     memory_space> const spline_coef) const
@@ -313,10 +313,10 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout2,
                     memory_space> const spline_coef) const
@@ -355,10 +355,10 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class DElem, class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION double deriv(
+    KOKKOS_FUNCTION Real deriv(
             DElem const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         static_assert(is_discrete_element_v<DElem>);
@@ -394,7 +394,7 @@ public:
             class... CoordsDims>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
@@ -402,7 +402,7 @@ public:
                     Layout2,
                     memory_space> const coords_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout3,
                     memory_space> const spline_coef) const
@@ -447,10 +447,10 @@ public:
     template <class DElem, class Layout1, class Layout2, class BatchedInterpolationDDom>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout2,
                     memory_space> const spline_coef) const
@@ -492,8 +492,8 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedDDom, class BatchedSplineDDom>
     void integrate(
-            ddc::ChunkSpan<double, BatchedDDom, Layout1, memory_space> const integrals,
-            ddc::ChunkSpan<double const, BatchedSplineDDom, Layout2, memory_space> const
+            ddc::ChunkSpan<Real, BatchedDDom, Layout1, memory_space> const integrals,
+            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const
                     spline_coef) const
     {
         static_assert(
@@ -508,7 +508,7 @@ public:
         ddc::Chunk values_alloc(
                 "values (ddc::SplineEvaluator::integrate)",
                 ddc::DiscreteDomain<bsplines_type>(spline_coef.domain()),
-                ddc::KokkosAllocator<double, memory_space>());
+                ddc::KokkosAllocator<Real, memory_space>());
         ddc::ChunkSpan const values = values_alloc.span_view();
         ddc::integrals(exec_space(), values);
 
@@ -527,9 +527,9 @@ public:
 
 private:
     template <class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION double eval(
+    KOKKOS_INLINE_FUNCTION Real eval(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         ddc::Coordinate<continuous_dimension_type> coord_eval_interest(coord_eval);
@@ -554,10 +554,10 @@ private:
     }
 
     template <class... DerivDims, class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION double eval_no_bc(
+    KOKKOS_INLINE_FUNCTION Real eval_no_bc(
             ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         using deriv_dim = ddc::Deriv<continuous_dimension_type>;
@@ -569,8 +569,8 @@ private:
                 "The only valid dimension for deriv_order is Deriv<Dim>");
 
         ddc::DiscreteElement<bsplines_type> jmin;
-        std::array<double, bsplines_type::degree() + 1> vals_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, bsplines_type::degree() + 1>> const
+        std::array<Real, bsplines_type::degree() + 1> vals_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type::degree() + 1>> const
                 vals(vals_ptr.data());
         ddc::Coordinate<continuous_dimension_type> const coord_eval_interest(coord_eval);
 
@@ -580,10 +580,10 @@ private:
             auto const order = deriv_order.uid();
             KOKKOS_ASSERT(order > 0 && order <= bsplines_type::degree())
 
-            std::array<double, (bsplines_type::degree() + 1) * (bsplines_type::degree() + 1)>
+            std::array<Real, (bsplines_type::degree() + 1) * (bsplines_type::degree() + 1)>
                     derivs_ptr;
             Kokkos::mdspan<
-                    double,
+                    Real,
                     Kokkos::extents<
                             std::size_t,
                             bsplines_type::degree() + 1,
@@ -597,7 +597,7 @@ private:
             }
         }
 
-        double y = 0.0;
+        Real y = 0.0;
         for (std::size_t i = 0; i < bsplines_type::degree() + 1; ++i) {
             y += spline_coef(ddc::DiscreteElement<bsplines_type>(jmin + i)) * vals[i];
         }

--- a/src/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -168,11 +168,11 @@ public:
             "PeriodicExtrapolationRule has to be used if and only if dimension is periodic");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     LowerExtrapolationRule1,
                     ddc::Coordinate<continuous_dimension_type1>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -180,11 +180,11 @@ public:
             "with usual arguments.");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     UpperExtrapolationRule1,
                     ddc::Coordinate<continuous_dimension_type1>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -192,11 +192,11 @@ public:
             "with usual arguments.");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     LowerExtrapolationRule2,
                     ddc::Coordinate<continuous_dimension_type2>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -204,11 +204,11 @@ public:
             "with usual arguments.");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     UpperExtrapolationRule2,
                     ddc::Coordinate<continuous_dimension_type2>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -339,9 +339,9 @@ public:
      * @return The value of the spline function at the desired coordinate.
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION double operator()(
+    KOKKOS_FUNCTION Real operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         return eval(coord_eval, spline_coef);
@@ -374,7 +374,7 @@ public:
             class BatchedInterpolationDDom,
             class... CoordsDims>
     void operator()(
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
@@ -382,7 +382,7 @@ public:
                     Layout2,
                     memory_space> const coords_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout3,
                     memory_space> const spline_coef) const
@@ -425,10 +425,10 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout2,
                     memory_space> const spline_coef) const
@@ -469,10 +469,10 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class DElem, class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION double deriv(
+    KOKKOS_FUNCTION Real deriv(
             DElem const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         return eval_no_bc(deriv_order, coord_eval, spline_coef);
@@ -509,7 +509,7 @@ public:
             class... CoordsDims>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
@@ -517,7 +517,7 @@ public:
                     Layout2,
                     memory_space> const coords_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout3,
                     memory_space> const spline_coef) const
@@ -566,10 +566,10 @@ public:
     template <class DElem, class Layout1, class Layout2, class BatchedInterpolationDDom>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout2,
                     memory_space> const spline_coef) const
@@ -614,8 +614,8 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedDDom, class BatchedSplineDDom>
     void integrate(
-            ddc::ChunkSpan<double, BatchedDDom, Layout1, memory_space> const integrals,
-            ddc::ChunkSpan<double const, BatchedSplineDDom, Layout2, memory_space> const
+            ddc::ChunkSpan<Real, BatchedDDom, Layout1, memory_space> const integrals,
+            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const
                     spline_coef) const
     {
         static_assert(
@@ -633,13 +633,13 @@ public:
         ddc::Chunk values1_alloc(
                 "values1 (ddc::SplineEvaluator2D::integrate)",
                 ddc::DiscreteDomain<bsplines_type1>(spline_coef.domain()),
-                ddc::KokkosAllocator<double, memory_space>());
+                ddc::KokkosAllocator<Real, memory_space>());
         ddc::ChunkSpan values1 = values1_alloc.span_view();
         ddc::integrals(exec_space(), values1);
         ddc::Chunk values2_alloc(
                 "values2 (ddc::SplineEvaluator2D::integrate)",
                 ddc::DiscreteDomain<bsplines_type2>(spline_coef.domain()),
-                ddc::KokkosAllocator<double, memory_space>());
+                ddc::KokkosAllocator<Real, memory_space>());
         ddc::ChunkSpan values2 = values2_alloc.span_view();
         ddc::integrals(exec_space(), values2);
 
@@ -671,14 +671,14 @@ private:
      * @param[out] vals1 A ChunkSpan with the not-null values of each function of the spline in the first dimension.
      * @param[out] vals2 A ChunkSpan with the not-null values of each function of the spline in the second dimension.
      *
-     * @return A double with the value of the function at the coordinate given.
+     * @return A Real with the value of the function at the coordinate given.
      *
      * @see SplineBoundaryValue
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION double eval(
+    KOKKOS_INLINE_FUNCTION Real eval(
             ddc::Coordinate<CoordsDims...> coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         using Dim1 = continuous_dimension_type1;
@@ -738,10 +738,10 @@ private:
      * @param[in] splne_coef The B-splines coefficients of the function we want to evaluate.
      */
     template <class... DerivDims, class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION double eval_no_bc(
+    KOKKOS_INLINE_FUNCTION Real eval_no_bc(
             ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         using deriv_dim1 = ddc::Deriv<continuous_dimension_type1>;
@@ -756,11 +756,11 @@ private:
         ddc::DiscreteElement<bsplines_type1> jmin1;
         ddc::DiscreteElement<bsplines_type2> jmin2;
 
-        std::array<double, bsplines_type1::degree() + 1> vals1_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, bsplines_type1::degree() + 1>> const
+        std::array<Real, bsplines_type1::degree() + 1> vals1_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type1::degree() + 1>> const
                 vals1(vals1_ptr.data());
-        std::array<double, bsplines_type2::degree() + 1> vals2_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, bsplines_type2::degree() + 1>> const
+        std::array<Real, bsplines_type2::degree() + 1> vals2_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type2::degree() + 1>> const
                 vals2(vals2_ptr.data());
         ddc::Coordinate<continuous_dimension_type1> const coord_eval_interest1(coord_eval);
         ddc::Coordinate<continuous_dimension_type2> const coord_eval_interest2(coord_eval);
@@ -771,10 +771,10 @@ private:
             auto const order1 = deriv_order.template uid<deriv_dim1>();
             KOKKOS_ASSERT(order1 > 0 && order1 <= bsplines_type1::degree())
 
-            std::array<double, (bsplines_type1::degree() + 1) * (bsplines_type1::degree() + 1)>
+            std::array<Real, (bsplines_type1::degree() + 1) * (bsplines_type1::degree() + 1)>
                     derivs1_ptr;
             Kokkos::mdspan<
-                    double,
+                    Real,
                     Kokkos::extents<
                             std::size_t,
                             bsplines_type1::degree() + 1,
@@ -794,10 +794,10 @@ private:
             auto const order2 = deriv_order.template uid<deriv_dim2>();
             KOKKOS_ASSERT(order2 > 0 && order2 <= bsplines_type2::degree())
 
-            std::array<double, (bsplines_type2::degree() + 1) * (bsplines_type2::degree() + 1)>
+            std::array<Real, (bsplines_type2::degree() + 1) * (bsplines_type2::degree() + 1)>
                     derivs2_ptr;
             Kokkos::mdspan<
-                    double,
+                    Real,
                     Kokkos::extents<
                             std::size_t,
                             bsplines_type2::degree() + 1,
@@ -811,7 +811,7 @@ private:
             }
         }
 
-        double y = 0.0;
+        Real y = 0.0;
         for (std::size_t i = 0; i < bsplines_type1::degree() + 1; ++i) {
             for (std::size_t j = 0; j < bsplines_type2::degree() + 1; ++j) {
                 y += spline_coef(

--- a/src/ddc/kernels/splines/spline_evaluator_2d.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_2d.hpp
@@ -341,8 +341,8 @@ public:
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION Real operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         return eval(coord_eval, spline_coef);
     }
@@ -374,8 +374,7 @@ public:
             class BatchedInterpolationDDom,
             class... CoordsDims>
     void operator()(
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
                     BatchedInterpolationDDom,
@@ -425,8 +424,7 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
@@ -469,11 +467,11 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class DElem, class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION Real deriv(
-            DElem const& deriv_order,
-            ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+    KOKKOS_FUNCTION Real
+    deriv(DElem const& deriv_order,
+          ddc::Coordinate<CoordsDims...> const& coord_eval,
+          ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         return eval_no_bc(deriv_order, coord_eval, spline_coef);
     }
@@ -509,8 +507,7 @@ public:
             class... CoordsDims>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
                     BatchedInterpolationDDom,
@@ -566,8 +563,7 @@ public:
     template <class DElem, class Layout1, class Layout2, class BatchedInterpolationDDom>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
@@ -615,8 +611,8 @@ public:
     template <class Layout1, class Layout2, class BatchedDDom, class BatchedSplineDDom>
     void integrate(
             ddc::ChunkSpan<Real, BatchedDDom, Layout1, memory_space> const integrals,
-            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const spline_coef)
+            const
     {
         static_assert(
                 ddc::type_seq_contains_v<
@@ -676,10 +672,10 @@ private:
      * @see SplineBoundaryValue
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION Real eval(
-            ddc::Coordinate<CoordsDims...> coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+    KOKKOS_INLINE_FUNCTION Real
+    eval(ddc::Coordinate<CoordsDims...> coord_eval,
+         ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         using Dim1 = continuous_dimension_type1;
         using Dim2 = continuous_dimension_type2;
@@ -741,8 +737,8 @@ private:
     KOKKOS_INLINE_FUNCTION Real eval_no_bc(
             ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         using deriv_dim1 = ddc::Deriv<continuous_dimension_type1>;
         using deriv_dim2 = ddc::Deriv<continuous_dimension_type2>;

--- a/src/ddc/kernels/splines/spline_evaluator_3d.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_3d.hpp
@@ -212,11 +212,11 @@ public:
             "PeriodicExtrapolationRule has to be used if and only if dimension is periodic");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     LowerExtrapolationRule1,
                     ddc::Coordinate<continuous_dimension_type1>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -224,11 +224,11 @@ public:
             "with usual arguments.");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     UpperExtrapolationRule1,
                     ddc::Coordinate<continuous_dimension_type1>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -236,11 +236,11 @@ public:
             "with usual arguments.");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     LowerExtrapolationRule2,
                     ddc::Coordinate<continuous_dimension_type2>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -248,11 +248,11 @@ public:
             "with usual arguments.");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     UpperExtrapolationRule2,
                     ddc::Coordinate<continuous_dimension_type2>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -260,11 +260,11 @@ public:
             "with usual arguments.");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     LowerExtrapolationRule3,
                     ddc::Coordinate<continuous_dimension_type3>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -272,11 +272,11 @@ public:
             "with usual arguments.");
     static_assert(
             std::is_invocable_r_v<
-                    double,
+                    Real,
                     UpperExtrapolationRule3,
                     ddc::Coordinate<continuous_dimension_type3>,
                     ddc::ChunkSpan<
-                            double const,
+                            Real const,
                             spline_domain_type,
                             Kokkos::layout_right,
                             memory_space>>,
@@ -441,9 +441,9 @@ public:
      * @return The value of the spline function at the desired coordinate.
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION double operator()(
+    KOKKOS_FUNCTION Real operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         return eval(coord_eval, spline_coef);
@@ -476,7 +476,7 @@ public:
             class BatchedInterpolationDDom,
             class... CoordsDims>
     void operator()(
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
@@ -484,7 +484,7 @@ public:
                     Layout2,
                     memory_space> const coords_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout3,
                     memory_space> const spline_coef) const
@@ -531,10 +531,10 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout2,
                     memory_space> const spline_coef) const
@@ -584,10 +584,10 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class DElem, class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION double deriv(
+    KOKKOS_FUNCTION Real deriv(
             DElem const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         static_assert(is_discrete_element_v<DElem>);
@@ -623,7 +623,7 @@ public:
             class... CoordsDims>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
@@ -631,7 +631,7 @@ public:
                     Layout2,
                     memory_space> const coords_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout3,
                     memory_space> const spline_coef) const
@@ -683,10 +683,10 @@ public:
     template <class DElem, class Layout1, class Layout2, class BatchedInterpolationDDom>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout2,
                     memory_space> const spline_coef) const
@@ -740,8 +740,8 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedDDom, class BatchedSplineDDom>
     void integrate(
-            ddc::ChunkSpan<double, BatchedDDom, Layout1, memory_space> const integrals,
-            ddc::ChunkSpan<double const, BatchedSplineDDom, Layout2, memory_space> const
+            ddc::ChunkSpan<Real, BatchedDDom, Layout1, memory_space> const integrals,
+            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const
                     spline_coef) const
     {
         static_assert(
@@ -759,19 +759,19 @@ public:
         ddc::Chunk values1_alloc(
                 "values1 (ddc::SplineEvaluator3D::integrate)",
                 ddc::DiscreteDomain<bsplines_type1>(spline_coef.domain()),
-                ddc::KokkosAllocator<double, memory_space>());
+                ddc::KokkosAllocator<Real, memory_space>());
         ddc::ChunkSpan values1 = values1_alloc.span_view();
         ddc::integrals(exec_space(), values1);
         ddc::Chunk values2_alloc(
                 "values2 (ddc::SplineEvaluator3D::integrate)",
                 ddc::DiscreteDomain<bsplines_type2>(spline_coef.domain()),
-                ddc::KokkosAllocator<double, memory_space>());
+                ddc::KokkosAllocator<Real, memory_space>());
         ddc::ChunkSpan values2 = values2_alloc.span_view();
         ddc::integrals(exec_space(), values2);
         ddc::Chunk values3_alloc(
                 "values3 (ddc::SplineEvaluator3D::integrate)",
                 ddc::DiscreteDomain<bsplines_type3>(spline_coef.domain()),
-                ddc::KokkosAllocator<double, memory_space>());
+                ddc::KokkosAllocator<Real, memory_space>());
         ddc::ChunkSpan values3 = values3_alloc.span_view();
         ddc::integrals(exec_space(), values3);
 
@@ -807,14 +807,14 @@ private:
      * @param[out] vals1 A ChunkSpan with the not-null values of each function of the spline in the first dimension.
      * @param[out] vals2 A ChunkSpan with the not-null values of each function of the spline in the second dimension.
      *
-     * @return A double with the value of the function at the coordinate given.
+     * @return A Real with the value of the function at the coordinate given.
      *
      * @see SplineBoundaryValue
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION double eval(
+    KOKKOS_INLINE_FUNCTION Real eval(
             ddc::Coordinate<CoordsDims...> coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         using Dim1 = continuous_dimension_type1;
@@ -898,10 +898,10 @@ private:
      * @param[in] splne_coef The B-splines coefficients of the function we want to evaluate.
      */
     template <class... DerivDims, class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION double eval_no_bc(
+    KOKKOS_INLINE_FUNCTION Real eval_no_bc(
             ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<double const, spline_domain_type, Layout, memory_space> const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
                     spline_coef) const
     {
         using deriv_dim1 = Deriv<continuous_dimension_type1>;
@@ -920,14 +920,14 @@ private:
         ddc::DiscreteElement<bsplines_type2> jmin2;
         ddc::DiscreteElement<bsplines_type3> jmin3;
 
-        std::array<double, bsplines_type1::degree() + 1> vals1_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, bsplines_type1::degree() + 1>> const
+        std::array<Real, bsplines_type1::degree() + 1> vals1_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type1::degree() + 1>> const
                 vals1(vals1_ptr.data());
-        std::array<double, bsplines_type2::degree() + 1> vals2_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, bsplines_type2::degree() + 1>> const
+        std::array<Real, bsplines_type2::degree() + 1> vals2_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type2::degree() + 1>> const
                 vals2(vals2_ptr.data());
-        std::array<double, bsplines_type3::degree() + 1> vals3_ptr;
-        Kokkos::mdspan<double, Kokkos::extents<std::size_t, bsplines_type3::degree() + 1>> const
+        std::array<Real, bsplines_type3::degree() + 1> vals3_ptr;
+        Kokkos::mdspan<Real, Kokkos::extents<std::size_t, bsplines_type3::degree() + 1>> const
                 vals3(vals3_ptr.data());
         ddc::Coordinate<continuous_dimension_type1> const coord_eval_interest1(coord_eval);
         ddc::Coordinate<continuous_dimension_type2> const coord_eval_interest2(coord_eval);
@@ -939,10 +939,10 @@ private:
             auto const order1 = deriv_order.template uid<deriv_dim1>();
             KOKKOS_ASSERT(order1 > 0 && order1 <= bsplines_type1::degree())
 
-            std::array<double, (bsplines_type1::degree() + 1) * (bsplines_type1::degree() + 1)>
+            std::array<Real, (bsplines_type1::degree() + 1) * (bsplines_type1::degree() + 1)>
                     derivs1_ptr;
             Kokkos::mdspan<
-                    double,
+                    Real,
                     Kokkos::extents<
                             std::size_t,
                             bsplines_type1::degree() + 1,
@@ -962,10 +962,10 @@ private:
             auto const order2 = deriv_order.template uid<deriv_dim2>();
             KOKKOS_ASSERT(order2 > 0 && order2 <= bsplines_type2::degree())
 
-            std::array<double, (bsplines_type2::degree() + 1) * (bsplines_type2::degree() + 1)>
+            std::array<Real, (bsplines_type2::degree() + 1) * (bsplines_type2::degree() + 1)>
                     derivs2_ptr;
             Kokkos::mdspan<
-                    double,
+                    Real,
                     Kokkos::extents<
                             std::size_t,
                             bsplines_type2::degree() + 1,
@@ -985,10 +985,10 @@ private:
             auto const order3 = deriv_order.template uid<deriv_dim3>();
             KOKKOS_ASSERT(order3 > 0 && order3 <= bsplines_type3::degree())
 
-            std::array<double, (bsplines_type3::degree() + 1) * (bsplines_type3::degree() + 1)>
+            std::array<Real, (bsplines_type3::degree() + 1) * (bsplines_type3::degree() + 1)>
                     derivs3_ptr;
             Kokkos::mdspan<
-                    double,
+                    Real,
                     Kokkos::extents<
                             std::size_t,
                             bsplines_type3::degree() + 1,
@@ -1002,7 +1002,7 @@ private:
             }
         }
 
-        double y = 0.0;
+        Real y = 0.0;
         for (std::size_t i = 0; i < bsplines_type1::degree() + 1; ++i) {
             for (std::size_t j = 0; j < bsplines_type2::degree() + 1; ++j) {
                 for (std::size_t k = 0; k < bsplines_type3::degree() + 1; ++k) {

--- a/src/ddc/kernels/splines/spline_evaluator_3d.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_3d.hpp
@@ -443,8 +443,8 @@ public:
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION Real operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         return eval(coord_eval, spline_coef);
     }
@@ -476,8 +476,7 @@ public:
             class BatchedInterpolationDDom,
             class... CoordsDims>
     void operator()(
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
                     BatchedInterpolationDDom,
@@ -531,8 +530,7 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
@@ -584,11 +582,11 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class DElem, class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION Real deriv(
-            DElem const& deriv_order,
-            ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+    KOKKOS_FUNCTION Real
+    deriv(DElem const& deriv_order,
+          ddc::Coordinate<CoordsDims...> const& coord_eval,
+          ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         static_assert(is_discrete_element_v<DElem>);
         return eval_no_bc(deriv_order, coord_eval, spline_coef);
@@ -623,8 +621,7 @@ public:
             class... CoordsDims>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
                     BatchedInterpolationDDom,
@@ -683,8 +680,7 @@ public:
     template <class DElem, class Layout1, class Layout2, class BatchedInterpolationDDom>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
@@ -741,8 +737,8 @@ public:
     template <class Layout1, class Layout2, class BatchedDDom, class BatchedSplineDDom>
     void integrate(
             ddc::ChunkSpan<Real, BatchedDDom, Layout1, memory_space> const integrals,
-            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const spline_coef)
+            const
     {
         static_assert(
                 ddc::type_seq_contains_v<
@@ -812,10 +808,10 @@ private:
      * @see SplineBoundaryValue
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION Real eval(
-            ddc::Coordinate<CoordsDims...> coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+    KOKKOS_INLINE_FUNCTION Real
+    eval(ddc::Coordinate<CoordsDims...> coord_eval,
+         ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         using Dim1 = continuous_dimension_type1;
         using Dim2 = continuous_dimension_type2;
@@ -901,8 +897,8 @@ private:
     KOKKOS_INLINE_FUNCTION Real eval_no_bc(
             ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, spline_domain_type, Layout, memory_space> const spline_coef)
+            const
     {
         using deriv_dim1 = Deriv<continuous_dimension_type1>;
         using deriv_dim2 = Deriv<continuous_dimension_type2>;

--- a/src/ddc/kernels/splines/spline_evaluator_nd.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_nd.hpp
@@ -306,11 +306,8 @@ public:
     template <class Layout, class... CoordsDims>
     KOKKOS_FUNCTION Real operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<
-                    Real const,
-                    ddc::DiscreteDomain<BSplines...>,
-                    Layout,
-                    memory_space> const spline_coef) const
+            ddc::ChunkSpan<Real const, ddc::DiscreteDomain<BSplines...>, Layout, memory_space> const
+                    spline_coef) const
     {
         return eval(coord_eval, spline_coef);
     }
@@ -342,8 +339,7 @@ public:
             class BatchedInterpolationDDom,
             class... CoordsDims>
     void operator()(
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
                     BatchedInterpolationDDom,
@@ -395,8 +391,7 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
@@ -442,14 +437,11 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class DElem, class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION Real deriv(
-            DElem const& deriv_order,
-            ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<
-                    Real const,
-                    ddc::DiscreteDomain<BSplines...>,
-                    Layout,
-                    memory_space> const spline_coef) const
+    KOKKOS_FUNCTION Real
+    deriv(DElem const& deriv_order,
+          ddc::Coordinate<CoordsDims...> const& coord_eval,
+          ddc::ChunkSpan<Real const, ddc::DiscreteDomain<BSplines...>, Layout, memory_space> const
+                  spline_coef) const
     {
         static_assert(ddc::is_discrete_element_v<DElem>);
 
@@ -486,8 +478,7 @@ public:
             class... CoordsDims>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
                     BatchedInterpolationDDom,
@@ -545,8 +536,7 @@ public:
     template <class DElem, class Layout1, class Layout2, class BatchedInterpolationDDom>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
-                    spline_eval,
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const spline_eval,
             ddc::ChunkSpan<
                     Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
@@ -596,8 +586,8 @@ public:
     template <class Layout1, class Layout2, class BatchedDDom, class BatchedSplineDDom>
     void integrate(
             ddc::ChunkSpan<Real, BatchedDDom, Layout1, memory_space> const integrals,
-            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const
-                    spline_coef) const
+            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const spline_coef)
+            const
     {
         static_assert(
                 ddc::type_seq_contains_v<bsplines_ts, to_type_seq_t<BatchedSplineDDom>>,
@@ -656,11 +646,8 @@ private:
     template <std::size_t I, class Layout, class... CoordsDims>
     KOKKOS_INLINE_FUNCTION bool check_needs_extrapolation(
             ddc::Coordinate<CoordsDims...> coord_eval,
-            ddc::ChunkSpan<
-                    Real const,
-                    ddc::DiscreteDomain<BSplines...>,
-                    Layout,
-                    memory_space> const spline_coef,
+            ddc::ChunkSpan<Real const, ddc::DiscreteDomain<BSplines...>, Layout, memory_space> const
+                    spline_coef,
             Real& res) const
     {
         if constexpr (!bsplines_type<I>::is_periodic()) {
@@ -694,13 +681,10 @@ private:
      * @see SplineBoundaryValue
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION Real eval(
-            ddc::Coordinate<CoordsDims...> coord_eval,
-            ddc::ChunkSpan<
-                    Real const,
-                    ddc::DiscreteDomain<BSplines...>,
-                    Layout,
-                    memory_space> const spline_coef) const
+    KOKKOS_INLINE_FUNCTION Real
+    eval(ddc::Coordinate<CoordsDims...> coord_eval,
+         ddc::ChunkSpan<Real const, ddc::DiscreteDomain<BSplines...>, Layout, memory_space> const
+                 spline_coef) const
     {
         (update_coord_eval<s_idx<BSplines>>(coord_eval), ...);
 
@@ -782,11 +766,8 @@ private:
     KOKKOS_INLINE_FUNCTION Real eval_no_bc(
             ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
-            ddc::ChunkSpan<
-                    Real const,
-                    ddc::DiscreteDomain<BSplines...>,
-                    Layout,
-                    memory_space> const spline_coef) const
+            ddc::ChunkSpan<Real const, ddc::DiscreteDomain<BSplines...>, Layout, memory_space> const
+                    spline_coef) const
     {
         // Check that the tags are valid
         static_assert(

--- a/src/ddc/kernels/splines/spline_evaluator_nd.hpp
+++ b/src/ddc/kernels/splines/spline_evaluator_nd.hpp
@@ -191,11 +191,11 @@ public:
             "PeriodicExtrapolationRule has to be used if and only if dimension is periodic");
     static_assert(
             (std::is_invocable_r_v<
-                     double,
+                     Real,
                      ddc::type_seq_element_t<s_idx<BSplines>, lower_extrap_rule_ts>,
                      ddc::Coordinate<typename BSplines::continuous_dimension_type...>,
                      ddc::ChunkSpan<
-                             double const,
+                             Real const,
                              ddc::DiscreteDomain<BSplines...>,
                              Kokkos::layout_right,
                              memory_space>>
@@ -204,11 +204,11 @@ public:
             "with usual arguments.");
     static_assert(
             (std::is_invocable_r_v<
-                     double,
+                     Real,
                      ddc::type_seq_element_t<s_idx<BSplines>, upper_extrap_rule_ts>,
                      ddc::Coordinate<typename BSplines::continuous_dimension_type...>,
                      ddc::ChunkSpan<
-                             double const,
+                             Real const,
                              ddc::DiscreteDomain<BSplines...>,
                              Kokkos::layout_right,
                              memory_space>>
@@ -304,10 +304,10 @@ public:
      * @return The value of the spline function at the desired coordinate.
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION double operator()(
+    KOKKOS_FUNCTION Real operator()(
             ddc::Coordinate<CoordsDims...> const& coord_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     ddc::DiscreteDomain<BSplines...>,
                     Layout,
                     memory_space> const spline_coef) const
@@ -342,7 +342,7 @@ public:
             class BatchedInterpolationDDom,
             class... CoordsDims>
     void operator()(
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
@@ -350,7 +350,7 @@ public:
                     Layout2,
                     memory_space> const coords_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout3,
                     memory_space> const spline_coef) const
@@ -395,10 +395,10 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedInterpolationDDom>
     void operator()(
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout2,
                     memory_space> const spline_coef) const
@@ -442,11 +442,11 @@ public:
      * @return The derivative of the spline function at the desired coordinate.
      */
     template <class DElem, class Layout, class... CoordsDims>
-    KOKKOS_FUNCTION double deriv(
+    KOKKOS_FUNCTION Real deriv(
             DElem const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     ddc::DiscreteDomain<BSplines...>,
                     Layout,
                     memory_space> const spline_coef) const
@@ -486,7 +486,7 @@ public:
             class... CoordsDims>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
                     ddc::Coordinate<CoordsDims...> const,
@@ -494,7 +494,7 @@ public:
                     Layout2,
                     memory_space> const coords_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout3,
                     memory_space> const spline_coef) const
@@ -545,10 +545,10 @@ public:
     template <class DElem, class Layout1, class Layout2, class BatchedInterpolationDDom>
     void deriv(
             DElem const& deriv_order,
-            ddc::ChunkSpan<double, BatchedInterpolationDDom, Layout1, memory_space> const
+            ddc::ChunkSpan<Real, BatchedInterpolationDDom, Layout1, memory_space> const
                     spline_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     batched_spline_domain_type<BatchedInterpolationDDom>,
                     Layout2,
                     memory_space> const spline_coef) const
@@ -595,8 +595,8 @@ public:
      */
     template <class Layout1, class Layout2, class BatchedDDom, class BatchedSplineDDom>
     void integrate(
-            ddc::ChunkSpan<double, BatchedDDom, Layout1, memory_space> const integrals,
-            ddc::ChunkSpan<double const, BatchedSplineDDom, Layout2, memory_space> const
+            ddc::ChunkSpan<Real, BatchedDDom, Layout1, memory_space> const integrals,
+            ddc::ChunkSpan<Real const, BatchedSplineDDom, Layout2, memory_space> const
                     spline_coef) const
     {
         static_assert(
@@ -613,7 +613,7 @@ public:
         auto values_alloc = cexa::make_tuple(
                 ddc::
                         Chunk(ddc::DiscreteDomain<BSplines>(spline_coef.domain()),
-                              ddc::KokkosAllocator<double, memory_space>())...);
+                              ddc::KokkosAllocator<Real, memory_space>())...);
         auto values = cexa::make_tuple(cexa::get<s_idx<BSplines>>(values_alloc).span_view()...);
         (ddc::integrals(exec_space(), cexa::get<s_idx<BSplines>>(values)), ...);
 
@@ -657,11 +657,11 @@ private:
     KOKKOS_INLINE_FUNCTION bool check_needs_extrapolation(
             ddc::Coordinate<CoordsDims...> coord_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     ddc::DiscreteDomain<BSplines...>,
                     Layout,
                     memory_space> const spline_coef,
-            double& res) const
+            Real& res) const
     {
         if constexpr (!bsplines_type<I>::is_periodic()) {
             if (ddc::get<continuous_dimension_type<I>>(coord_eval)
@@ -689,22 +689,22 @@ private:
      * @param[out] vals1 A ChunkSpan with the not-null values of each function of the spline in the first dimension.
      * @param[out] vals2 A ChunkSpan with the not-null values of each function of the spline in the second dimension.
      *
-     * @return A double with the value of the function at the coordinate given.
+     * @return A Real with the value of the function at the coordinate given.
      *
      * @see SplineBoundaryValue
      */
     template <class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION double eval(
+    KOKKOS_INLINE_FUNCTION Real eval(
             ddc::Coordinate<CoordsDims...> coord_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     ddc::DiscreteDomain<BSplines...>,
                     Layout,
                     memory_space> const spline_coef) const
     {
         (update_coord_eval<s_idx<BSplines>>(coord_eval), ...);
 
-        double res = 0.;
+        Real res = 0.;
         // We rely on short circuit here. If we need to extrapolate on one of the dims, `res` will be set and `check_needs_extrapolation` will return true.
         bool const needs_extrapolation
                 = (... || check_needs_extrapolation<s_idx<BSplines>>(coord_eval, spline_coef, res));
@@ -723,7 +723,7 @@ private:
     template <class BSplinesType, class... DerivDims, class CoordDim>
     KOKKOS_INLINE_FUNCTION static ddc::DiscreteElement<BSplinesType> get_jmin(
             ddc::DiscreteElement<DerivDims...> const& deriv_order,
-            Kokkos::mdspan<double, Kokkos::extents<std::size_t, BSplinesType::degree() + 1>> vals,
+            Kokkos::mdspan<Real, Kokkos::extents<std::size_t, BSplinesType::degree() + 1>> vals,
             ddc::Coordinate<CoordDim> const& coord_eval)
     {
         using deriv_dim = Deriv<typename BSplinesType::continuous_dimension_type>;
@@ -734,10 +734,10 @@ private:
             auto const order = deriv_order.template uid<deriv_dim>();
             KOKKOS_ASSERT(order > 0 && order <= BSplinesType::degree())
 
-            std::array<double, (BSplinesType::degree() + 1) * (BSplinesType::degree() + 1)>
+            std::array<Real, (BSplinesType::degree() + 1) * (BSplinesType::degree() + 1)>
                     derivs_ptr;
             Kokkos::mdspan<
-                    double,
+                    Real,
                     Kokkos::extents<
                             std::size_t,
                             BSplinesType::degree() + 1,
@@ -779,11 +779,11 @@ private:
      * @param[in] splne_coef The B-splines coefficients of the function we want to evaluate.
      */
     template <class... DerivDims, class Layout, class... CoordsDims>
-    KOKKOS_INLINE_FUNCTION double eval_no_bc(
+    KOKKOS_INLINE_FUNCTION Real eval_no_bc(
             ddc::DiscreteElement<DerivDims...> const& deriv_order,
             ddc::Coordinate<CoordsDims...> const& coord_eval,
             ddc::ChunkSpan<
-                    double const,
+                    Real const,
                     ddc::DiscreteDomain<BSplines...>,
                     Layout,
                     memory_space> const spline_coef) const
@@ -797,9 +797,9 @@ private:
                 "The only valid dimensions for deriv_order are Deriv<Dim1>, Deriv<Dim2>, ..., "
                 "Deriv<DimN>");
 
-        auto vals_ptr = cexa::make_tuple(std::array<double, BSplines::degree() + 1> {}...);
+        auto vals_ptr = cexa::make_tuple(std::array<Real, BSplines::degree() + 1> {}...);
         auto const vals = cexa::make_tuple(
-                Kokkos::mdspan<double, Kokkos::extents<std::size_t, BSplines::degree() + 1>>(
+                Kokkos::mdspan<Real, Kokkos::extents<std::size_t, BSplines::degree() + 1>>(
                         cexa::get<s_idx<BSplines>>(vals_ptr).data())...);
 
         auto const jmin = cexa::make_tuple(
@@ -809,7 +809,7 @@ private:
                         ddc::Coordinate<typename BSplines::continuous_dimension_type>(
                                 coord_eval))...);
 
-        double y = 0.0;
+        Real y = 0.0;
         for_each(
                 std::array<std::size_t, dimension> {(BSplines::degree() + 1)...},
                 [&](std::array<std::size_t, dimension> idx) {

--- a/src/ddc/kernels/splines/splines_linear_problem.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem.hpp
@@ -7,9 +7,9 @@
 #include <cstddef>
 #include <iosfwd>
 
-#include <Kokkos_Core.hpp>
-
 #include <ddc/real_type.hpp>
+
+#include <Kokkos_Core.hpp>
 
 namespace ddc::detail {
 

--- a/src/ddc/kernels/splines/splines_linear_problem.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem.hpp
@@ -9,6 +9,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <ddc/real_type.hpp>
+
 namespace ddc::detail {
 
 /**
@@ -24,7 +26,7 @@ public:
     using memory_space = ExecSpace::memory_space;
 
     /// @brief The type of a Kokkos::View storing multiple right-hand sides.
-    using MultiRHS = Kokkos::View<double**, Kokkos::LayoutRight, memory_space>;
+    using MultiRHS = Kokkos::View<Real**, Kokkos::LayoutRight, memory_space>;
 
 private:
     std::size_t m_size;
@@ -52,7 +54,7 @@ public:
      *
      * @return The value of the element of the matrix.
      */
-    virtual double get_element(std::size_t i, std::size_t j) const = 0;
+    virtual Real get_element(std::size_t i, std::size_t j) const = 0;
 
     /**
      * @brief Set an element of the matrix at indexes i, j. It must not be called after `setup_solver`.
@@ -61,7 +63,7 @@ public:
      * @param j The column index of the set element.
      * @param aij The value to set in the element of the matrix.
      */
-    virtual void set_element(std::size_t i, std::size_t j, double aij) = 0;
+    virtual void set_element(std::size_t i, std::size_t j, Real aij) = 0;
 
     /**
      * @brief Perform a pre-process operation on the solver. Must be called after filling the matrix.

--- a/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.cpp
@@ -22,7 +22,7 @@ struct SplinesLinearProblem2x2Blocks<ExecSpace>::Coo
     std::size_t m_ncols;
     Kokkos::View<int*, Kokkos::LayoutRight, memory_space> m_rows_idx;
     Kokkos::View<int*, Kokkos::LayoutRight, memory_space> m_cols_idx;
-    Kokkos::View<double*, Kokkos::LayoutRight, memory_space> m_values;
+    Kokkos::View<Real*, Kokkos::LayoutRight, memory_space> m_values;
 
     Coo() : m_nrows(0), m_ncols(0) {}
 
@@ -30,7 +30,7 @@ struct SplinesLinearProblem2x2Blocks<ExecSpace>::Coo
         std::size_t const ncols_,
         Kokkos::View<int*, Kokkos::LayoutRight, memory_space> rows_idx_,
         Kokkos::View<int*, Kokkos::LayoutRight, memory_space> cols_idx_,
-        Kokkos::View<double*, Kokkos::LayoutRight, memory_space> values_)
+        Kokkos::View<Real*, Kokkos::LayoutRight, memory_space> values_)
         : m_nrows(nrows_)
         , m_ncols(ncols_)
         , m_rows_idx(std::move(rows_idx_))
@@ -66,7 +66,7 @@ struct SplinesLinearProblem2x2Blocks<ExecSpace>::Coo
         return m_cols_idx;
     }
 
-    KOKKOS_FUNCTION Kokkos::View<double*, Kokkos::LayoutRight, memory_space> values() const
+    KOKKOS_FUNCTION Kokkos::View<Real*, Kokkos::LayoutRight, memory_space> values() const
     {
         return m_values;
     }
@@ -99,7 +99,7 @@ template <class ExecSpace>
 SplinesLinearProblem2x2Blocks<ExecSpace>::~SplinesLinearProblem2x2Blocks() = default;
 
 template <class ExecSpace>
-double SplinesLinearProblem2x2Blocks<ExecSpace>::get_element(
+Real SplinesLinearProblem2x2Blocks<ExecSpace>::get_element(
         std::size_t const i,
         std::size_t const j) const
 {
@@ -126,7 +126,7 @@ template <class ExecSpace>
 void SplinesLinearProblem2x2Blocks<ExecSpace>::set_element(
         std::size_t const i,
         std::size_t const j,
-        double const aij)
+        Real const aij)
 {
     assert(i < size());
     assert(j < size());
@@ -146,14 +146,14 @@ void SplinesLinearProblem2x2Blocks<ExecSpace>::set_element(
 template <class ExecSpace>
 std::unique_ptr<typename SplinesLinearProblem2x2Blocks<ExecSpace>::Coo>
 SplinesLinearProblem2x2Blocks<ExecSpace>::dense2coo(
-        Kokkos::View<double const**, Kokkos::LayoutRight, memory_space> dense_matrix,
-        double const tol)
+        Kokkos::View<Real const**, Kokkos::LayoutRight, memory_space> dense_matrix,
+        Real const tol)
 {
     Kokkos::View<int*, Kokkos::LayoutRight, memory_space>
             rows_idx("ddc_splines_coo_rows_idx", dense_matrix.extent(0) * dense_matrix.extent(1));
     Kokkos::View<int*, Kokkos::LayoutRight, memory_space>
             cols_idx("ddc_splines_coo_cols_idx", dense_matrix.extent(0) * dense_matrix.extent(1));
-    Kokkos::View<double*, Kokkos::LayoutRight, memory_space>
+    Kokkos::View<Real*, Kokkos::LayoutRight, memory_space>
             values("ddc_splines_coo_values", dense_matrix.extent(0) * dense_matrix.extent(1));
 
     Kokkos::DualView<std::size_t, Kokkos::LayoutRight, memory_space> n_nonzeros(
@@ -169,7 +169,7 @@ SplinesLinearProblem2x2Blocks<ExecSpace>::dense2coo(
             KOKKOS_LAMBDA(int const) {
                 for (int i = 0; i < dense_matrix.extent(0); ++i) {
                     for (int j = 0; j < dense_matrix.extent(1); ++j) {
-                        double const aij = dense_matrix(i, j);
+                        Real const aij = dense_matrix(i, j);
                         if (Kokkos::abs(aij) >= tol) {
                             rows_idx(n_nonzeros_device()) = i;
                             cols_idx(n_nonzeros_device()) = j;
@@ -200,7 +200,7 @@ void SplinesLinearProblem2x2Blocks<ExecSpace>::compute_schur_complement()
                     {0, 0},
                     {m_bottom_right_block->size(), m_bottom_right_block->size()}),
             [&](int const i, int const j) {
-                double val = 0.0;
+                Real val = 0.0;
                 for (int l = 0; l < m_top_left_block->size(); ++l) {
                     val += bottom_left_block(i, l) * top_right_block(l, j);
                 }

--- a/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.cpp
@@ -99,9 +99,8 @@ template <class ExecSpace>
 SplinesLinearProblem2x2Blocks<ExecSpace>::~SplinesLinearProblem2x2Blocks() = default;
 
 template <class ExecSpace>
-Real SplinesLinearProblem2x2Blocks<ExecSpace>::get_element(
-        std::size_t const i,
-        std::size_t const j) const
+Real SplinesLinearProblem2x2Blocks<ExecSpace>::get_element(std::size_t const i, std::size_t const j)
+        const
 {
     assert(i < size());
     assert(j < size());

--- a/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.hpp
@@ -88,7 +88,7 @@ public:
      */
     std::unique_ptr<Coo> dense2coo(
             Kokkos::View<Real const**, Kokkos::LayoutRight, memory_space> dense_matrix,
-            Real tol = 100 * Kokkos::Experimental::epsilon_v<Real>);
+            Real tol = 100 * std::numeric_limits<Real>::epsilon());
 
 private:
     /// @brief Compute the Schur complement delta - lambda*Q^-1*gamma.

--- a/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.hpp
@@ -88,7 +88,7 @@ public:
      */
     std::unique_ptr<Coo> dense2coo(
             Kokkos::View<Real const**, Kokkos::LayoutRight, memory_space> dense_matrix,
-            Real tol = 100 * std::numeric_limits<Real>::epsilon());
+            Real tol = 100 * Kokkos::Experimental::epsilon_v<Real>);
 
 private:
     /// @brief Compute the Schur complement delta - lambda*Q^-1*gamma.

--- a/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_2x2_blocks.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 #include <memory>
 
 #include <Kokkos_Core.hpp>
@@ -44,9 +45,9 @@ public:
 
 protected:
     std::unique_ptr<SplinesLinearProblem<ExecSpace>> m_top_left_block;
-    Kokkos::DualView<double**, Kokkos::LayoutRight, memory_space> m_top_right_block;
+    Kokkos::DualView<Real**, Kokkos::LayoutRight, memory_space> m_top_right_block;
     std::unique_ptr<Coo> m_top_right_block_coo;
-    Kokkos::DualView<double**, Kokkos::LayoutRight, memory_space> m_bottom_left_block;
+    Kokkos::DualView<Real**, Kokkos::LayoutRight, memory_space> m_bottom_left_block;
     std::unique_ptr<Coo> m_bottom_left_block_coo;
     std::unique_ptr<SplinesLinearProblem<ExecSpace>> m_bottom_right_block;
 
@@ -71,9 +72,9 @@ public:
 
     SplinesLinearProblem2x2Blocks& operator=(SplinesLinearProblem2x2Blocks&& rhs) = delete;
 
-    double get_element(std::size_t i, std::size_t j) const override;
+    Real get_element(std::size_t i, std::size_t j) const override;
 
-    void set_element(std::size_t i, std::size_t j, double aij) override;
+    void set_element(std::size_t i, std::size_t j, Real aij) override;
 
     /**
      * @brief Fill a COO version of a Dense matrix (remove zeros).
@@ -86,8 +87,8 @@ public:
      * @return The COO storage matrix filled with the non-zeros from dense_matrix.
      */
     std::unique_ptr<Coo> dense2coo(
-            Kokkos::View<double const**, Kokkos::LayoutRight, memory_space> dense_matrix,
-            double tol = 1e-14);
+            Kokkos::View<Real const**, Kokkos::LayoutRight, memory_space> dense_matrix,
+            Real tol = 100 * std::numeric_limits<Real>::epsilon());
 
 private:
     /// @brief Compute the Schur complement delta - lambda*Q^-1*gamma.

--- a/src/ddc/kernels/splines/splines_linear_problem_3x3_blocks.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_3x3_blocks.cpp
@@ -47,7 +47,7 @@ void SplinesLinearProblem3x3Blocks<ExecSpace>::adjust_indices(std::size_t& i, st
 }
 
 template <class ExecSpace>
-double SplinesLinearProblem3x3Blocks<ExecSpace>::get_element(std::size_t i, std::size_t j) const
+Real SplinesLinearProblem3x3Blocks<ExecSpace>::get_element(std::size_t i, std::size_t j) const
 {
     adjust_indices(i, j);
     return SplinesLinearProblem2x2Blocks<ExecSpace>::get_element(i, j);
@@ -57,7 +57,7 @@ template <class ExecSpace>
 void SplinesLinearProblem3x3Blocks<ExecSpace>::set_element(
         std::size_t i,
         std::size_t j,
-        double const aij)
+        Real const aij)
 {
     adjust_indices(i, j);
     SplinesLinearProblem2x2Blocks<ExecSpace>::set_element(i, j, aij);

--- a/src/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_3x3_blocks.hpp
@@ -72,9 +72,9 @@ private:
     void adjust_indices(std::size_t& i, std::size_t& j) const;
 
 public:
-    double get_element(std::size_t i, std::size_t j) const override;
+    Real get_element(std::size_t i, std::size_t j) const override;
 
-    void set_element(std::size_t i, std::size_t j, double aij) override;
+    void set_element(std::size_t i, std::size_t j, Real aij) override;
 
 private:
     /**

--- a/src/ddc/kernels/splines/splines_linear_problem_band.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_band.cpp
@@ -8,8 +8,10 @@
 #    include <cmath>
 #endif
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 #include <Kokkos_Core.hpp>
 
@@ -60,7 +62,7 @@ std::size_t SplinesLinearProblemBand<ExecSpace>::band_storage_row_index(
 }
 
 template <class ExecSpace>
-double SplinesLinearProblemBand<ExecSpace>::get_element(std::size_t const i, std::size_t const j)
+Real SplinesLinearProblemBand<ExecSpace>::get_element(std::size_t const i, std::size_t const j)
         const
 {
     assert(i < size());
@@ -85,7 +87,7 @@ template <class ExecSpace>
 void SplinesLinearProblemBand<ExecSpace>::set_element(
         std::size_t const i,
         std::size_t const j,
-        double const aij)
+        Real const aij)
 {
     assert(i < size());
     assert(j < size());
@@ -101,25 +103,39 @@ void SplinesLinearProblemBand<ExecSpace>::set_element(
         && i < std::min(size(), j + m_kl + 1)) {
         m_q.view_host()(band_storage_row_index(i, j), j) = aij;
     } else {
-        assert(std::fabs(aij) < 1e-15);
+        assert(std::fabs(aij) < 10 * std::numeric_limits<Real>::epsilon());
     }
 }
 
 template <class ExecSpace>
 void SplinesLinearProblemBand<ExecSpace>::setup_solver()
 {
-    int const info = LAPACKE_dgbtrf(
-            LAPACK_ROW_MAJOR,
-            size(),
-            size(),
-            m_kl,
-            m_ku,
-            m_q.view_host().data(),
-            m_q.view_host().stride(
-                    0), // m_q.view_host().stride(0) if LAPACK_ROW_MAJOR, m_q.view_host().stride(1) if LAPACK_COL_MAJOR
-            m_ipiv.view_host().data());
+    int info;
+    if constexpr (std::is_same_v<Real, float>) {
+        info = LAPACKE_sgbtrf(
+                LAPACK_ROW_MAJOR,
+                size(),
+                size(),
+                m_kl,
+                m_ku,
+                m_q.view_host().data(),
+                m_q.view_host().stride(
+                        0), // m_q.view_host().stride(0) if LAPACK_ROW_MAJOR, m_q.view_host().stride(1) if LAPACK_COL_MAJOR
+                m_ipiv.view_host().data());
+    } else {
+        info = LAPACKE_dgbtrf(
+                LAPACK_ROW_MAJOR,
+                size(),
+                size(),
+                m_kl,
+                m_ku,
+                m_q.view_host().data(),
+                m_q.view_host().stride(
+                        0), // m_q.view_host().stride(0) if LAPACK_ROW_MAJOR, m_q.view_host().stride(1) if LAPACK_COL_MAJOR
+                m_ipiv.view_host().data());
+    }
     if (info != 0) {
-        throw std::runtime_error("LAPACKE_dgbtrf failed with error code " + std::to_string(info));
+        throw std::runtime_error("LAPACKE_gbtrf failed with error code " + std::to_string(info));
     }
 
     // Convert 1-based index to 0-based index

--- a/src/ddc/kernels/splines/splines_linear_problem_band.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_band.cpp
@@ -103,7 +103,7 @@ void SplinesLinearProblemBand<ExecSpace>::set_element(
         && i < std::min(size(), j + m_kl + 1)) {
         m_q.view_host()(band_storage_row_index(i, j), j) = aij;
     } else {
-        assert(std::fabs(aij) < 10 * Kokkos::Experimental::epsilon_v<Real>);
+        assert(std::fabs(aij) < 10 * std::numeric_limits<Real>::epsilon());
     }
 }
 

--- a/src/ddc/kernels/splines/splines_linear_problem_band.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_band.cpp
@@ -103,7 +103,7 @@ void SplinesLinearProblemBand<ExecSpace>::set_element(
         && i < std::min(size(), j + m_kl + 1)) {
         m_q.view_host()(band_storage_row_index(i, j), j) = aij;
     } else {
-        assert(std::fabs(aij) < 10 * std::numeric_limits<Real>::epsilon());
+        assert(std::fabs(aij) < 10 * Kokkos::Experimental::epsilon_v<Real>);
     }
 }
 

--- a/src/ddc/kernels/splines/splines_linear_problem_band.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_band.hpp
@@ -38,7 +38,7 @@ public:
 protected:
     std::size_t m_kl; // no. of subdiagonals
     std::size_t m_ku; // no. of superdiagonals
-    Kokkos::DualView<double**, Kokkos::LayoutRight, memory_space> m_q; // band matrix representation
+    Kokkos::DualView<Real**, Kokkos::LayoutRight, memory_space> m_q; // band matrix representation
     Kokkos::DualView<int*, memory_space> m_ipiv; // pivot indices
 
 public:
@@ -65,9 +65,9 @@ private:
     std::size_t band_storage_row_index(std::size_t i, std::size_t j) const;
 
 public:
-    double get_element(std::size_t i, std::size_t j) const override;
+    Real get_element(std::size_t i, std::size_t j) const override;
 
-    void set_element(std::size_t i, std::size_t j, double aij) override;
+    void set_element(std::size_t i, std::size_t j, Real aij) override;
 
     /**
      * @brief Perform a pre-process operation on the solver. Must be called after filling the matrix.

--- a/src/ddc/kernels/splines/splines_linear_problem_dense.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_dense.cpp
@@ -6,6 +6,7 @@
 #include <cstddef>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 
 #include <Kokkos_Core.hpp>
 
@@ -44,7 +45,7 @@ template <class ExecSpace>
 SplinesLinearProblemDense<ExecSpace>::~SplinesLinearProblemDense() = default;
 
 template <class ExecSpace>
-double SplinesLinearProblemDense<ExecSpace>::get_element(std::size_t const i, std::size_t const j)
+Real SplinesLinearProblemDense<ExecSpace>::get_element(std::size_t const i, std::size_t const j)
         const
 {
     assert(i < size());
@@ -56,7 +57,7 @@ template <class ExecSpace>
 void SplinesLinearProblemDense<ExecSpace>::set_element(
         std::size_t const i,
         std::size_t const j,
-        double const aij)
+        Real const aij)
 {
     assert(i < size());
     assert(j < size());
@@ -66,15 +67,26 @@ void SplinesLinearProblemDense<ExecSpace>::set_element(
 template <class ExecSpace>
 void SplinesLinearProblemDense<ExecSpace>::setup_solver()
 {
-    int const info = LAPACKE_dgetrf(
-            LAPACK_ROW_MAJOR,
-            size(),
-            size(),
-            m_a.view_host().data(),
-            size(),
-            m_ipiv.view_host().data());
+    int info;
+    if constexpr (std::is_same_v<Real, float>) {
+        info = LAPACKE_sgetrf(
+                LAPACK_ROW_MAJOR,
+                size(),
+                size(),
+                m_a.view_host().data(),
+                size(),
+                m_ipiv.view_host().data());
+    } else {
+        info = LAPACKE_dgetrf(
+                LAPACK_ROW_MAJOR,
+                size(),
+                size(),
+                m_a.view_host().data(),
+                size(),
+                m_ipiv.view_host().data());
+    }
     if (info != 0) {
-        throw std::runtime_error("LAPACKE_dgetrf failed with error code " + std::to_string(info));
+        throw std::runtime_error("LAPACKE_getrf failed with error code " + std::to_string(info));
     }
 
     // Convert 1-based index to 0-based index

--- a/src/ddc/kernels/splines/splines_linear_problem_dense.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_dense.hpp
@@ -29,7 +29,7 @@ public:
     using SplinesLinearProblem<ExecSpace>::size;
 
 protected:
-    Kokkos::DualView<double**, Kokkos::LayoutRight, memory_space> m_a;
+    Kokkos::DualView<Real**, Kokkos::LayoutRight, memory_space> m_a;
     Kokkos::DualView<int*, memory_space> m_ipiv;
 
 public:
@@ -50,9 +50,9 @@ public:
 
     SplinesLinearProblemDense& operator=(SplinesLinearProblemDense&& rhs) = delete;
 
-    double get_element(std::size_t i, std::size_t j) const override;
+    Real get_element(std::size_t i, std::size_t j) const override;
 
-    void set_element(std::size_t i, std::size_t j, double aij) override;
+    void set_element(std::size_t i, std::size_t j, Real aij) override;
 
     /**
      * @brief Perform a pre-process operation on the solver. Must be called after filling the matrix.

--- a/src/ddc/kernels/splines/splines_linear_problem_pds_band.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_pds_band.cpp
@@ -78,7 +78,7 @@ void SplinesLinearProblemPDSBand<ExecSpace>::set_element(
     if (j - i < m_q.extent(0)) {
         m_q.view_host()(j - i, i) = aij;
     } else {
-        assert(std::fabs(aij) < 10 * std::numeric_limits<Real>::epsilon());
+        assert(std::fabs(aij) < 10 * Kokkos::Experimental::epsilon_v<Real>);
     }
 }
 

--- a/src/ddc/kernels/splines/splines_linear_problem_pds_band.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_pds_band.cpp
@@ -7,8 +7,10 @@
 #    include <cmath>
 #endif
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include <Kokkos_Core.hpp>
@@ -43,7 +45,7 @@ template <class ExecSpace>
 SplinesLinearProblemPDSBand<ExecSpace>::~SplinesLinearProblemPDSBand() = default;
 
 template <class ExecSpace>
-double SplinesLinearProblemPDSBand<ExecSpace>::get_element(std::size_t i, std::size_t j) const
+Real SplinesLinearProblemPDSBand<ExecSpace>::get_element(std::size_t i, std::size_t j) const
 {
     assert(i < size());
     assert(j < size());
@@ -64,7 +66,7 @@ template <class ExecSpace>
 void SplinesLinearProblemPDSBand<ExecSpace>::set_element(
         std::size_t i,
         std::size_t j,
-        double const aij)
+        Real const aij)
 {
     assert(i < size());
     assert(j < size());
@@ -76,24 +78,37 @@ void SplinesLinearProblemPDSBand<ExecSpace>::set_element(
     if (j - i < m_q.extent(0)) {
         m_q.view_host()(j - i, i) = aij;
     } else {
-        assert(std::fabs(aij) < 1e-15);
+        assert(std::fabs(aij) < 10 * std::numeric_limits<Real>::epsilon());
     }
 }
 
 template <class ExecSpace>
 void SplinesLinearProblemPDSBand<ExecSpace>::setup_solver()
 {
-    int const info = LAPACKE_dpbtrf(
-            LAPACK_ROW_MAJOR,
-            'L',
-            size(),
-            m_q.extent(0) - 1,
-            m_q.view_host().data(),
-            m_q.view_host().stride(
-                    0) // m_q.view_host().stride(0) if LAPACK_ROW_MAJOR, m_q.view_host().stride(1) if LAPACK_COL_MAJOR
-    );
+    int info;
+    if constexpr (std::is_same_v<Real, float>) {
+        info = LAPACKE_spbtrf(
+                LAPACK_ROW_MAJOR,
+                'L',
+                size(),
+                m_q.extent(0) - 1,
+                m_q.view_host().data(),
+                m_q.view_host().stride(
+                        0) // m_q.view_host().stride(0) if LAPACK_ROW_MAJOR, m_q.view_host().stride(1) if LAPACK_COL_MAJOR
+        );
+    } else {
+        info = LAPACKE_dpbtrf(
+                LAPACK_ROW_MAJOR,
+                'L',
+                size(),
+                m_q.extent(0) - 1,
+                m_q.view_host().data(),
+                m_q.view_host().stride(
+                        0) // m_q.view_host().stride(0) if LAPACK_ROW_MAJOR, m_q.view_host().stride(1) if LAPACK_COL_MAJOR
+        );
+    }
     if (info != 0) {
-        throw std::runtime_error("LAPACKE_dpbtrf failed with error code " + std::to_string(info));
+        throw std::runtime_error("LAPACKE_pbtrf failed with error code " + std::to_string(info));
     }
 
     // Push on device

--- a/src/ddc/kernels/splines/splines_linear_problem_pds_band.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_pds_band.cpp
@@ -78,7 +78,7 @@ void SplinesLinearProblemPDSBand<ExecSpace>::set_element(
     if (j - i < m_q.extent(0)) {
         m_q.view_host()(j - i, i) = aij;
     } else {
-        assert(std::fabs(aij) < 10 * Kokkos::Experimental::epsilon_v<Real>);
+        assert(std::fabs(aij) < 10 * std::numeric_limits<Real>::epsilon());
     }
 }
 

--- a/src/ddc/kernels/splines/splines_linear_problem_pds_band.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_pds_band.hpp
@@ -35,7 +35,7 @@ public:
     using SplinesLinearProblem<ExecSpace>::size;
 
 protected:
-    Kokkos::DualView<double**, Kokkos::LayoutRight, memory_space>
+    Kokkos::DualView<Real**, Kokkos::LayoutRight, memory_space>
             m_q; // pds band matrix representation
 
 public:
@@ -57,9 +57,9 @@ public:
 
     SplinesLinearProblemPDSBand& operator=(SplinesLinearProblemPDSBand&& rhs) = delete;
 
-    double get_element(std::size_t i, std::size_t j) const override;
+    Real get_element(std::size_t i, std::size_t j) const override;
 
-    void set_element(std::size_t i, std::size_t j, double aij) override;
+    void set_element(std::size_t i, std::size_t j, Real aij) override;
 
     /**
      * @brief Perform a pre-process operation on the solver. Must be called after filling the matrix.

--- a/src/ddc/kernels/splines/splines_linear_problem_pds_tridiag.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_pds_tridiag.cpp
@@ -75,7 +75,7 @@ void SplinesLinearProblemPDSTridiag<ExecSpace>::set_element(
     if (j - i < 2) {
         m_q.view_host()(j - i, i) = aij;
     } else {
-        assert(std::fabs(aij) < 10 * Kokkos::Experimental::epsilon_v<Real>);
+        assert(std::fabs(aij) < 10 * std::numeric_limits<Real>::epsilon());
     }
 }
 

--- a/src/ddc/kernels/splines/splines_linear_problem_pds_tridiag.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_pds_tridiag.cpp
@@ -7,8 +7,10 @@
 #    include <cmath>
 #endif
 #include <cstddef>
+#include <limits>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include <Kokkos_Core.hpp>
@@ -40,7 +42,7 @@ template <class ExecSpace>
 SplinesLinearProblemPDSTridiag<ExecSpace>::~SplinesLinearProblemPDSTridiag() = default;
 
 template <class ExecSpace>
-double SplinesLinearProblemPDSTridiag<ExecSpace>::get_element(std::size_t i, std::size_t j) const
+Real SplinesLinearProblemPDSTridiag<ExecSpace>::get_element(std::size_t i, std::size_t j) const
 {
     assert(i < size());
     assert(j < size());
@@ -61,7 +63,7 @@ template <class ExecSpace>
 void SplinesLinearProblemPDSTridiag<ExecSpace>::set_element(
         std::size_t i,
         std::size_t j,
-        double const aij)
+        Real const aij)
 {
     assert(i < size());
     assert(j < size());
@@ -73,19 +75,27 @@ void SplinesLinearProblemPDSTridiag<ExecSpace>::set_element(
     if (j - i < 2) {
         m_q.view_host()(j - i, i) = aij;
     } else {
-        assert(std::fabs(aij) < 1e-15);
+        assert(std::fabs(aij) < 10 * std::numeric_limits<Real>::epsilon());
     }
 }
 
 template <class ExecSpace>
 void SplinesLinearProblemPDSTridiag<ExecSpace>::setup_solver()
 {
-    int const info = LAPACKE_dpttrf(
-            size(),
-            m_q.view_host().data(),
-            m_q.view_host().data() + m_q.view_host().stride(0));
+    int info;
+    if constexpr (std::is_same_v<Real, float>) {
+        info = LAPACKE_spttrf(
+                size(),
+                m_q.view_host().data(),
+                m_q.view_host().data() + m_q.view_host().stride(0));
+    } else {
+        info = LAPACKE_dpttrf(
+                size(),
+                m_q.view_host().data(),
+                m_q.view_host().data() + m_q.view_host().stride(0));
+    }
     if (info != 0) {
-        throw std::runtime_error("LAPACKE_dpttrf failed with error code " + std::to_string(info));
+        throw std::runtime_error("LAPACKE_pttrf failed with error code " + std::to_string(info));
     }
 
     // Push on device

--- a/src/ddc/kernels/splines/splines_linear_problem_pds_tridiag.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_pds_tridiag.cpp
@@ -75,7 +75,7 @@ void SplinesLinearProblemPDSTridiag<ExecSpace>::set_element(
     if (j - i < 2) {
         m_q.view_host()(j - i, i) = aij;
     } else {
-        assert(std::fabs(aij) < 10 * std::numeric_limits<Real>::epsilon());
+        assert(std::fabs(aij) < 10 * Kokkos::Experimental::epsilon_v<Real>);
     }
 }
 

--- a/src/ddc/kernels/splines/splines_linear_problem_pds_tridiag.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_pds_tridiag.hpp
@@ -35,7 +35,7 @@ public:
     using SplinesLinearProblem<ExecSpace>::size;
 
 protected:
-    Kokkos::DualView<double**, Kokkos::LayoutRight, memory_space>
+    Kokkos::DualView<Real**, Kokkos::LayoutRight, memory_space>
             m_q; // pds tridiagonal matrix representation
 
 public:
@@ -56,9 +56,9 @@ public:
 
     SplinesLinearProblemPDSTridiag& operator=(SplinesLinearProblemPDSTridiag&& rhs) = delete;
 
-    double get_element(std::size_t i, std::size_t j) const override;
+    Real get_element(std::size_t i, std::size_t j) const override;
 
-    void set_element(std::size_t i, std::size_t j, double aij) override;
+    void set_element(std::size_t i, std::size_t j, Real aij) override;
 
     /**
      * @brief Perform a pre-process operation on the solver. Must be called after filling the matrix.

--- a/src/ddc/kernels/splines/splines_linear_problem_sparse.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_sparse.cpp
@@ -193,7 +193,7 @@ public:
         // Create the solver factory
         std::shared_ptr const residual_criterion
                 = gko::stop::ResidualNorm<Real>::build()
-                          .with_reduction_factor(10 * Kokkos::Experimental::epsilon_v<Real>)
+                          .with_reduction_factor(10 * std::numeric_limits<Real>::epsilon())
                           .on(gko_exec);
 
         std::shared_ptr const iterations_criterion

--- a/src/ddc/kernels/splines/splines_linear_problem_sparse.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_sparse.cpp
@@ -193,7 +193,7 @@ public:
         // Create the solver factory
         std::shared_ptr const residual_criterion
                 = gko::stop::ResidualNorm<Real>::build()
-                          .with_reduction_factor(10 * std::numeric_limits<Real>::epsilon())
+                          .with_reduction_factor(10 * Kokkos::Experimental::epsilon_v<Real>)
                           .on(gko_exec);
 
         std::shared_ptr const iterations_criterion

--- a/src/ddc/kernels/splines/splines_linear_problem_sparse.cpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_sparse.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -135,13 +136,13 @@ public:
     using MultiRHS = SplinesLinearProblem<ExecSpace>::MultiRHS;
 
 private:
-    using matrix_sparse_type = gko::matrix::Csr<double, gko::int32>;
-    using solver_type = gko::solver::Bicgstab<double>;
+    using matrix_sparse_type = gko::matrix::Csr<Real, gko::int32>;
+    using solver_type = gko::solver::Bicgstab<Real>;
 
 private:
     std::size_t m_mat_size;
 
-    std::unique_ptr<gko::matrix::Dense<double>> m_matrix_dense;
+    std::unique_ptr<gko::matrix::Dense<Real>> m_matrix_dense;
 
     std::shared_ptr<matrix_sparse_type> m_matrix_sparse;
 
@@ -164,17 +165,17 @@ public:
     {
         std::shared_ptr const gko_exec = gko::ext::kokkos::create_executor(ExecSpace());
         m_matrix_dense = gko::matrix::Dense<
-                double>::create(gko_exec->get_master(), gko::dim<2>(mat_size, mat_size));
+                Real>::create(gko_exec->get_master(), gko::dim<2>(mat_size, mat_size));
         m_matrix_dense->fill(0);
         m_matrix_sparse = matrix_sparse_type::create(gko_exec, gko::dim<2>(mat_size, mat_size));
     }
 
-    double get_element(std::size_t const i, std::size_t const j) const
+    Real get_element(std::size_t const i, std::size_t const j) const
     {
         return m_matrix_dense->at(i, j);
     }
 
-    void set_element(std::size_t const i, std::size_t const j, double const aij)
+    void set_element(std::size_t const i, std::size_t const j, Real const aij)
     {
         m_matrix_dense->at(i, j) = aij;
     }
@@ -182,7 +183,7 @@ public:
     void setup_solver()
     {
         // Remove zeros
-        gko::matrix_data<double> matrix_data(gko::dim<2>(m_mat_size, m_mat_size));
+        gko::matrix_data<Real> matrix_data(gko::dim<2>(m_mat_size, m_mat_size));
         m_matrix_dense->write(matrix_data);
         m_matrix_dense.reset();
         matrix_data.remove_zeros();
@@ -191,14 +192,15 @@ public:
 
         // Create the solver factory
         std::shared_ptr const residual_criterion
-                = gko::stop::ResidualNorm<double>::build().with_reduction_factor(1e-15).on(
-                        gko_exec);
+                = gko::stop::ResidualNorm<Real>::build()
+                          .with_reduction_factor(10 * std::numeric_limits<Real>::epsilon())
+                          .on(gko_exec);
 
         std::shared_ptr const iterations_criterion
                 = gko::stop::Iteration::build().with_max_iters(1000U).on(gko_exec);
 
         std::shared_ptr const preconditioner
-                = gko::preconditioner::Jacobi<double>::build()
+                = gko::preconditioner::Jacobi<Real>::build()
                           .with_max_block_size(m_preconditioner_max_block_size)
                           .on(gko_exec);
 
@@ -228,7 +230,7 @@ public:
         assert(b.extent(0) == m_mat_size);
 
         std::shared_ptr const gko_exec = m_solver->get_executor();
-        std::shared_ptr const convergence_logger = gko::log::Convergence<double>::create();
+        std::shared_ptr const convergence_logger = gko::log::Convergence<Real>::create();
 
         std::size_t const main_chunk_size = std::min(m_cols_per_chunk, b.extent(1));
 
@@ -293,13 +295,13 @@ template <class ExecSpace>
 SplinesLinearProblemSparse<ExecSpace>::~SplinesLinearProblemSparse() = default;
 
 template <class ExecSpace>
-double SplinesLinearProblemSparse<ExecSpace>::get_element(std::size_t i, std::size_t j) const
+Real SplinesLinearProblemSparse<ExecSpace>::get_element(std::size_t i, std::size_t j) const
 {
     return m_impl->get_element(i, j);
 }
 
 template <class ExecSpace>
-void SplinesLinearProblemSparse<ExecSpace>::set_element(std::size_t i, std::size_t j, double aij)
+void SplinesLinearProblemSparse<ExecSpace>::set_element(std::size_t i, std::size_t j, Real aij)
 {
     m_impl->set_element(i, j, aij);
 }

--- a/src/ddc/kernels/splines/splines_linear_problem_sparse.hpp
+++ b/src/ddc/kernels/splines/splines_linear_problem_sparse.hpp
@@ -59,16 +59,16 @@ public:
 
     SplinesLinearProblemSparse& operator=(SplinesLinearProblemSparse&& rhs) = delete;
 
-    double get_element(std::size_t i, std::size_t j) const override;
+    Real get_element(std::size_t i, std::size_t j) const override;
 
-    void set_element(std::size_t i, std::size_t j, double aij) override;
+    void set_element(std::size_t i, std::size_t j, Real aij) override;
 
     /**
      * @brief Perform a pre-process operation on the solver. Must be called after filling the matrix.
      *
      * Removes the zeros from the CSR object and instantiate a Ginkgo solver. It also constructs a transposed version of the solver.
      *
-     * The stopping criterion is a reduction factor ||Ax-b||/||b||<1e-15 with 1000 maximum iterations.
+     * The stopping criterion is a reduction factor ||Ax-b||/||b||<10*epsilon(Real) with 1000 maximum iterations.
      */
     void setup_solver() override;
 

--- a/src/ddc/kernels/splines/view.hpp
+++ b/src/ddc/kernels/splines/view.hpp
@@ -8,6 +8,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include <ddc/real_type.hpp>
+
 namespace ddc::detail {
 
 template <std::size_t N, class ElementType, bool CONTIGUOUS = true>
@@ -51,16 +53,16 @@ using View1D = ViewND<1, ElementType>;
 template <class ElementType>
 using View2D = ViewND<2, ElementType>;
 
-using DSpan1D = ddc::Span1D<double>;
+using DSpan1D = ddc::Span1D<Real>;
 
-using DSpan2D = ddc::Span2D<double>;
+using DSpan2D = ddc::Span2D<Real>;
 
-using CDSpan1D = ddc::Span1D<double const>;
+using CDSpan1D = ddc::Span1D<Real const>;
 
-using CDSpan2D = ddc::Span2D<double const>;
+using CDSpan2D = ddc::Span2D<Real const>;
 
-using DView1D = View1D<double>;
+using DView1D = View1D<Real>;
 
-using DView2D = View2D<double>;
+using DView2D = View2D<Real>;
 
 } // namespace ddc

--- a/src/ddc/kernels/splines/view.hpp
+++ b/src/ddc/kernels/splines/view.hpp
@@ -6,9 +6,9 @@
 
 #include <cstddef>
 
-#include <Kokkos_Core.hpp>
-
 #include <ddc/real_type.hpp>
+
+#include <Kokkos_Core.hpp>
 
 namespace ddc::detail {
 

--- a/tests/splines/1d_spline_evaluator_derivatives.cpp
+++ b/tests/splines/1d_spline_evaluator_derivatives.cpp
@@ -86,7 +86,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -142,17 +142,17 @@ void test_deriv(
 
     auto const order = ddc::select_or(deriv_order, ddc::DiscreteElement<ddc::Deriv<I>>(0)).uid();
 
-    double const max_norm_error_diff = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(domain::discrete_element_type const e) {
                 Coord<I> const x = ddc::coordinate(ddc::DiscreteElement<DDimI>(e));
                 return Kokkos::abs(spline_eval_deriv(e) - evaluator.deriv(x, order));
             });
 
-    double const max_norm_diff = evaluator.max_norm(order);
+    ddc::Real const max_norm_diff = evaluator.max_norm(order);
 
     SplineErrorBounds<evaluator_type<DDimI>> const error_bounds(evaluator);
 
@@ -163,7 +163,7 @@ void test_deriv(
                                 std::array<ddc::DiscreteElementType, 1> {order},
                                 {dx<I>(ncells)},
                                 {s_degree}),
-                        1e-11 * max_norm_diff));
+                        static_cast<ddc::Real>(1e-11) * max_norm_diff));
 }
 
 template <
@@ -242,14 +242,14 @@ void TestSplineEvaluator1dDerivatives()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<DDimI> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -257,7 +257,7 @@ void TestSplineEvaluator1dDerivatives()
             KOKKOS_LAMBDA(DElem<DDims...> const e) { vals(e) = vals_1d(DElem<DDimI>(e)); });
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -288,7 +288,7 @@ void TestSplineEvaluator1dDerivatives()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv = spline_eval_deriv_alloc.span_view();
 
     launch_deriv_tests(

--- a/tests/splines/1d_spline_evaluator_derivatives.cpp
+++ b/tests/splines/1d_spline_evaluator_derivatives.cpp
@@ -145,7 +145,7 @@ void test_deriv(
     ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(domain::discrete_element_type const e) {
                 Coord<I> const x = ddc::coordinate(ddc::DiscreteElement<DDimI>(e));

--- a/tests/splines/2d_spline_evaluator_derivatives.cpp
+++ b/tests/splines/2d_spline_evaluator_derivatives.cpp
@@ -87,7 +87,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -146,18 +146,18 @@ void test_deriv(
     auto const order1 = ddc::select_or(deriv_order, ddc::DiscreteElement<ddc::Deriv<I1>>(0)).uid();
     auto const order2 = ddc::select_or(deriv_order, ddc::DiscreteElement<ddc::Deriv<I2>>(0)).uid();
 
-    double const max_norm_error_diff = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(domain::discrete_element_type const e) {
                 Coord<I1> const x = ddc::coordinate(ddc::DiscreteElement<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(ddc::DiscreteElement<DDimI2>(e));
                 return Kokkos::abs(spline_eval_deriv(e) - evaluator.deriv(x, y, order1, order2));
             });
 
-    double const max_norm_diff = evaluator.max_norm(order1, order2);
+    ddc::Real const max_norm_diff = evaluator.max_norm(order1, order2);
 
     SplineErrorBounds<evaluator_type<DDimI1, DDimI2>> const error_bounds(evaluator);
 
@@ -168,7 +168,7 @@ void test_deriv(
                                 std::array<ddc::DiscreteElementType, 2> {order1, order2},
                                 {dx<I1>(ncells), dx<I2>(ncells)},
                                 {s_degree, s_degree}),
-                        1e-11 * max_norm_diff));
+                        static_cast<ddc::Real>(1e-11) * max_norm_diff));
 }
 
 template <
@@ -276,14 +276,14 @@ void TestSplineEvaluator2dDerivatives()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<DDimI1, DDimI2> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -293,7 +293,7 @@ void TestSplineEvaluator2dDerivatives()
             });
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -335,7 +335,7 @@ void TestSplineEvaluator2dDerivatives()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv = spline_eval_deriv_alloc.span_view();
 
     launch_deriv_tests(

--- a/tests/splines/2d_spline_evaluator_derivatives.cpp
+++ b/tests/splines/2d_spline_evaluator_derivatives.cpp
@@ -149,7 +149,7 @@ void test_deriv(
     ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(domain::discrete_element_type const e) {
                 Coord<I1> const x = ddc::coordinate(ddc::DiscreteElement<DDimI1>(e));

--- a/tests/splines/3d_spline_evaluator_derivatives.cpp
+++ b/tests/splines/3d_spline_evaluator_derivatives.cpp
@@ -94,7 +94,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -156,11 +156,11 @@ void test_deriv(
     auto const order2 = ddc::select_or(deriv_order, ddc::DiscreteElement<ddc::Deriv<I2>>(0)).uid();
     auto const order3 = ddc::select_or(deriv_order, ddc::DiscreteElement<ddc::Deriv<I3>>(0)).uid();
 
-    double const max_norm_error_diff = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(domain::discrete_element_type const e) {
                 Coord<I1> const x = ddc::coordinate(ddc::DiscreteElement<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(ddc::DiscreteElement<DDimI2>(e));
@@ -169,7 +169,7 @@ void test_deriv(
                         spline_eval_deriv(e) - evaluator.deriv(x, y, z, order1, order2, order3));
             });
 
-    double const max_norm_diff = evaluator.max_norm(order1, order2, order3);
+    ddc::Real const max_norm_diff = evaluator.max_norm(order1, order2, order3);
 
     SplineErrorBounds<evaluator_type<DDimI1, DDimI2, DDimI3>> const error_bounds(evaluator);
 
@@ -180,7 +180,7 @@ void test_deriv(
                                 std::array<ddc::DiscreteElementType, 3> {order1, order2, order3},
                                 {dx<I1>(ncells), dx<I2>(ncells), dx<I3>(ncells)},
                                 {s_degree, s_degree, s_degree}),
-                        1e-11 * max_norm_diff));
+                        static_cast<ddc::Real>(1e-11) * max_norm_diff));
 }
 
 template <
@@ -332,14 +332,14 @@ void TestSplineEvaluator3dDerivatives()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<DDimI1, DDimI2, DDimI3> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -349,7 +349,7 @@ void TestSplineEvaluator3dDerivatives()
             });
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -399,7 +399,7 @@ void TestSplineEvaluator3dDerivatives()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv = spline_eval_deriv_alloc.span_view();
 
     launch_deriv_tests(

--- a/tests/splines/3d_spline_evaluator_derivatives.cpp
+++ b/tests/splines/3d_spline_evaluator_derivatives.cpp
@@ -159,7 +159,7 @@ void test_deriv(
     ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(domain::discrete_element_type const e) {
                 Coord<I1> const x = ddc::coordinate(ddc::DiscreteElement<DDimI1>(e));

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -498,7 +498,7 @@ void TestBatched2dSpline()
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
@@ -506,7 +506,7 @@ void TestBatched2dSpline()
     ddc::Real const max_norm_error_diff1 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -516,7 +516,7 @@ void TestBatched2dSpline()
     ddc::Real const max_norm_error_diff2 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv2.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -526,7 +526,7 @@ void TestBatched2dSpline()
     ddc::Real const max_norm_error_diff12 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -340,13 +340,17 @@ void TestBatched2dSpline()
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs_lhs = derivs_mixed_lhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs_lhs = derivs_mixed_rhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs_rhs = derivs_mixed_lhs_rhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs_rhs = derivs_mixed_rhs_rhs_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {

--- a/tests/splines/batched_2d_spline_builder.cpp
+++ b/tests/splines/batched_2d_spline_builder.cpp
@@ -121,7 +121,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -218,14 +218,14 @@ void TestBatched2dSpline()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<DDimI1, DDimI2> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -236,12 +236,12 @@ void TestBatched2dSpline()
 
 #if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
-    ddc::Chunk derivs_1d_lhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_1d_lhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_1d_lhs = derivs_1d_lhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs_1d_lhs1_host_alloc(
                 ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_domain1, interpolation_domain2),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_1d_lhs1_host = derivs_1d_lhs1_host_alloc.span_view();
         ddc::host_for_each(
                 derivs_1d_lhs1_host.domain(),
@@ -262,12 +262,12 @@ void TestBatched2dSpline()
                 });
     }
 
-    ddc::Chunk derivs_1d_rhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_1d_rhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_1d_rhs = derivs_1d_rhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs_1d_rhs1_host_alloc(
                 ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_domain1, interpolation_domain2),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_1d_rhs1_host = derivs_1d_rhs1_host_alloc.span_view();
         ddc::host_for_each(
                 derivs_1d_rhs1_host.domain(),
@@ -288,12 +288,12 @@ void TestBatched2dSpline()
                 });
     }
 
-    ddc::Chunk derivs2_lhs_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs2_lhs_alloc(dom_derivs2, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs2_lhs = derivs2_lhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs2_lhs1_host_alloc(
                 ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs2_lhs1_host = derivs2_lhs1_host_alloc.span_view();
         ddc::host_for_each(
                 derivs2_lhs1_host.domain(),
@@ -314,12 +314,12 @@ void TestBatched2dSpline()
                 });
     }
 
-    ddc::Chunk derivs2_rhs_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs2_rhs_alloc(dom_derivs2, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs2_rhs = derivs2_rhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs2_rhs1_host_alloc(
                 ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs2_rhs1_host = derivs2_rhs1_host_alloc.span_view();
         ddc::host_for_each(
                 derivs2_rhs1_host.domain(),
@@ -340,26 +340,26 @@ void TestBatched2dSpline()
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs_lhs = derivs_mixed_lhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs_lhs = derivs_mixed_rhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs_rhs = derivs_mixed_lhs_rhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs_rhs = derivs_mixed_rhs_rhs_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs_lhs1_host
                 = derivs_mixed_lhs_lhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs_lhs1_host
                 = derivs_mixed_rhs_lhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs_rhs1_host
                 = derivs_mixed_lhs_rhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs_rhs1_host
                 = derivs_mixed_rhs_rhs1_host_alloc.span_view();
 
@@ -403,7 +403,7 @@ void TestBatched2dSpline()
 #endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -463,13 +463,13 @@ void TestBatched2dSpline()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
-    ddc::Chunk spline_eval_deriv1_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv1_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv1 = spline_eval_deriv1_alloc.span_view();
-    ddc::Chunk spline_eval_deriv2_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv2_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv2 = spline_eval_deriv2_alloc.span_view();
-    ddc::Chunk spline_eval_deriv12_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv12_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv12 = spline_eval_deriv12_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -491,39 +491,39 @@ void TestBatched2dSpline()
                    coef.span_cview());
 
     // Checking errors (we recover the initial values)
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
             });
-    double const max_norm_error_diff1 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff1 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 return Kokkos::abs(spline_eval_deriv1(e) - evaluator.deriv(x, y, 1, 0));
             });
-    double const max_norm_error_diff2 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff2 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv2.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 return Kokkos::abs(spline_eval_deriv2(e) - evaluator.deriv(x, y, 0, 1));
             });
-    double const max_norm_error_diff12 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff12 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
@@ -531,10 +531,10 @@ void TestBatched2dSpline()
             });
 
 
-    double const max_norm = evaluator.max_norm();
-    double const max_norm_diff1 = evaluator.max_norm(1, 0);
-    double const max_norm_diff2 = evaluator.max_norm(0, 1);
-    double const max_norm_diff12 = evaluator.max_norm(1, 1);
+    ddc::Real const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm_diff1 = evaluator.max_norm(1, 0);
+    ddc::Real const max_norm_diff2 = evaluator.max_norm(0, 1);
+    ddc::Real const max_norm_diff12 = evaluator.max_norm(1, 1);
 
     SplineErrorBounds<evaluator_type<DDimI1, DDimI2>> const error_bounds(evaluator);
     EXPECT_LE(
@@ -542,7 +542,7 @@ void TestBatched2dSpline()
             std::
                     max(error_bounds
                                 .error_bound(dx<I1>(ncells), dx<I2>(ncells), s_degree, s_degree),
-                        1.0e-14 * max_norm));
+                        static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff1,
             std::
@@ -551,7 +551,7 @@ void TestBatched2dSpline()
                                 dx<I2>(ncells),
                                 s_degree,
                                 s_degree),
-                        1e-10 * max_norm_diff1));
+                        static_cast<ddc::Real>(1e-10) * max_norm_diff1));
     EXPECT_LE(
             max_norm_error_diff2,
             std::
@@ -560,7 +560,7 @@ void TestBatched2dSpline()
                                 dx<I2>(ncells),
                                 s_degree,
                                 s_degree),
-                        1e-10 * max_norm_diff2));
+                        static_cast<ddc::Real>(1e-10) * max_norm_diff2));
     EXPECT_LE(
             max_norm_error_diff12,
             std::
@@ -569,7 +569,7 @@ void TestBatched2dSpline()
                                 dx<I2>(ncells),
                                 s_degree,
                                 s_degree),
-                        1e-8 * max_norm_diff12));
+                        static_cast<ddc::Real>(1e-8) * max_norm_diff12));
 }
 
 } // namespace anonymous_namespace_workaround_batched_2d_spline_builder_cpp

--- a/tests/splines/batched_3d_spline_builder.cpp
+++ b/tests/splines/batched_3d_spline_builder.cpp
@@ -1023,7 +1023,7 @@ void TestBatched3dSpline()
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
@@ -1031,7 +1031,7 @@ void TestBatched3dSpline()
     ddc::Real const max_norm_error_diff1 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -1042,7 +1042,7 @@ void TestBatched3dSpline()
     ddc::Real const max_norm_error_diff2 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv2.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -1053,7 +1053,7 @@ void TestBatched3dSpline()
     ddc::Real const max_norm_error_diff3 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv3.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -1064,7 +1064,7 @@ void TestBatched3dSpline()
     ddc::Real const max_norm_error_diff12 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv12.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -1075,7 +1075,7 @@ void TestBatched3dSpline()
     ddc::Real const max_norm_error_diff23 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv23.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -1086,7 +1086,7 @@ void TestBatched3dSpline()
     ddc::Real const max_norm_error_diff13 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv13.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -1097,7 +1097,7 @@ void TestBatched3dSpline()
     ddc::Real const max_norm_error_diff123 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv123.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));

--- a/tests/splines/batched_3d_spline_builder.cpp
+++ b/tests/splines/batched_3d_spline_builder.cpp
@@ -481,16 +481,20 @@ void TestBatched3dSpline()
             = derivs_mixed_rhs1_rhs2_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_host
                 = derivs_mixed_lhs1_lhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_host
                 = derivs_mixed_rhs1_lhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_host
                 = derivs_mixed_lhs1_rhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_host
                 = derivs_mixed_rhs1_rhs2_host_alloc.span_view();
 
@@ -561,16 +565,20 @@ void TestBatched3dSpline()
             = derivs_mixed_rhs2_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs2_lhs3_host
                 = derivs_mixed_lhs2_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs2_lhs3_host
                 = derivs_mixed_rhs2_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs2_rhs3_host
                 = derivs_mixed_lhs2_rhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs2_rhs3_host
                 = derivs_mixed_rhs2_rhs3_host_alloc.span_view();
 
@@ -641,16 +649,20 @@ void TestBatched3dSpline()
             = derivs_mixed_rhs1_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs3_host
                 = derivs_mixed_lhs1_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs3_host
                 = derivs_mixed_rhs1_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs3_host
                 = derivs_mixed_lhs1_rhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs3_host
                 = derivs_mixed_rhs1_rhs3_host_alloc.span_view();
 

--- a/tests/splines/batched_3d_spline_builder.cpp
+++ b/tests/splines/batched_3d_spline_builder.cpp
@@ -134,7 +134,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -260,14 +260,14 @@ void TestBatched3dSpline()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<DDimI1, DDimI2, DDimI3> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -279,7 +279,7 @@ void TestBatched3dSpline()
 #if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
 
-    ddc::Chunk derivs1_lhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs1_lhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs1_lhs_view = derivs1_lhs_view_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs1_lhs_host_alloc(
@@ -287,7 +287,7 @@ void TestBatched3dSpline()
                         ddc::Deriv<I1>,
                         DDimI2,
                         DDimI3>(derivs_domain1, interpolation_domain2, interpolation_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs1_lhs_host = derivs1_lhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs1_lhs_host.domain(),
@@ -308,7 +308,7 @@ void TestBatched3dSpline()
                 });
     }
 
-    ddc::Chunk derivs1_rhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs1_rhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs1_rhs_view = derivs1_rhs_view_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs1_rhs_host_alloc(
@@ -316,7 +316,7 @@ void TestBatched3dSpline()
                         ddc::Deriv<I1>,
                         DDimI2,
                         DDimI3>(derivs_domain1, interpolation_domain2, interpolation_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs1_rhs_host = derivs1_rhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs1_rhs_host.domain(),
@@ -337,7 +337,7 @@ void TestBatched3dSpline()
                 });
     }
 
-    ddc::Chunk derivs2_lhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs2_lhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs2_lhs_view = derivs2_lhs_view_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs2_lhs_host_alloc(
@@ -345,7 +345,7 @@ void TestBatched3dSpline()
                         DDimI1,
                         ddc::Deriv<I2>,
                         DDimI3>(interpolation_domain1, derivs_domain2, interpolation_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs2_lhs_host = derivs2_lhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs2_lhs_host.domain(),
@@ -367,7 +367,7 @@ void TestBatched3dSpline()
                 });
     }
 
-    ddc::Chunk derivs2_rhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs2_rhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs2_rhs_view = derivs2_rhs_view_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs2_rhs_host_alloc(
@@ -375,7 +375,7 @@ void TestBatched3dSpline()
                         DDimI1,
                         ddc::Deriv<I2>,
                         DDimI3>(interpolation_domain1, derivs_domain2, interpolation_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs2_rhs_host = derivs2_rhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs2_rhs_host.domain(),
@@ -397,7 +397,7 @@ void TestBatched3dSpline()
                 });
     }
 
-    ddc::Chunk derivs3_lhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs3_lhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs3_lhs_view = derivs3_lhs_view_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs3_lhs_host_alloc(
@@ -406,7 +406,7 @@ void TestBatched3dSpline()
                         DDimI2,
                         ddc::Deriv<
                                 I3>>(interpolation_domain1, interpolation_domain2, derivs_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs3_lhs_host = derivs3_lhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs3_lhs_host.domain(),
@@ -428,7 +428,7 @@ void TestBatched3dSpline()
                 });
     }
 
-    ddc::Chunk derivs3_rhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs3_rhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs3_rhs_view = derivs3_rhs_view_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs3_rhs_host_alloc(
@@ -437,7 +437,7 @@ void TestBatched3dSpline()
                         DDimI2,
                         ddc::Deriv<
                                 I3>>(interpolation_domain1, interpolation_domain2, derivs_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs3_rhs_host = derivs3_rhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs3_rhs_host.domain(),
@@ -461,36 +461,36 @@ void TestBatched3dSpline()
 
     ddc::Chunk derivs_mixed_lhs1_lhs2_view_alloc(
             dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_view
             = derivs_mixed_lhs1_lhs2_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_lhs2_view_alloc(
             dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_view
             = derivs_mixed_rhs1_lhs2_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_rhs2_view_alloc(
             dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_view
             = derivs_mixed_lhs1_rhs2_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_rhs2_view_alloc(
             dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_view
             = derivs_mixed_rhs1_rhs2_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_host
                 = derivs_mixed_lhs1_lhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_host
                 = derivs_mixed_rhs1_lhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_host
                 = derivs_mixed_lhs1_rhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_host
                 = derivs_mixed_rhs1_rhs2_host_alloc.span_view();
 
@@ -541,36 +541,36 @@ void TestBatched3dSpline()
 
     ddc::Chunk derivs_mixed_lhs2_lhs3_view_alloc(
             dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs2_lhs3_view
             = derivs_mixed_lhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs2_lhs3_view_alloc(
             dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs2_lhs3_view
             = derivs_mixed_rhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs2_rhs3_view_alloc(
             dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs2_rhs3_view
             = derivs_mixed_lhs2_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs2_rhs3_view_alloc(
             dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs2_rhs3_view
             = derivs_mixed_rhs2_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs2_lhs3_host
                 = derivs_mixed_lhs2_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs2_lhs3_host
                 = derivs_mixed_rhs2_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs2_rhs3_host
                 = derivs_mixed_lhs2_rhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs2_rhs3_host
                 = derivs_mixed_rhs2_rhs3_host_alloc.span_view();
 
@@ -621,36 +621,36 @@ void TestBatched3dSpline()
 
     ddc::Chunk derivs_mixed_lhs1_lhs3_view_alloc(
             dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_lhs3_view
             = derivs_mixed_lhs1_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_lhs3_view_alloc(
             dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_lhs3_view
             = derivs_mixed_rhs1_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_rhs3_view_alloc(
             dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_rhs3_view
             = derivs_mixed_lhs1_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_rhs3_view_alloc(
             dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_rhs3_view
             = derivs_mixed_rhs1_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs3_host
                 = derivs_mixed_lhs1_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs3_host
                 = derivs_mixed_rhs1_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs3_host
                 = derivs_mixed_lhs1_rhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs3_host
                 = derivs_mixed_rhs1_rhs3_host_alloc.span_view();
 
@@ -701,84 +701,84 @@ void TestBatched3dSpline()
 
     ddc::Chunk derivs_mixed_lhs1_lhs2_lhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_lhs3_view
             = derivs_mixed_lhs1_lhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_lhs2_lhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_lhs3_view
             = derivs_mixed_rhs1_lhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_rhs2_lhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_lhs3_view
             = derivs_mixed_lhs1_rhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_rhs2_lhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_lhs3_view
             = derivs_mixed_rhs1_rhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_lhs2_rhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_rhs3_view
             = derivs_mixed_lhs1_lhs2_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_lhs2_rhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_rhs3_view
             = derivs_mixed_rhs1_lhs2_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_rhs2_rhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_rhs3_view
             = derivs_mixed_lhs1_rhs2_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_rhs2_rhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_rhs3_view
             = derivs_mixed_rhs1_rhs2_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs_mixed_lhs1_lhs2_lhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_lhs3_host
                 = derivs_mixed_lhs1_lhs2_lhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_rhs1_lhs2_lhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_lhs3_host
                 = derivs_mixed_rhs1_lhs2_lhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_lhs1_rhs2_lhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_lhs3_host
                 = derivs_mixed_lhs1_rhs2_lhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_rhs1_rhs2_lhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_lhs3_host
                 = derivs_mixed_rhs1_rhs2_lhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_lhs1_lhs2_rhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_rhs3_host
                 = derivs_mixed_lhs1_lhs2_rhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_rhs1_lhs2_rhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_rhs3_host
                 = derivs_mixed_rhs1_lhs2_rhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_lhs1_rhs2_rhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_rhs3_host
                 = derivs_mixed_lhs1_rhs2_rhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_rhs1_rhs2_rhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_rhs3_host
                 = derivs_mixed_rhs1_rhs2_rhs3_host_alloc.span_view();
 
@@ -865,7 +865,7 @@ void TestBatched3dSpline()
 #endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -952,21 +952,21 @@ void TestBatched3dSpline()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
-    ddc::Chunk spline_eval_deriv1_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv1_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv1 = spline_eval_deriv1_alloc.span_view();
-    ddc::Chunk spline_eval_deriv2_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv2_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv2 = spline_eval_deriv2_alloc.span_view();
-    ddc::Chunk spline_eval_deriv3_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv3_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv3 = spline_eval_deriv3_alloc.span_view();
-    ddc::Chunk spline_eval_deriv12_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv12_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv12 = spline_eval_deriv12_alloc.span_view();
-    ddc::Chunk spline_eval_deriv23_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv23_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv23 = spline_eval_deriv23_alloc.span_view();
-    ddc::Chunk spline_eval_deriv13_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv13_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv13 = spline_eval_deriv13_alloc.span_view();
-    ddc::Chunk spline_eval_deriv123_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv123_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv123 = spline_eval_deriv123_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -1008,85 +1008,85 @@ void TestBatched3dSpline()
                    coef.span_cview());
 
     // Checking errors (we recover the initial values)
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
             });
-    double const max_norm_error_diff1 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff1 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 Coord<I3> const z = ddc::coordinate(DElem<DDimI3>(e));
                 return Kokkos::abs(spline_eval_deriv1(e) - evaluator.deriv(x, y, z, 1, 0, 0));
             });
-    double const max_norm_error_diff2 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff2 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv2.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 Coord<I3> const z = ddc::coordinate(DElem<DDimI3>(e));
                 return Kokkos::abs(spline_eval_deriv2(e) - evaluator.deriv(x, y, z, 0, 1, 0));
             });
-    double const max_norm_error_diff3 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff3 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv3.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 Coord<I3> const z = ddc::coordinate(DElem<DDimI3>(e));
                 return Kokkos::abs(spline_eval_deriv3(e) - evaluator.deriv(x, y, z, 0, 0, 1));
             });
-    double const max_norm_error_diff12 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff12 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv12.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 Coord<I3> const z = ddc::coordinate(DElem<DDimI3>(e));
                 return Kokkos::abs(spline_eval_deriv12(e) - evaluator.deriv(x, y, z, 1, 1, 0));
             });
-    double const max_norm_error_diff23 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff23 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv23.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 Coord<I3> const z = ddc::coordinate(DElem<DDimI3>(e));
                 return Kokkos::abs(spline_eval_deriv23(e) - evaluator.deriv(x, y, z, 0, 1, 1));
             });
-    double const max_norm_error_diff13 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff13 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv13.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 Coord<I3> const z = ddc::coordinate(DElem<DDimI3>(e));
                 return Kokkos::abs(spline_eval_deriv13(e) - evaluator.deriv(x, y, z, 1, 0, 1));
             });
-    double const max_norm_error_diff123 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff123 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv123.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
@@ -1094,14 +1094,14 @@ void TestBatched3dSpline()
                 return Kokkos::abs(spline_eval_deriv123(e) - evaluator.deriv(x, y, z, 1, 1, 1));
             });
 
-    double const max_norm = evaluator.max_norm();
-    double const max_norm_diff1 = evaluator.max_norm(1, 0, 0);
-    double const max_norm_diff2 = evaluator.max_norm(0, 1, 0);
-    double const max_norm_diff3 = evaluator.max_norm(0, 0, 1);
-    double const max_norm_diff12 = evaluator.max_norm(1, 1, 0);
-    double const max_norm_diff23 = evaluator.max_norm(0, 1, 1);
-    double const max_norm_diff13 = evaluator.max_norm(1, 0, 1);
-    double const max_norm_diff123 = evaluator.max_norm(1, 1, 1);
+    ddc::Real const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm_diff1 = evaluator.max_norm(1, 0, 0);
+    ddc::Real const max_norm_diff2 = evaluator.max_norm(0, 1, 0);
+    ddc::Real const max_norm_diff3 = evaluator.max_norm(0, 0, 1);
+    ddc::Real const max_norm_diff12 = evaluator.max_norm(1, 1, 0);
+    ddc::Real const max_norm_diff23 = evaluator.max_norm(0, 1, 1);
+    ddc::Real const max_norm_diff13 = evaluator.max_norm(1, 0, 1);
+    ddc::Real const max_norm_diff123 = evaluator.max_norm(1, 1, 1);
 
     SplineErrorBounds<evaluator_type<DDimI1, DDimI2, DDimI3>> const error_bounds(evaluator);
     EXPECT_LE(
@@ -1114,7 +1114,7 @@ void TestBatched3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1.0e-14 * max_norm));
+                        static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff1,
             std::
@@ -1125,7 +1125,7 @@ void TestBatched3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-11 * max_norm_diff1));
+                        static_cast<ddc::Real>(1e-11) * max_norm_diff1));
     EXPECT_LE(
             max_norm_error_diff2,
             std::
@@ -1136,7 +1136,7 @@ void TestBatched3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-9 * max_norm_diff2));
+                        static_cast<ddc::Real>(1e-9) * max_norm_diff2));
     EXPECT_LE(
             max_norm_error_diff3,
             std::
@@ -1147,7 +1147,7 @@ void TestBatched3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-11 * max_norm_diff3));
+                        static_cast<ddc::Real>(1e-11) * max_norm_diff3));
     EXPECT_LE(
             max_norm_error_diff12,
             std::
@@ -1158,7 +1158,7 @@ void TestBatched3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-7 * max_norm_diff12));
+                        static_cast<ddc::Real>(1e-7) * max_norm_diff12));
     EXPECT_LE(
             max_norm_error_diff23,
             std::
@@ -1169,7 +1169,7 @@ void TestBatched3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-8 * max_norm_diff23));
+                        static_cast<ddc::Real>(1e-8) * max_norm_diff23));
     EXPECT_LE(
             max_norm_error_diff13,
             std::
@@ -1180,7 +1180,7 @@ void TestBatched3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-9 * max_norm_diff13));
+                        static_cast<ddc::Real>(1e-9) * max_norm_diff13));
     EXPECT_LE(
             max_norm_error_diff123,
             std::
@@ -1191,7 +1191,7 @@ void TestBatched3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-6 * max_norm_diff123));
+                        static_cast<ddc::Real>(1e-6) * max_norm_diff123));
 }
 
 } // namespace anonymous_namespace_workaround_batched_3d_spline_builder_cpp

--- a/tests/splines/batched_nd_evaluator_1d_spline_builder.cpp
+++ b/tests/splines/batched_nd_evaluator_1d_spline_builder.cpp
@@ -278,7 +278,8 @@ void TestBatchedNd1dSpline()
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
     ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv = spline_eval_deriv_alloc.span_view();
-    ddc::Chunk spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_integrals = spline_eval_integrals_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -329,7 +330,9 @@ void TestBatchedNd1dSpline()
     SplineErrorBounds<evaluator_type<DDimI>> const error_bounds(evaluator);
     EXPECT_LE(
             max_norm_error,
-            std::max(error_bounds.error_bound(dx<I>(ncells), s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
+            std::
+                    max(error_bounds.error_bound(dx<I>(ncells), s_degree),
+                        static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff,
             std::

--- a/tests/splines/batched_nd_evaluator_1d_spline_builder.cpp
+++ b/tests/splines/batched_nd_evaluator_1d_spline_builder.cpp
@@ -295,7 +295,7 @@ void TestBatchedNd1dSpline()
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
@@ -304,7 +304,7 @@ void TestBatchedNd1dSpline()
     ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I> const x = ddc::coordinate(DElem<DDimI>(e));
@@ -313,7 +313,7 @@ void TestBatchedNd1dSpline()
     ddc::Real const max_norm_error_integ = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_integrals.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(
                     decltype(spline_builder)::template batch_domain_type<

--- a/tests/splines/batched_nd_evaluator_1d_spline_builder.cpp
+++ b/tests/splines/batched_nd_evaluator_1d_spline_builder.cpp
@@ -104,7 +104,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -177,14 +177,14 @@ void TestBatchedNd1dSpline()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<DDimI> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -193,10 +193,10 @@ void TestBatchedNd1dSpline()
 
 #if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
-    ddc::Chunk derivs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_lhs = derivs_lhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_lhs1_host = derivs_lhs1_host_alloc.span_view();
         for (ddc::DiscreteElement<ddc::Deriv<I>> const ei : derivs_domain) {
             derivs_lhs1_host(ei) = evaluator.deriv(x0<I>(), ei.uid());
@@ -211,10 +211,10 @@ void TestBatchedNd1dSpline()
                 });
     }
 
-    ddc::Chunk derivs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_rhs = derivs_rhs_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_rhs1_host = derivs_rhs1_host_alloc.span_view();
         for (ddc::DiscreteElement<ddc::Deriv<I>> const ei : derivs_domain) {
             derivs_rhs1_host(ei) = evaluator.deriv(xn<I>(), ei.uid());
@@ -232,7 +232,7 @@ void TestBatchedNd1dSpline()
 #endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -274,11 +274,11 @@ void TestBatchedNd1dSpline()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
-    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv = spline_eval_deriv_alloc.span_view();
-    ddc::Chunk spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_integrals = spline_eval_integrals_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -291,29 +291,29 @@ void TestBatchedNd1dSpline()
     spline_evaluator_batched.integrate(spline_eval_integrals, coef.span_cview());
 
     // Checking errors (we recover the initial values)
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
             });
 
-    double const max_norm_error_diff = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I> const x = ddc::coordinate(DElem<DDimI>(e));
                 return Kokkos::abs(spline_eval_deriv(e) - evaluator.deriv(x, 1));
             });
-    double const max_norm_error_integ = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_integ = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_integrals.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(
                     decltype(spline_builder)::template batch_domain_type<
                             ddc::DiscreteDomain<DDims...>>::discrete_element_type const e) {
@@ -322,24 +322,24 @@ void TestBatchedNd1dSpline()
                         + evaluator.deriv(x0<I>(), -1));
             });
 
-    double const max_norm = evaluator.max_norm();
-    double const max_norm_diff = evaluator.max_norm(1);
-    double const max_norm_int = evaluator.max_norm(-1);
+    ddc::Real const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm_diff = evaluator.max_norm(1);
+    ddc::Real const max_norm_int = evaluator.max_norm(-1);
 
     SplineErrorBounds<evaluator_type<DDimI>> const error_bounds(evaluator);
     EXPECT_LE(
             max_norm_error,
-            std::max(error_bounds.error_bound(dx<I>(ncells), s_degree), 1.0e-14 * max_norm));
+            std::max(error_bounds.error_bound(dx<I>(ncells), s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff,
             std::
                     max(error_bounds.error_bound_on_deriv(dx<I>(ncells), s_degree),
-                        1e-12 * max_norm_diff));
+                        static_cast<ddc::Real>(1e-12) * max_norm_diff));
     EXPECT_LE(
             max_norm_error_integ,
             std::
                     max(error_bounds.error_bound_on_int(dx<I>(ncells), s_degree),
-                        1.0e-14 * max_norm_int));
+                        static_cast<ddc::Real>(1.0e-14) * max_norm_int));
 }
 
 } // namespace anonymous_namespace_workaround_batched_nd_evaluator_1d_spline_builder_cpp

--- a/tests/splines/batched_nd_evaluator_3d_spline_builder.cpp
+++ b/tests/splines/batched_nd_evaluator_3d_spline_builder.cpp
@@ -134,7 +134,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -170,7 +170,7 @@ template <
         typename ExecSpace,
         typename ChunkSpanType,
         typename Evaluator>
-double get_max_norm_error_deriv(
+ddc::Real get_max_norm_error_deriv(
         ExecSpace const& exec_space,
         Evaluator const evaluator,
         ChunkSpanType const spline_eval,
@@ -184,8 +184,8 @@ double get_max_norm_error_deriv(
     return ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DDimsDElem const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
@@ -292,14 +292,14 @@ void TestBatchedNd3dSpline()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<DDimI1, DDimI2, DDimI3> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -310,7 +310,7 @@ void TestBatchedNd3dSpline()
 
 #if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
-    ddc::Chunk derivs1_lhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs1_lhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs1_lhs_view = derivs1_lhs_view_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs1_lhs_host_alloc(
@@ -318,7 +318,7 @@ void TestBatchedNd3dSpline()
                         ddc::Deriv<I1>,
                         DDimI2,
                         DDimI3>(derivs_domain1, interpolation_domain2, interpolation_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs1_lhs_host = derivs1_lhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs1_lhs_host.domain(),
@@ -339,7 +339,7 @@ void TestBatchedNd3dSpline()
                 });
     }
 
-    ddc::Chunk derivs1_rhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs1_rhs_view_alloc(dom_derivs1, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs1_rhs_view = derivs1_rhs_view_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs1_rhs_host_alloc(
@@ -347,7 +347,7 @@ void TestBatchedNd3dSpline()
                         ddc::Deriv<I1>,
                         DDimI2,
                         DDimI3>(derivs_domain1, interpolation_domain2, interpolation_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs1_rhs_host = derivs1_rhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs1_rhs_host.domain(),
@@ -368,7 +368,7 @@ void TestBatchedNd3dSpline()
                 });
     }
 
-    ddc::Chunk derivs2_lhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs2_lhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs2_lhs_view = derivs2_lhs_view_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs2_lhs_host_alloc(
@@ -376,7 +376,7 @@ void TestBatchedNd3dSpline()
                         DDimI1,
                         ddc::Deriv<I2>,
                         DDimI3>(interpolation_domain1, derivs_domain2, interpolation_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs2_lhs_host = derivs2_lhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs2_lhs_host.domain(),
@@ -398,7 +398,7 @@ void TestBatchedNd3dSpline()
                 });
     }
 
-    ddc::Chunk derivs2_rhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs2_rhs_view_alloc(dom_derivs2, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs2_rhs_view = derivs2_rhs_view_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs2_rhs_host_alloc(
@@ -406,7 +406,7 @@ void TestBatchedNd3dSpline()
                         DDimI1,
                         ddc::Deriv<I2>,
                         DDimI3>(interpolation_domain1, derivs_domain2, interpolation_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs2_rhs_host = derivs2_rhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs2_rhs_host.domain(),
@@ -428,7 +428,7 @@ void TestBatchedNd3dSpline()
                 });
     }
 
-    ddc::Chunk derivs3_lhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs3_lhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs3_lhs_view = derivs3_lhs_view_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs3_lhs_host_alloc(
@@ -437,7 +437,7 @@ void TestBatchedNd3dSpline()
                         DDimI2,
                         ddc::Deriv<
                                 I3>>(interpolation_domain1, interpolation_domain2, derivs_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs3_lhs_host = derivs3_lhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs3_lhs_host.domain(),
@@ -459,7 +459,7 @@ void TestBatchedNd3dSpline()
                 });
     }
 
-    ddc::Chunk derivs3_rhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs3_rhs_view_alloc(dom_derivs3, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs3_rhs_view = derivs3_rhs_view_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs3_rhs_host_alloc(
@@ -468,7 +468,7 @@ void TestBatchedNd3dSpline()
                         DDimI2,
                         ddc::Deriv<
                                 I3>>(interpolation_domain1, interpolation_domain2, derivs_domain3),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs3_rhs_host = derivs3_rhs_host_alloc.span_view();
         ddc::host_for_each(
                 derivs3_rhs_host.domain(),
@@ -492,36 +492,36 @@ void TestBatchedNd3dSpline()
 
     ddc::Chunk derivs_mixed_lhs1_lhs2_view_alloc(
             dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_view
             = derivs_mixed_lhs1_lhs2_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_lhs2_view_alloc(
             dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_view
             = derivs_mixed_rhs1_lhs2_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_rhs2_view_alloc(
             dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_view
             = derivs_mixed_lhs1_rhs2_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_rhs2_view_alloc(
             dom_derivs12,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_view
             = derivs_mixed_rhs1_rhs2_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_host
                 = derivs_mixed_lhs1_lhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_host
                 = derivs_mixed_rhs1_lhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_host
                 = derivs_mixed_lhs1_rhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_host
                 = derivs_mixed_rhs1_rhs2_host_alloc.span_view();
 
@@ -572,36 +572,36 @@ void TestBatchedNd3dSpline()
 
     ddc::Chunk derivs_mixed_lhs2_lhs3_view_alloc(
             dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs2_lhs3_view
             = derivs_mixed_lhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs2_lhs3_view_alloc(
             dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs2_lhs3_view
             = derivs_mixed_rhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs2_rhs3_view_alloc(
             dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs2_rhs3_view
             = derivs_mixed_lhs2_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs2_rhs3_view_alloc(
             dom_derivs23,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs2_rhs3_view
             = derivs_mixed_rhs2_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs2_lhs3_host
                 = derivs_mixed_lhs2_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs2_lhs3_host
                 = derivs_mixed_rhs2_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs2_rhs3_host
                 = derivs_mixed_lhs2_rhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs2_rhs3_host
                 = derivs_mixed_rhs2_rhs3_host_alloc.span_view();
 
@@ -652,36 +652,36 @@ void TestBatchedNd3dSpline()
 
     ddc::Chunk derivs_mixed_lhs1_lhs3_view_alloc(
             dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_lhs3_view
             = derivs_mixed_lhs1_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_lhs3_view_alloc(
             dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_lhs3_view
             = derivs_mixed_rhs1_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_rhs3_view_alloc(
             dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_rhs3_view
             = derivs_mixed_lhs1_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_rhs3_view_alloc(
             dom_derivs13,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_rhs3_view
             = derivs_mixed_rhs1_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs3_host
                 = derivs_mixed_lhs1_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs3_host
                 = derivs_mixed_rhs1_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs3_host
                 = derivs_mixed_lhs1_rhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs3_host
                 = derivs_mixed_rhs1_rhs3_host_alloc.span_view();
 
@@ -732,84 +732,84 @@ void TestBatchedNd3dSpline()
 
     ddc::Chunk derivs_mixed_lhs1_lhs2_lhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_lhs3_view
             = derivs_mixed_lhs1_lhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_lhs2_lhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_lhs3_view
             = derivs_mixed_rhs1_lhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_rhs2_lhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_lhs3_view
             = derivs_mixed_lhs1_rhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_rhs2_lhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_lhs3_view
             = derivs_mixed_rhs1_rhs2_lhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_lhs2_rhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_rhs3_view
             = derivs_mixed_lhs1_lhs2_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_lhs2_rhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_rhs3_view
             = derivs_mixed_rhs1_lhs2_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_lhs1_rhs2_rhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_rhs3_view
             = derivs_mixed_lhs1_rhs2_rhs3_view_alloc.span_view();
     ddc::Chunk derivs_mixed_rhs1_rhs2_rhs3_view_alloc(
             dom_derivs_all,
-            ddc::KokkosAllocator<double, MemorySpace>());
+            ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_rhs3_view
             = derivs_mixed_rhs1_rhs2_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs_mixed_lhs1_lhs2_lhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_lhs3_host
                 = derivs_mixed_lhs1_lhs2_lhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_rhs1_lhs2_lhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_lhs3_host
                 = derivs_mixed_rhs1_lhs2_lhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_lhs1_rhs2_lhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_lhs3_host
                 = derivs_mixed_lhs1_rhs2_lhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_rhs1_rhs2_lhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_lhs3_host
                 = derivs_mixed_rhs1_rhs2_lhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_lhs1_lhs2_rhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_rhs3_host
                 = derivs_mixed_lhs1_lhs2_rhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_rhs1_lhs2_rhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_rhs3_host
                 = derivs_mixed_rhs1_lhs2_rhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_lhs1_rhs2_rhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_rhs3_host
                 = derivs_mixed_lhs1_rhs2_rhs3_host_alloc.span_view();
         ddc::Chunk derivs_mixed_rhs1_rhs2_rhs3_host_alloc(
                 derivs_domain_all,
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_rhs3_host
                 = derivs_mixed_rhs1_rhs2_rhs3_host_alloc.span_view();
 
@@ -896,7 +896,7 @@ void TestBatchedNd3dSpline()
 #endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -980,21 +980,21 @@ void TestBatchedNd3dSpline()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
-    ddc::Chunk spline_eval_deriv1_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv1_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv1 = spline_eval_deriv1_alloc.span_view();
-    ddc::Chunk spline_eval_deriv2_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv2_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv2 = spline_eval_deriv2_alloc.span_view();
-    ddc::Chunk spline_eval_deriv3_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv3_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv3 = spline_eval_deriv3_alloc.span_view();
-    ddc::Chunk spline_eval_deriv12_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv12_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv12 = spline_eval_deriv12_alloc.span_view();
-    ddc::Chunk spline_eval_deriv23_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv23_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv23 = spline_eval_deriv23_alloc.span_view();
-    ddc::Chunk spline_eval_deriv13_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv13_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv13 = spline_eval_deriv13_alloc.span_view();
-    ddc::Chunk spline_eval_deriv123_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv123_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv123 = spline_eval_deriv123_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -1036,58 +1036,58 @@ void TestBatchedNd3dSpline()
                    coef.span_cview());
 
     // Checking errors (we recover the initial values)
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
             });
-    double const max_norm_error_diff1 = get_max_norm_error_deriv<
+    ddc::Real const max_norm_error_diff1 = get_max_norm_error_deriv<
             DDimI1,
             DDimI2,
             DDimI3,
             DElem<DDims...>>(exec_space, evaluator, spline_eval_deriv1, 1, 0, 0);
-    double const max_norm_error_diff2 = get_max_norm_error_deriv<
+    ddc::Real const max_norm_error_diff2 = get_max_norm_error_deriv<
             DDimI1,
             DDimI2,
             DDimI3,
             DElem<DDims...>>(exec_space, evaluator, spline_eval_deriv2, 0, 1, 0);
-    double const max_norm_error_diff3 = get_max_norm_error_deriv<
+    ddc::Real const max_norm_error_diff3 = get_max_norm_error_deriv<
             DDimI1,
             DDimI2,
             DDimI3,
             DElem<DDims...>>(exec_space, evaluator, spline_eval_deriv3, 0, 0, 1);
-    double const max_norm_error_diff12 = get_max_norm_error_deriv<
+    ddc::Real const max_norm_error_diff12 = get_max_norm_error_deriv<
             DDimI1,
             DDimI2,
             DDimI3,
             DElem<DDims...>>(exec_space, evaluator, spline_eval_deriv12, 1, 1, 0);
-    double const max_norm_error_diff13 = get_max_norm_error_deriv<
+    ddc::Real const max_norm_error_diff13 = get_max_norm_error_deriv<
             DDimI1,
             DDimI2,
             DDimI3,
             DElem<DDims...>>(exec_space, evaluator, spline_eval_deriv13, 1, 0, 1);
-    double const max_norm_error_diff23 = get_max_norm_error_deriv<
+    ddc::Real const max_norm_error_diff23 = get_max_norm_error_deriv<
             DDimI1,
             DDimI2,
             DDimI3,
             DElem<DDims...>>(exec_space, evaluator, spline_eval_deriv23, 0, 1, 1);
-    double const max_norm_error_diff123 = get_max_norm_error_deriv<
+    ddc::Real const max_norm_error_diff123 = get_max_norm_error_deriv<
             DDimI1,
             DDimI2,
             DDimI3,
             DElem<DDims...>>(exec_space, evaluator, spline_eval_deriv123, 1, 1, 1);
 
-    double const max_norm = evaluator.max_norm();
-    double const max_norm_diff1 = evaluator.max_norm(1, 0, 0);
-    double const max_norm_diff2 = evaluator.max_norm(0, 1, 0);
-    double const max_norm_diff3 = evaluator.max_norm(0, 0, 1);
-    double const max_norm_diff12 = evaluator.max_norm(1, 1, 0);
-    double const max_norm_diff23 = evaluator.max_norm(0, 1, 1);
-    double const max_norm_diff13 = evaluator.max_norm(1, 0, 1);
-    double const max_norm_diff123 = evaluator.max_norm(1, 1, 1);
+    ddc::Real const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm_diff1 = evaluator.max_norm(1, 0, 0);
+    ddc::Real const max_norm_diff2 = evaluator.max_norm(0, 1, 0);
+    ddc::Real const max_norm_diff3 = evaluator.max_norm(0, 0, 1);
+    ddc::Real const max_norm_diff12 = evaluator.max_norm(1, 1, 0);
+    ddc::Real const max_norm_diff23 = evaluator.max_norm(0, 1, 1);
+    ddc::Real const max_norm_diff13 = evaluator.max_norm(1, 0, 1);
+    ddc::Real const max_norm_diff123 = evaluator.max_norm(1, 1, 1);
 
     SplineErrorBounds<evaluator_type<DDimI1, DDimI2, DDimI3>> const error_bounds(evaluator);
     EXPECT_LE(
@@ -1100,7 +1100,7 @@ void TestBatchedNd3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1.0e-14 * max_norm));
+                        static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff1,
             std::
@@ -1111,7 +1111,7 @@ void TestBatchedNd3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-11 * max_norm_diff1));
+                        static_cast<ddc::Real>(1e-11) * max_norm_diff1));
     EXPECT_LE(
             max_norm_error_diff2,
             std::
@@ -1122,7 +1122,7 @@ void TestBatchedNd3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-9 * max_norm_diff2));
+                        static_cast<ddc::Real>(1e-9) * max_norm_diff2));
     EXPECT_LE(
             max_norm_error_diff3,
             std::
@@ -1133,7 +1133,7 @@ void TestBatchedNd3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-11 * max_norm_diff3));
+                        static_cast<ddc::Real>(1e-11) * max_norm_diff3));
     EXPECT_LE(
             max_norm_error_diff12,
             std::
@@ -1144,7 +1144,7 @@ void TestBatchedNd3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-7 * max_norm_diff12));
+                        static_cast<ddc::Real>(1e-7) * max_norm_diff12));
     EXPECT_LE(
             max_norm_error_diff23,
             std::
@@ -1155,7 +1155,7 @@ void TestBatchedNd3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-8 * max_norm_diff23));
+                        static_cast<ddc::Real>(1e-8) * max_norm_diff23));
     EXPECT_LE(
             max_norm_error_diff13,
             std::
@@ -1166,7 +1166,7 @@ void TestBatchedNd3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-9 * max_norm_diff13));
+                        static_cast<ddc::Real>(1e-9) * max_norm_diff13));
     EXPECT_LE(
             max_norm_error_diff123,
             std::
@@ -1177,7 +1177,7 @@ void TestBatchedNd3dSpline()
                                 s_degree,
                                 s_degree,
                                 s_degree),
-                        1e-6 * max_norm_diff123));
+                        static_cast<ddc::Real>(1e-6) * max_norm_diff123));
 }
 
 } // namespace anonymous_namespace_workaround_batched_nd_evaluator_3d_spline_builder_cpp

--- a/tests/splines/batched_nd_evaluator_3d_spline_builder.cpp
+++ b/tests/splines/batched_nd_evaluator_3d_spline_builder.cpp
@@ -512,16 +512,20 @@ void TestBatchedNd3dSpline()
             = derivs_mixed_rhs1_rhs2_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs2_host
                 = derivs_mixed_lhs1_lhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs1_lhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs2_host
                 = derivs_mixed_rhs1_lhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs2_host
                 = derivs_mixed_lhs1_rhs2_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs1_rhs2_host_alloc(derivs_domain12, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs2_host
                 = derivs_mixed_rhs1_rhs2_host_alloc.span_view();
 
@@ -592,16 +596,20 @@ void TestBatchedNd3dSpline()
             = derivs_mixed_rhs2_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs2_lhs3_host
                 = derivs_mixed_lhs2_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs2_lhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs2_lhs3_host
                 = derivs_mixed_rhs2_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs2_rhs3_host
                 = derivs_mixed_lhs2_rhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs2_rhs3_host_alloc(derivs_domain23, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs2_rhs3_host
                 = derivs_mixed_rhs2_rhs3_host_alloc.span_view();
 
@@ -672,16 +680,20 @@ void TestBatchedNd3dSpline()
             = derivs_mixed_rhs1_rhs3_view_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_lhs3_host
                 = derivs_mixed_lhs1_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs1_lhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_lhs3_host
                 = derivs_mixed_rhs1_lhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_lhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs1_rhs3_host
                 = derivs_mixed_lhs1_rhs3_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
+        ddc::Chunk
+                derivs_mixed_rhs1_rhs3_host_alloc(derivs_domain13, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs1_rhs3_host
                 = derivs_mixed_rhs1_rhs3_host_alloc.span_view();
 

--- a/tests/splines/batched_nd_evaluator_3d_spline_builder.cpp
+++ b/tests/splines/batched_nd_evaluator_3d_spline_builder.cpp
@@ -184,7 +184,7 @@ ddc::Real get_max_norm_error_deriv(
     return ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DDimsDElem const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -1051,7 +1051,7 @@ void TestBatchedNd3dSpline()
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -111,7 +111,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -184,14 +184,14 @@ void TestBatchedSpline()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<DDimI> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -200,10 +200,10 @@ void TestBatchedSpline()
 
 #if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
-    ddc::Chunk derivs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_lhs = derivs_lhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_lhs1_host = derivs_lhs1_host_alloc.span_view();
         for (ddc::DiscreteElement<ddc::Deriv<I>> const ei : derivs_domain) {
             derivs_lhs1_host(ei) = evaluator.deriv(x0<I>(), ei.uid());
@@ -218,10 +218,10 @@ void TestBatchedSpline()
                 });
     }
 
-    ddc::Chunk derivs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_rhs = derivs_rhs_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_rhs1_host = derivs_rhs1_host_alloc.span_view();
         for (ddc::DiscreteElement<ddc::Deriv<I>> const ei : derivs_domain) {
             derivs_rhs1_host(ei) = evaluator.deriv(xn<I>(), ei.uid());
@@ -239,7 +239,7 @@ void TestBatchedSpline()
 #endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -282,11 +282,11 @@ void TestBatchedSpline()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
-    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv = spline_eval_deriv_alloc.span_view();
-    ddc::Chunk spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_integrals = spline_eval_integrals_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -299,29 +299,29 @@ void TestBatchedSpline()
     spline_evaluator_batched.integrate(spline_eval_integrals, coef.span_cview());
 
     // Checking errors (we recover the initial values)
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
             });
 
-    double const max_norm_error_diff = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I> const x = ddc::coordinate(DElem<DDimI>(e));
                 return Kokkos::abs(spline_eval_deriv(e) - evaluator.deriv(x, 1));
             });
-    double const max_norm_error_integ = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_integ = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_integrals.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(
                     decltype(spline_builder)::template batch_domain_type<
                             ddc::DiscreteDomain<DDims...>>::discrete_element_type const e) {
@@ -330,24 +330,24 @@ void TestBatchedSpline()
                         + evaluator.deriv(x0<I>(), -1));
             });
 
-    double const max_norm = evaluator.max_norm();
-    double const max_norm_diff = evaluator.max_norm(1);
-    double const max_norm_int = evaluator.max_norm(-1);
+    ddc::Real const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm_diff = evaluator.max_norm(1);
+    ddc::Real const max_norm_int = evaluator.max_norm(-1);
 
     SplineErrorBounds<evaluator_type<DDimI>> const error_bounds(evaluator);
     EXPECT_LE(
             max_norm_error,
-            std::max(error_bounds.error_bound(dx<I>(ncells), s_degree), 1.0e-14 * max_norm));
+            std::max(error_bounds.error_bound(dx<I>(ncells), s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff,
             std::
                     max(error_bounds.error_bound_on_deriv(dx<I>(ncells), s_degree),
-                        1e-12 * max_norm_diff));
+                        static_cast<ddc::Real>(1e-12) * max_norm_diff));
     EXPECT_LE(
             max_norm_error_integ,
             std::
                     max(error_bounds.error_bound_on_int(dx<I>(ncells), s_degree),
-                        1.0e-14 * max_norm_int));
+                        static_cast<ddc::Real>(1.0e-14) * max_norm_int));
 }
 
 } // namespace anonymous_namespace_workaround_batched_spline_builder_cpp

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -286,7 +286,8 @@ void TestBatchedSpline()
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
     ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv = spline_eval_deriv_alloc.span_view();
-    ddc::Chunk spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_integrals = spline_eval_integrals_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -337,7 +338,9 @@ void TestBatchedSpline()
     SplineErrorBounds<evaluator_type<DDimI>> const error_bounds(evaluator);
     EXPECT_LE(
             max_norm_error,
-            std::max(error_bounds.error_bound(dx<I>(ncells), s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
+            std::
+                    max(error_bounds.error_bound(dx<I>(ncells), s_degree),
+                        static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff,
             std::

--- a/tests/splines/batched_spline_builder.cpp
+++ b/tests/splines/batched_spline_builder.cpp
@@ -303,7 +303,7 @@ void TestBatchedSpline()
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
@@ -312,7 +312,7 @@ void TestBatchedSpline()
     ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I> const x = ddc::coordinate(DElem<DDimI>(e));
@@ -321,7 +321,7 @@ void TestBatchedSpline()
     ddc::Real const max_norm_error_integ = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_integrals.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(
                     decltype(spline_builder)::template batch_domain_type<

--- a/tests/splines/bsplines.cpp
+++ b/tests/splines/bsplines.cpp
@@ -83,17 +83,17 @@ TYPED_TEST(BSplinesFixture, PartitionOfUnityUniform)
     std::size_t const ncells = TestFixture::ncells;
     ddc::init_discrete_space<BSplinesX>(xmin, xmax, ncells);
 
-    std::array<double, degree + 1> values_ptr;
-    Kokkos::mdspan<double, Kokkos::extents<std::size_t, degree + 1>> const values(
+    std::array<ddc::Real, degree + 1> values_ptr;
+    Kokkos::mdspan<ddc::Real, Kokkos::extents<std::size_t, degree + 1>> const values(
             values_ptr.data());
 
     std::size_t const n_test_points = ncells * 30;
-    double const dx = (xmax - xmin) / (n_test_points - 1);
+    ddc::Real const dx = (xmax - xmin) / (n_test_points - 1);
 
     for (std::size_t i(0); i < n_test_points; ++i) {
         CoordX const test_point(xmin + dx * i);
         ddc::discrete_space<BSplinesX>().eval_basis(values, test_point);
-        double sum = 0.0;
+        ddc::Real sum = 0.0;
         for (std::size_t j(0); j < degree + 1; ++j) {
             sum += DDC_MDSPAN_ACCESS_OP(values, j);
         }
@@ -111,14 +111,14 @@ TYPED_TEST(BSplinesFixture, PartitionOfUnityNonUniform)
     CoordX const xmax(0.2);
     std::size_t const ncells = TestFixture::ncells;
     std::vector<CoordX> breaks(ncells + 1);
-    double dx = (xmax - xmin) / ncells;
+    ddc::Real dx = (xmax - xmin) / ncells;
     for (std::size_t i(0); i < ncells + 1; ++i) {
         breaks[i] = CoordX(xmin + i * dx);
     }
     ddc::init_discrete_space<BSplinesX>(breaks);
 
-    std::array<double, degree + 1> values_ptr;
-    Kokkos::mdspan<double, Kokkos::extents<std::size_t, degree + 1>> const values(
+    std::array<ddc::Real, degree + 1> values_ptr;
+    Kokkos::mdspan<ddc::Real, Kokkos::extents<std::size_t, degree + 1>> const values(
             values_ptr.data());
 
 
@@ -128,7 +128,7 @@ TYPED_TEST(BSplinesFixture, PartitionOfUnityNonUniform)
     for (std::size_t i(0); i < n_test_points; ++i) {
         CoordX const test_point(xmin + dx * i);
         ddc::discrete_space<BSplinesX>().eval_basis(values, test_point);
-        double sum = 0.0;
+        ddc::Real sum = 0.0;
         for (std::size_t j(0); j < degree + 1; ++j) {
             sum += DDC_MDSPAN_ACCESS_OP(values, j);
         }
@@ -163,7 +163,7 @@ TYPED_TEST(BSplinesFixture, RoundingNonUniform)
     CoordX const xmax(0.2);
     std::size_t const ncells = TestFixture::ncells;
     std::vector<CoordX> breaks(ncells + 1);
-    double const dx = (xmax - xmin) / ncells;
+    ddc::Real const dx = (xmax - xmin) / ncells;
     for (std::size_t i(0); i < ncells + 1; ++i) {
         breaks[i] = CoordX(xmin + i * dx);
     }
@@ -172,16 +172,16 @@ TYPED_TEST(BSplinesFixture, RoundingNonUniform)
     ddc::DiscreteDomain<BSplinesX> const bspl_full_domain
             = ddc::discrete_space<BSplinesX>().full_domain();
 
-    std::array<double, degree + 1> values_ptr;
-    Kokkos::mdspan<double, Kokkos::extents<std::size_t, degree + 1>> const values(
+    std::array<ddc::Real, degree + 1> values_ptr;
+    Kokkos::mdspan<ddc::Real, Kokkos::extents<std::size_t, degree + 1>> const values(
             values_ptr.data());
 
-    CoordX const test_point_min(xmin - std::numeric_limits<double>::epsilon());
+    CoordX const test_point_min(xmin - std::numeric_limits<ddc::Real>::epsilon());
     ddc::DiscreteElement<BSplinesX> const front_idx
             = ddc::discrete_space<BSplinesX>().eval_basis(values, test_point_min);
     EXPECT_EQ(front_idx, bspl_full_domain.front());
 
-    CoordX const test_point_max(xmax + std::numeric_limits<double>::epsilon());
+    CoordX const test_point_max(xmax + std::numeric_limits<ddc::Real>::epsilon());
     ddc::DiscreteElement<BSplinesX> const back_idx
             = ddc::discrete_space<BSplinesX>().eval_basis(values, test_point_max);
     EXPECT_EQ(back_idx, bspl_full_domain.back() - BSplinesX::degree());
@@ -201,16 +201,16 @@ TYPED_TEST(BSplinesFixture, RoundingUniform)
     ddc::DiscreteDomain<BSplinesX> const bspl_full_domain
             = ddc::discrete_space<BSplinesX>().full_domain();
 
-    std::array<double, degree + 1> values_ptr;
-    Kokkos::mdspan<double, Kokkos::extents<std::size_t, degree + 1>> const values(
+    std::array<ddc::Real, degree + 1> values_ptr;
+    Kokkos::mdspan<ddc::Real, Kokkos::extents<std::size_t, degree + 1>> const values(
             values_ptr.data());
 
-    CoordX const test_point_min(xmin - std::numeric_limits<double>::epsilon());
+    CoordX const test_point_min(xmin - std::numeric_limits<ddc::Real>::epsilon());
     ddc::DiscreteElement<BSplinesX> const front_idx
             = ddc::discrete_space<BSplinesX>().eval_basis(values, test_point_min);
     EXPECT_EQ(front_idx, bspl_full_domain.front());
 
-    CoordX const test_point_max(xmax + std::numeric_limits<double>::epsilon());
+    CoordX const test_point_max(xmax + std::numeric_limits<ddc::Real>::epsilon());
     ddc::DiscreteElement<BSplinesX> const back_idx
             = ddc::discrete_space<BSplinesX>().eval_basis(values, test_point_max);
     EXPECT_EQ(back_idx, bspl_full_domain.back() - BSplinesX::degree());

--- a/tests/splines/cosine_evaluator.hpp
+++ b/tests/splines/cosine_evaluator.hpp
@@ -18,14 +18,14 @@ struct CosineEvaluator
         using Dim = DDim;
 
     private:
-        static constexpr double s_2_pi = 2 * Kokkos::numbers::pi;
+        static constexpr ddc::Real s_2_pi = 2 * Kokkos::numbers::pi;
 
-        static constexpr double s_pi_2 = Kokkos::numbers::pi / 2;
+        static constexpr ddc::Real s_pi_2 = Kokkos::numbers::pi / 2;
 
     private:
-        double m_coef0;
+        ddc::Real m_coef0;
 
-        double m_coef1;
+        ddc::Real m_coef1;
 
     public:
         template <class Domain>
@@ -34,15 +34,15 @@ struct CosineEvaluator
         {
         }
 
-        Evaluator(double coef0, double coef1) : m_coef0(coef0), m_coef1(coef1) {}
+        Evaluator(ddc::Real coef0, ddc::Real coef1) : m_coef0(coef0), m_coef1(coef1) {}
 
-        KOKKOS_FUNCTION double operator()(double const x) const noexcept
+        KOKKOS_FUNCTION ddc::Real operator()(ddc::Real const x) const noexcept
         {
             return eval(x, 0);
         }
 
         KOKKOS_FUNCTION void operator()(
-                ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>> chunk) const
+                ddc::ChunkSpan<ddc::Real, ddc::DiscreteDomain<DDim>> chunk) const
         {
             ddc::DiscreteDomain<DDim> const domain = chunk.domain();
 
@@ -51,13 +51,13 @@ struct CosineEvaluator
             }
         }
 
-        KOKKOS_FUNCTION double deriv(double const x, int const derivative) const noexcept
+        KOKKOS_FUNCTION ddc::Real deriv(ddc::Real const x, int const derivative) const noexcept
         {
             return eval(x, derivative);
         }
 
         KOKKOS_FUNCTION void deriv(
-                ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>> chunk,
+                ddc::ChunkSpan<ddc::Real, ddc::DiscreteDomain<DDim>> chunk,
                 int const derivative) const
         {
             ddc::DiscreteDomain<DDim> const domain = chunk.domain();
@@ -67,13 +67,13 @@ struct CosineEvaluator
             }
         }
 
-        KOKKOS_FUNCTION double max_norm(int diff = 0) const
+        KOKKOS_FUNCTION ddc::Real max_norm(int diff = 0) const
         {
             return ddc::detail::ipow(s_2_pi * m_coef0, diff);
         }
 
     private:
-        KOKKOS_FUNCTION double eval(double const x, int const derivative) const noexcept
+        KOKKOS_FUNCTION ddc::Real eval(ddc::Real const x, int const derivative) const noexcept
         {
             return ddc::detail::ipow(s_2_pi * m_coef0, derivative)
                    * Kokkos::cos(s_pi_2 * derivative + s_2_pi * (m_coef0 * x + m_coef1));

--- a/tests/splines/evaluator_2d.hpp
+++ b/tests/splines/evaluator_2d.hpp
@@ -23,19 +23,19 @@ struct Evaluator2D
         {
         }
 
-        KOKKOS_FUNCTION double operator()(double const x, double const y) const noexcept
+        KOKKOS_FUNCTION ddc::Real operator()(ddc::Real const x, ddc::Real const y) const noexcept
         {
             return m_eval_func1(x) * m_eval_func2(y);
         }
 
         template <class DDim1, class DDim2>
-        KOKKOS_FUNCTION double operator()(ddc::Coordinate<DDim1, DDim2> const x) const noexcept
+        KOKKOS_FUNCTION ddc::Real operator()(ddc::Coordinate<DDim1, DDim2> const x) const noexcept
         {
             return m_eval_func1(ddc::get<DDim1>(x)) * m_eval_func2(ddc::get<DDim2>(x));
         }
 
         template <class DDim1, class DDim2>
-        void operator()(ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim1, DDim2>> chunk) const
+        void operator()(ddc::ChunkSpan<ddc::Real, ddc::DiscreteDomain<DDim1, DDim2>> chunk) const
         {
             ddc::DiscreteDomain<DDim1, DDim2> const domain = chunk.domain();
 
@@ -47,9 +47,9 @@ struct Evaluator2D
             }
         }
 
-        KOKKOS_FUNCTION double deriv(
-                double const x,
-                double const y,
+        KOKKOS_FUNCTION ddc::Real deriv(
+                ddc::Real const x,
+                ddc::Real const y,
                 int const derivative_x,
                 int const derivative_y) const noexcept
         {
@@ -57,7 +57,7 @@ struct Evaluator2D
         }
 
         template <class DDim1, class DDim2>
-        KOKKOS_FUNCTION double deriv(
+        KOKKOS_FUNCTION ddc::Real deriv(
                 ddc::Coordinate<DDim1, DDim2> const x,
                 int const derivative_x,
                 int const derivative_y) const noexcept
@@ -68,7 +68,7 @@ struct Evaluator2D
 
         template <class DDim1, class DDim2>
         void deriv(
-                ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim1, DDim2>> chunk,
+                ddc::ChunkSpan<ddc::Real, ddc::DiscreteDomain<DDim1, DDim2>> chunk,
                 int const derivative_x,
                 int const derivative_y) const
         {
@@ -82,7 +82,7 @@ struct Evaluator2D
             }
         }
 
-        KOKKOS_FUNCTION double max_norm(int diff1 = 0, int diff2 = 0) const
+        KOKKOS_FUNCTION ddc::Real max_norm(int diff1 = 0, int diff2 = 0) const
         {
             return m_eval_func1.max_norm(diff1) * m_eval_func2.max_norm(diff2);
         }

--- a/tests/splines/evaluator_3d.hpp
+++ b/tests/splines/evaluator_3d.hpp
@@ -25,14 +25,14 @@ struct Evaluator3D
         {
         }
 
-        KOKKOS_FUNCTION double operator()(double const x, double const y, double const z)
+        KOKKOS_FUNCTION ddc::Real operator()(ddc::Real const x, ddc::Real const y, ddc::Real const z)
                 const noexcept
         {
             return m_eval_func1(x) * m_eval_func2(y) * m_eval_func3(z);
         }
 
         template <class DDim1, class DDim2, class DDim3>
-        KOKKOS_FUNCTION double operator()(
+        KOKKOS_FUNCTION ddc::Real operator()(
                 ddc::Coordinate<DDim1, DDim2, DDim3> const x) const noexcept
         {
             return m_eval_func1(ddc::get<DDim1>(x)) * m_eval_func2(ddc::get<DDim2>(x))
@@ -41,7 +41,7 @@ struct Evaluator3D
 
         template <class DDim1, class DDim2, class DDim3>
         void operator()(
-                ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim1, DDim2, DDim3>> chunk) const
+                ddc::ChunkSpan<ddc::Real, ddc::DiscreteDomain<DDim1, DDim2, DDim3>> chunk) const
         {
             ddc::DiscreteDomain<DDim1, DDim2, DDim3> const domain = chunk.domain();
 
@@ -56,10 +56,10 @@ struct Evaluator3D
             }
         }
 
-        KOKKOS_FUNCTION double deriv(
-                double const x,
-                double const y,
-                double const z,
+        KOKKOS_FUNCTION ddc::Real deriv(
+                ddc::Real const x,
+                ddc::Real const y,
+                ddc::Real const z,
                 int const derivative_x,
                 int const derivative_y,
                 int const derivative_z) const noexcept
@@ -69,7 +69,7 @@ struct Evaluator3D
         }
 
         template <class DDim1, class DDim2, class DDim3>
-        KOKKOS_FUNCTION double deriv(
+        KOKKOS_FUNCTION ddc::Real deriv(
                 ddc::Coordinate<DDim1, DDim2, DDim3> const x,
                 int const derivative_x,
                 int const derivative_y,
@@ -82,7 +82,7 @@ struct Evaluator3D
 
         template <class DDim1, class DDim2, class DDim3>
         void deriv(
-                ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim1, DDim2, DDim3>> chunk,
+                ddc::ChunkSpan<ddc::Real, ddc::DiscreteDomain<DDim1, DDim2, DDim3>> chunk,
                 int const derivative_x,
                 int const derivative_y,
                 int const derivative_z) const
@@ -100,7 +100,7 @@ struct Evaluator3D
             }
         }
 
-        KOKKOS_FUNCTION double max_norm(int diff1 = 0, int diff2 = 0, int diff3 = 0) const
+        KOKKOS_FUNCTION ddc::Real max_norm(int diff1 = 0, int diff2 = 0, int diff3 = 0) const
         {
             return m_eval_func1.max_norm(diff1) * m_eval_func2.max_norm(diff2)
                    * m_eval_func3.max_norm(diff3);

--- a/tests/splines/evaluator_3d.hpp
+++ b/tests/splines/evaluator_3d.hpp
@@ -25,8 +25,10 @@ struct Evaluator3D
         {
         }
 
-        KOKKOS_FUNCTION ddc::Real operator()(ddc::Real const x, ddc::Real const y, ddc::Real const z)
-                const noexcept
+        KOKKOS_FUNCTION ddc::Real operator()(
+                ddc::Real const x,
+                ddc::Real const y,
+                ddc::Real const z) const noexcept
         {
             return m_eval_func1(x) * m_eval_func2(y) * m_eval_func3(z);
         }

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -316,7 +316,7 @@ void TestExtrapolationRuleSpline()
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
 #if defined(ER_NULL)

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -119,7 +119,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -198,14 +198,14 @@ void TestExtrapolationRuleSpline()
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator_type<DDimI1, DDimI2> const evaluator(dom_interpolation);
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -215,7 +215,7 @@ void TestExtrapolationRuleSpline()
             });
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -306,18 +306,18 @@ void TestExtrapolationRuleSpline()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
     spline_evaluator_batched(spline_eval, coords_eval.span_cview(), coef.span_cview());
 
     // Checking errors (we recover the initial values)
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
 #if defined(ER_NULL)
                 return Kokkos::abs(spline_eval(e));
@@ -327,9 +327,9 @@ void TestExtrapolationRuleSpline()
                         vals.template domain<DDimI1>()))::discrete_element_type const
                         e_without_interest(e);
 #    if defined(BC_PERIODIC)
-                double const tmp = vals(vals.template domain<DDimI1>().back(), e_without_interest);
+                ddc::Real const tmp = vals(vals.template domain<DDimI1>().back(), e_without_interest);
 #    else
-                double tmp;
+                ddc::Real tmp;
                 if (Coord<I2>(coords_eval(e)) > xn<I2>()) {
                     typename decltype(ddc::remove_dims_of(
                             vals.domain(),
@@ -344,9 +344,9 @@ void TestExtrapolationRuleSpline()
 #endif
             });
 
-    double const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm = evaluator.max_norm();
 
-    EXPECT_LE(max_norm_error, 1.0e-14 * max_norm);
+    EXPECT_LE(max_norm_error, static_cast<ddc::Real>(1.0e-14) * max_norm);
 }
 
 } // namespace anonymous_namespace_workaround_extrapolation_rule_cpp

--- a/tests/splines/extrapolation_rule.cpp
+++ b/tests/splines/extrapolation_rule.cpp
@@ -327,7 +327,8 @@ void TestExtrapolationRuleSpline()
                         vals.template domain<DDimI1>()))::discrete_element_type const
                         e_without_interest(e);
 #    if defined(BC_PERIODIC)
-                ddc::Real const tmp = vals(vals.template domain<DDimI1>().back(), e_without_interest);
+                ddc::Real const tmp
+                        = vals(vals.template domain<DDimI1>().back(), e_without_interest);
 #    else
                 ddc::Real tmp;
                 if (Coord<I2>(coords_eval(e)) > xn<I2>()) {

--- a/tests/splines/knots_as_interpolation_points.cpp
+++ b/tests/splines/knots_as_interpolation_points.cpp
@@ -148,7 +148,7 @@ TYPED_TEST(NonUniformBSplinesFixture, KnotsAsInterpolationPoints)
     CoordX const xmax(1.);
     std::size_t const ncells = 20;
     std::vector<CoordX> breaks(ncells + 1);
-    double const dx = (xmax - xmin) / ncells;
+    ddc::Real const dx = (xmax - xmin) / ncells;
     for (std::size_t i = 0; i < ncells + 1; ++i) {
         breaks[i] = xmin + i * dx;
     }

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -319,13 +319,17 @@ std::tuple<ddc::Real, ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs_lhs = derivs_mixed_lhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs_lhs = derivs_mixed_rhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs_rhs = derivs_mixed_lhs_rhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs_rhs = derivs_mixed_rhs_rhs_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -126,7 +126,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -163,7 +163,7 @@ template <
         typename Builder,
         typename Evaluator,
         typename... DDims>
-std::tuple<double, double, double, double> compute_evaluation_error(
+std::tuple<ddc::Real, ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
         ExecSpace const& exec_space,
         ddc::DiscreteDomain<DDims...> const& dom_vals,
         Builder const& spline_builder,
@@ -198,13 +198,13 @@ std::tuple<double, double, double, double> compute_evaluation_error(
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -215,12 +215,12 @@ std::tuple<double, double, double, double> compute_evaluation_error(
 
 #if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
-    ddc::Chunk derivs_1d_lhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_1d_lhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_1d_lhs = derivs_1d_lhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs_1d_lhs1_host_alloc(
                 ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_domain1, interpolation_domain2),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_1d_lhs1_host = derivs_1d_lhs1_host_alloc.span_view();
         ddc::host_for_each(
                 derivs_1d_lhs1_host.domain(),
@@ -241,12 +241,12 @@ std::tuple<double, double, double, double> compute_evaluation_error(
                 });
     }
 
-    ddc::Chunk derivs_1d_rhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_1d_rhs_alloc(dom_derivs_1d, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_1d_rhs = derivs_1d_rhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs_1d_rhs1_host_alloc(
                 ddc::DiscreteDomain<ddc::Deriv<I1>, DDimI2>(derivs_domain1, interpolation_domain2),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_1d_rhs1_host = derivs_1d_rhs1_host_alloc.span_view();
         ddc::host_for_each(
                 derivs_1d_rhs1_host.domain(),
@@ -267,12 +267,12 @@ std::tuple<double, double, double, double> compute_evaluation_error(
                 });
     }
 
-    ddc::Chunk derivs2_lhs_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs2_lhs_alloc(dom_derivs2, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs2_lhs = derivs2_lhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs2_lhs1_host_alloc(
                 ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs2_lhs1_host = derivs2_lhs1_host_alloc.span_view();
         ddc::host_for_each(
                 derivs2_lhs1_host.domain(),
@@ -293,12 +293,12 @@ std::tuple<double, double, double, double> compute_evaluation_error(
                 });
     }
 
-    ddc::Chunk derivs2_rhs_alloc(dom_derivs2, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs2_rhs_alloc(dom_derivs2, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs2_rhs = derivs2_rhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::Chunk derivs2_rhs1_host_alloc(
                 ddc::DiscreteDomain<DDimI1, ddc::Deriv<I2>>(interpolation_domain1, derivs_domain2),
-                ddc::HostAllocator<double>());
+                ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs2_rhs1_host = derivs2_rhs1_host_alloc.span_view();
         ddc::host_for_each(
                 derivs2_rhs1_host.domain(),
@@ -319,26 +319,26 @@ std::tuple<double, double, double, double> compute_evaluation_error(
                 });
     }
 
-    ddc::Chunk derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_mixed_lhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs_lhs = derivs_mixed_lhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_mixed_rhs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs_lhs = derivs_mixed_rhs_lhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_mixed_lhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_lhs_rhs = derivs_mixed_lhs_rhs_alloc.span_view();
-    ddc::Chunk derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_mixed_rhs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_mixed_rhs_rhs = derivs_mixed_rhs_rhs_alloc.span_view();
 
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_mixed_lhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs_lhs1_host
                 = derivs_mixed_lhs_lhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs_lhs1_host
                 = derivs_mixed_rhs_lhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_lhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_lhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_lhs_rhs1_host
                 = derivs_mixed_lhs_rhs1_host_alloc.span_view();
-        ddc::Chunk derivs_mixed_rhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_mixed_rhs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_mixed_rhs_rhs1_host
                 = derivs_mixed_rhs_rhs1_host_alloc.span_view();
 
@@ -382,7 +382,7 @@ std::tuple<double, double, double, double> compute_evaluation_error(
 #endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -414,13 +414,13 @@ std::tuple<double, double, double, double> compute_evaluation_error(
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
-    ddc::Chunk spline_eval_deriv1_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv1_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv1 = spline_eval_deriv1_alloc.span_view();
-    ddc::Chunk spline_eval_deriv2_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv2_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv2 = spline_eval_deriv2_alloc.span_view();
-    ddc::Chunk spline_eval_deriv12_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv12_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv12 = spline_eval_deriv12_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -442,39 +442,39 @@ std::tuple<double, double, double, double> compute_evaluation_error(
                    coef.span_cview());
 
     // Checking errors (we recover the initial values)
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
             });
-    double const max_norm_error_diff1 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff1 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 return Kokkos::abs(spline_eval_deriv1(e) - evaluator.deriv(x, y, 1, 0));
             });
-    double const max_norm_error_diff2 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff2 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv2.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
                 return Kokkos::abs(spline_eval_deriv2(e) - evaluator.deriv(x, y, 0, 1));
             });
-    double const max_norm_error_diff12 = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff12 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
                 Coord<I2> const y = ddc::coordinate(DElem<DDimI2>(e));
@@ -578,10 +578,10 @@ void TestMultipleBatchDomain2dSpline()
                     ExecSpace,
                     MemorySpace>(exec_space, dom_vals, spline_builder, spline_evaluator, evaluator);
 
-    double const max_norm = evaluator.max_norm();
-    double const max_norm_diff1 = evaluator.max_norm(1, 0);
-    double const max_norm_diff2 = evaluator.max_norm(0, 1);
-    double const max_norm_diff12 = evaluator.max_norm(1, 1);
+    ddc::Real const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm_diff1 = evaluator.max_norm(1, 0);
+    ddc::Real const max_norm_diff2 = evaluator.max_norm(0, 1);
+    ddc::Real const max_norm_diff12 = evaluator.max_norm(1, 1);
 
     SplineErrorBounds<evaluator_type<DDimI1, DDimI2>> const error_bounds(evaluator);
     EXPECT_LE(
@@ -589,7 +589,7 @@ void TestMultipleBatchDomain2dSpline()
             std::
                     max(error_bounds
                                 .error_bound(dx<I1>(ncells), dx<I2>(ncells), s_degree, s_degree),
-                        1.0e-14 * max_norm));
+                        static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff1,
             std::
@@ -598,7 +598,7 @@ void TestMultipleBatchDomain2dSpline()
                                 dx<I2>(ncells),
                                 s_degree,
                                 s_degree),
-                        1e-11 * max_norm_diff1));
+                        static_cast<ddc::Real>(1e-11) * max_norm_diff1));
     EXPECT_LE(
             max_norm_error_diff2,
             std::
@@ -607,7 +607,7 @@ void TestMultipleBatchDomain2dSpline()
                                 dx<I2>(ncells),
                                 s_degree,
                                 s_degree),
-                        1e-10 * max_norm_diff2));
+                        static_cast<ddc::Real>(1e-10) * max_norm_diff2));
     EXPECT_LE(
             max_norm_error_diff12,
             std::
@@ -616,7 +616,7 @@ void TestMultipleBatchDomain2dSpline()
                                 dx<I2>(ncells),
                                 s_degree,
                                 s_degree),
-                        1e-9 * max_norm_diff12));
+                        static_cast<ddc::Real>(1e-9) * max_norm_diff12));
 
     // Check the evaluation error for the domain with an additional batch dimension
     auto const
@@ -631,10 +631,10 @@ void TestMultipleBatchDomain2dSpline()
                     spline_evaluator,
                     evaluator);
 
-    double const max_norm_extra = evaluator.max_norm();
-    double const max_norm_diff1_extra = evaluator.max_norm(1, 0);
-    double const max_norm_diff2_extra = evaluator.max_norm(0, 1);
-    double const max_norm_diff12_extra = evaluator.max_norm(1, 1);
+    ddc::Real const max_norm_extra = evaluator.max_norm();
+    ddc::Real const max_norm_diff1_extra = evaluator.max_norm(1, 0);
+    ddc::Real const max_norm_diff2_extra = evaluator.max_norm(0, 1);
+    ddc::Real const max_norm_diff12_extra = evaluator.max_norm(1, 1);
 
     SplineErrorBounds<evaluator_type<DDimI1, DDimI2>> const error_bounds_extra(evaluator);
     EXPECT_LE(
@@ -642,7 +642,7 @@ void TestMultipleBatchDomain2dSpline()
             std::
                     max(error_bounds_extra
                                 .error_bound(dx<I1>(ncells), dx<I2>(ncells), s_degree, s_degree),
-                        1.0e-13 * max_norm_extra));
+                        static_cast<ddc::Real>(1.0e-13) * max_norm_extra));
     EXPECT_LE(
             max_norm_error_diff1_extra,
             std::
@@ -651,7 +651,7 @@ void TestMultipleBatchDomain2dSpline()
                                 dx<I2>(ncells),
                                 s_degree,
                                 s_degree),
-                        1e-11 * max_norm_diff1_extra));
+                        static_cast<ddc::Real>(1e-11) * max_norm_diff1_extra));
     EXPECT_LE(
             max_norm_error_diff2_extra,
             std::
@@ -660,7 +660,7 @@ void TestMultipleBatchDomain2dSpline()
                                 dx<I2>(ncells),
                                 s_degree,
                                 s_degree),
-                        1e-10 * max_norm_diff2_extra));
+                        static_cast<ddc::Real>(1e-10) * max_norm_diff2_extra));
     EXPECT_LE(
             max_norm_error_diff12_extra,
             std::
@@ -669,7 +669,7 @@ void TestMultipleBatchDomain2dSpline()
                                 dx<I2>(ncells),
                                 s_degree,
                                 s_degree),
-                        1e-9 * max_norm_diff12_extra));
+                        static_cast<ddc::Real>(1e-9) * max_norm_diff12_extra));
 }
 
 } // namespace anonymous_namespace_workaround_batched_2d_spline_builder_cpp

--- a/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_2d_spline_builder.cpp
@@ -449,7 +449,7 @@ std::tuple<ddc::Real, ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
@@ -457,7 +457,7 @@ std::tuple<ddc::Real, ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
     ddc::Real const max_norm_error_diff1 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -467,7 +467,7 @@ std::tuple<ddc::Real, ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
     ddc::Real const max_norm_error_diff2 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv2.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));
@@ -477,7 +477,7 @@ std::tuple<ddc::Real, ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
     ddc::Real const max_norm_error_diff12 = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv1.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I1> const x = ddc::coordinate(DElem<DDimI1>(e));

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -269,7 +269,7 @@ std::tuple<ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
@@ -278,7 +278,7 @@ std::tuple<ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
     ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I> const x = ddc::coordinate(DElem<DDimI>(e));
@@ -287,7 +287,7 @@ std::tuple<ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
     ddc::Real const max_norm_error_integ = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_integrals.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(
                     Builder::template batch_domain_type<

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -252,7 +252,8 @@ std::tuple<ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
     ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv = spline_eval_deriv_alloc.span_view();
-    ddc::Chunk spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
+    ddc::Chunk
+            spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_integrals = spline_eval_integrals_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -372,7 +373,9 @@ void TestMultipleBatchDomainSpline()
     SplineErrorBounds<evaluator_type<DDimI>> const error_bounds(evaluator);
     EXPECT_LE(
             max_norm_error,
-            std::max(error_bounds.error_bound(dx<I>(ncells), s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
+            std::
+                    max(error_bounds.error_bound(dx<I>(ncells), s_degree),
+                        static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff,
             std::

--- a/tests/splines/multiple_batch_domain_spline_builder.cpp
+++ b/tests/splines/multiple_batch_domain_spline_builder.cpp
@@ -109,7 +109,7 @@ KOKKOS_FUNCTION Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -145,7 +145,7 @@ template <
         class Builder,
         class Evaluator,
         typename... DDims>
-std::tuple<double, double, double> compute_evaluation_error(
+std::tuple<ddc::Real, ddc::Real, ddc::Real> compute_evaluation_error(
         ExecSpace const& exec_space,
         ddc::DiscreteDomain<DDims...> const& dom_vals,
         Builder const& spline_builder,
@@ -168,13 +168,13 @@ std::tuple<double, double, double> compute_evaluation_error(
     auto const dom_spline = spline_builder.batched_spline_domain(dom_vals);
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<double>());
+    ddc::Chunk vals_1d_host_alloc(dom_interpolation, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_1d_host = vals_1d_host_alloc.span_view();
     evaluator(vals_1d_host);
     auto vals_1d_alloc = ddc::create_mirror_view_and_copy(exec_space, vals_1d_host);
     ddc::ChunkSpan const vals_1d = vals_1d_alloc.span_view();
 
-    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk vals_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const vals = vals_alloc.span_view();
     ddc::parallel_for_each(
             exec_space,
@@ -183,10 +183,10 @@ std::tuple<double, double, double> compute_evaluation_error(
 
 #if defined(BC_HERMITE)
     // Allocate and fill a chunk containing derivs to be passed as input to spline_builder.
-    ddc::Chunk derivs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_lhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_lhs = derivs_lhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_lhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_lhs1_host = derivs_lhs1_host_alloc.span_view();
         for (ddc::DiscreteElement<ddc::Deriv<I>> const ii : derivs_domain) {
             derivs_lhs1_host(ii) = evaluator.deriv(x0<I>(), ii.uid());
@@ -201,10 +201,10 @@ std::tuple<double, double, double> compute_evaluation_error(
                 });
     }
 
-    ddc::Chunk derivs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk derivs_rhs_alloc(dom_derivs, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const derivs_rhs = derivs_rhs_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
-        ddc::Chunk derivs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<double>());
+        ddc::Chunk derivs_rhs1_host_alloc(derivs_domain, ddc::HostAllocator<ddc::Real>());
         ddc::ChunkSpan const derivs_rhs1_host = derivs_rhs1_host_alloc.span_view();
         for (ddc::DiscreteElement<ddc::Deriv<I>> const ii : derivs_domain) {
             derivs_rhs1_host(ii) = evaluator.deriv(xn<I>(), ii.uid());
@@ -222,7 +222,7 @@ std::tuple<double, double, double> compute_evaluation_error(
 #endif
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_spline, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -248,11 +248,11 @@ std::tuple<double, double, double> compute_evaluation_error(
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
-    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_deriv_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_deriv = spline_eval_deriv_alloc.span_view();
-    ddc::Chunk spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_integrals_alloc(dom_batch, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval_integrals = spline_eval_integrals_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
@@ -265,29 +265,29 @@ std::tuple<double, double, double> compute_evaluation_error(
     spline_evaluator.integrate(spline_eval_integrals, coef.span_cview());
 
     // Checking errors (we recover the initial values)
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 return Kokkos::abs(spline_eval(e) - vals(e));
             });
 
-    double const max_norm_error_diff = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_deriv.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDims...> const e) {
                 Coord<I> const x = ddc::coordinate(DElem<DDimI>(e));
                 return Kokkos::abs(spline_eval_deriv(e) - evaluator.deriv(x, 1));
             });
-    double const max_norm_error_integ = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_integ = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval_integrals.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(
                     Builder::template batch_domain_type<
                             ddc::DiscreteDomain<DDims...>>::discrete_element_type const e) {
@@ -365,24 +365,24 @@ void TestMultipleBatchDomainSpline()
                     spline_evaluator_batched,
                     evaluator);
 
-    double const max_norm = evaluator.max_norm();
-    double const max_norm_diff = evaluator.max_norm(1);
-    double const max_norm_int = evaluator.max_norm(-1);
+    ddc::Real const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm_diff = evaluator.max_norm(1);
+    ddc::Real const max_norm_int = evaluator.max_norm(-1);
 
     SplineErrorBounds<evaluator_type<DDimI>> const error_bounds(evaluator);
     EXPECT_LE(
             max_norm_error,
-            std::max(error_bounds.error_bound(dx<I>(ncells), s_degree), 1.0e-14 * max_norm));
+            std::max(error_bounds.error_bound(dx<I>(ncells), s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff,
             std::
                     max(error_bounds.error_bound_on_deriv(dx<I>(ncells), s_degree),
-                        1e-12 * max_norm_diff));
+                        static_cast<ddc::Real>(1e-12) * max_norm_diff));
     EXPECT_LE(
             max_norm_error_integ,
             std::
                     max(error_bounds.error_bound_on_int(dx<I>(ncells), s_degree),
-                        1.0e-14 * max_norm_int));
+                        static_cast<ddc::Real>(1.0e-14) * max_norm_int));
 
     // Check the evaluation error for the domain with an additional batch dimension
     auto const [max_norm_error_extra, max_norm_error_diff_extra, max_norm_error_integ_extra]
@@ -393,26 +393,26 @@ void TestMultipleBatchDomainSpline()
                     spline_evaluator_batched,
                     evaluator);
 
-    double const max_norm_extra = evaluator.max_norm();
-    double const max_norm_diff_extra = evaluator.max_norm(1);
-    double const max_norm_int_extra = evaluator.max_norm(-1);
+    ddc::Real const max_norm_extra = evaluator.max_norm();
+    ddc::Real const max_norm_diff_extra = evaluator.max_norm(1);
+    ddc::Real const max_norm_int_extra = evaluator.max_norm(-1);
 
     SplineErrorBounds<evaluator_type<DDimI>> const error_bounds_extra(evaluator);
     EXPECT_LE(
             max_norm_error_extra,
             std::
                     max(error_bounds_extra.error_bound(dx<I>(ncells), s_degree),
-                        1.0e-14 * max_norm_extra));
+                        static_cast<ddc::Real>(1.0e-14) * max_norm_extra));
     EXPECT_LE(
             max_norm_error_diff_extra,
             std::
                     max(error_bounds_extra.error_bound_on_deriv(dx<I>(ncells), s_degree),
-                        1e-12 * max_norm_diff_extra));
+                        static_cast<ddc::Real>(1e-12) * max_norm_diff_extra));
     EXPECT_LE(
             max_norm_error_integ_extra,
             std::
                     max(error_bounds_extra.error_bound_on_int(dx<I>(ncells), s_degree),
-                        1.0e-14 * max_norm_int_extra));
+                        static_cast<ddc::Real>(1.0e-14) * max_norm_int_extra));
 }
 
 

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -187,8 +187,9 @@ void TestNonPeriodicSplineBuilderTestIdentity()
             interpolation_domain,
             KOKKOS_LAMBDA(DElemX const ix) { coords_eval(ix) = ddc::coordinate(ix); });
 
-    ddc::Chunk
-            spline_eval_alloc(interpolation_domain, ddc::KokkosAllocator<ddc::Real, memory_space>());
+    ddc::Chunk spline_eval_alloc(
+            interpolation_domain,
+            ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const spline_eval(spline_eval_alloc.span_view());
     spline_evaluator(spline_eval.span_view(), coords_eval.span_cview(), coef.span_cview());
 
@@ -304,16 +305,24 @@ void TestNonPeriodicSplineBuilderTestIdentity()
         ddc::Real const h = (xN - x0) / ncells;
         EXPECT_LE(
                 max_norm_error,
-                std::max(error_bounds.error_bound(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
+                std::
+                        max(error_bounds.error_bound(h, s_degree),
+                            static_cast<ddc::Real>(1.0e-14) * max_norm));
         EXPECT_LE(
                 max_norm_error_diff,
-                std::max(error_bounds.error_bound_on_deriv(h, s_degree), static_cast<ddc::Real>(1e-12) * max_norm_diff));
+                std::
+                        max(error_bounds.error_bound_on_deriv(h, s_degree),
+                            static_cast<ddc::Real>(1e-12) * max_norm_diff));
         EXPECT_LE(
                 max_norm_error_integ,
-                std::max(error_bounds.error_bound_on_int(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm_int));
+                std::
+                        max(error_bounds.error_bound_on_int(h, s_degree),
+                            static_cast<ddc::Real>(1.0e-14) * max_norm_int));
         EXPECT_LE(
                 max_norm_error_quadrature_integ,
-                std::max(error_bounds.error_bound_on_int(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm_int));
+                std::
+                        max(error_bounds.error_bound_on_int(h, s_degree),
+                            static_cast<ddc::Real>(1.0e-14) * max_norm_int));
     }
 }
 

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -68,8 +68,8 @@ using evaluator_type = PolynomialEvaluator::Evaluator<DDimX, s_degree>;
 
 using DElemX = ddc::DiscreteElement<DDimX>;
 using DVectX = ddc::DiscreteVector<DDimX>;
-using SplineX = ddc::Chunk<double, ddc::DiscreteDomain<BSplinesX>>;
-using FieldX = ddc::Chunk<double, ddc::DiscreteDomain<DDimX>>;
+using SplineX = ddc::Chunk<ddc::Real, ddc::DiscreteDomain<BSplinesX>>;
+using FieldX = ddc::Chunk<ddc::Real, ddc::DiscreteDomain<DDimX>>;
 using CoordX = ddc::Coordinate<DimX>;
 
 // Checks that when evaluating the spline at interpolation points one
@@ -90,7 +90,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
         DVectX const npoints(ncells + 1);
         std::vector<CoordX> breaks(npoints);
-        double const dx = (xN - x0) / ncells;
+        ddc::Real const dx = (xN - x0) / ncells;
         for (int i(0); i < npoints; ++i) {
             breaks[i] = CoordX(x0 + i * dx);
         }
@@ -106,7 +106,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
 
     // 2. Create a Spline represented by a chunk over BSplines
     // The chunk is filled with garbage data, we need to initialize it
-    ddc::Chunk coef(dom_bsplines_x, ddc::KokkosAllocator<double, memory_space>());
+    ddc::Chunk coef(dom_bsplines_x, ddc::KokkosAllocator<ddc::Real, memory_space>());
 
     // 3. Create the interpolation domain
     ddc::init_discrete_space<DDimX>(GrevillePoints::get_sampling<DDimX>());
@@ -123,7 +123,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
             ddc::SplineSolver::GINKGO> const spline_builder(interpolation_domain);
 
     // 5. Allocate and fill a chunk over the interpolation domain
-    ddc::Chunk yvals_alloc(interpolation_domain, ddc::KokkosAllocator<double, memory_space>());
+    ddc::Chunk yvals_alloc(interpolation_domain, ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const yvals(yvals_alloc.span_view());
     evaluator_type const evaluator(interpolation_domain);
     ddc::parallel_for_each(
@@ -131,7 +131,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
             yvals.domain(),
             KOKKOS_LAMBDA(DElemX const ix) { yvals(ix) = evaluator(ddc::coordinate(ix)); });
 
-    ddc::Chunk derivs_lhs_alloc(derivs_domain, ddc::KokkosAllocator<double, memory_space>());
+    ddc::Chunk derivs_lhs_alloc(derivs_domain, ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const derivs_lhs = derivs_lhs_alloc.span_view();
     if (s_sbcl == ddc::SplineBuilderClosure::HERMITE) {
         ddc::parallel_for_each(
@@ -142,7 +142,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
                 });
     }
 
-    ddc::Chunk derivs_rhs_alloc(derivs_domain, ddc::KokkosAllocator<double, memory_space>());
+    ddc::Chunk derivs_rhs_alloc(derivs_domain, ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const derivs_rhs = derivs_rhs_alloc.span_view();
     if (s_sbcr == ddc::SplineBuilderClosure::HERMITE) {
         ddc::parallel_for_each(
@@ -188,13 +188,13 @@ void TestNonPeriodicSplineBuilderTestIdentity()
             KOKKOS_LAMBDA(DElemX const ix) { coords_eval(ix) = ddc::coordinate(ix); });
 
     ddc::Chunk
-            spline_eval_alloc(interpolation_domain, ddc::KokkosAllocator<double, memory_space>());
+            spline_eval_alloc(interpolation_domain, ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const spline_eval(spline_eval_alloc.span_view());
     spline_evaluator(spline_eval.span_view(), coords_eval.span_cview(), coef.span_cview());
 
     ddc::Chunk spline_eval_deriv_alloc(
             interpolation_domain,
-            ddc::KokkosAllocator<double, memory_space>());
+            ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const spline_eval_deriv(spline_eval_deriv_alloc.span_view());
     spline_evaluator
             .deriv(ddc::DiscreteElement<ddc::Deriv<DimX>>(1),
@@ -204,20 +204,20 @@ void TestNonPeriodicSplineBuilderTestIdentity()
 
     ddc::Chunk integral(
             spline_builder.batch_domain(interpolation_domain),
-            ddc::KokkosAllocator<double, memory_space>());
+            ddc::KokkosAllocator<ddc::Real, memory_space>());
     spline_evaluator.integrate(integral.span_view(), coef.span_cview());
 
     ddc::Chunk<
-            double,
+            ddc::Real,
             ddc::DiscreteDomain<ddc::Deriv<DDimX::continuous_dimension_type>>,
-            ddc::KokkosAllocator<double, memory_space>>
+            ddc::KokkosAllocator<ddc::Real, memory_space>>
             quadrature_coefficients_derivs_xmin_alloc;
-    ddc::Chunk<double, ddc::DiscreteDomain<DDimX>, ddc::KokkosAllocator<double, memory_space>>
+    ddc::Chunk<ddc::Real, ddc::DiscreteDomain<DDimX>, ddc::KokkosAllocator<ddc::Real, memory_space>>
             quadrature_coefficients_alloc;
     ddc::Chunk<
-            double,
+            ddc::Real,
             ddc::DiscreteDomain<ddc::Deriv<DDimX::continuous_dimension_type>>,
-            ddc::KokkosAllocator<double, memory_space>>
+            ddc::KokkosAllocator<ddc::Real, memory_space>>
             quadrature_coefficients_derivs_xmax_alloc;
     std::
             tie(quadrature_coefficients_derivs_xmin_alloc,
@@ -228,72 +228,72 @@ void TestNonPeriodicSplineBuilderTestIdentity()
 #if defined(SBCL_HERMITE)
     ddc::ChunkSpan const quadrature_coefficients_derivs_xmin(
             quadrature_coefficients_derivs_xmin_alloc.span_view());
-    double const quadrature_integral_derivs_xmin = ddc::parallel_transform_reduce(
+    ddc::Real const quadrature_integral_derivs_xmin = ddc::parallel_transform_reduce(
             execution_space(),
             quadrature_coefficients_derivs_xmin.domain(),
-            0.0,
-            ddc::reducer::sum<double>(),
+            ddc::Real(0.0),
+            ddc::reducer::sum<ddc::Real>(),
             KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<DimX>> const ix) {
                 return quadrature_coefficients_derivs_xmin(ix) * derivs_lhs(ix);
             });
 #else
-    double const quadrature_integral_derivs_xmin = 0.;
+    ddc::Real const quadrature_integral_derivs_xmin = 0.;
 #endif
-    double quadrature_integral = ddc::parallel_transform_reduce(
+    ddc::Real quadrature_integral = ddc::parallel_transform_reduce(
             execution_space(),
             quadrature_coefficients.domain(),
-            0.0,
-            ddc::reducer::sum<double>(),
+            ddc::Real(0.0),
+            ddc::reducer::sum<ddc::Real>(),
             KOKKOS_LAMBDA(ddc::DiscreteElement<DDimX> const ix) {
                 return quadrature_coefficients(ix) * yvals(ix);
             });
 #if defined(SBCR_HERMITE)
     ddc::ChunkSpan const quadrature_coefficients_derivs_xmax(
             quadrature_coefficients_derivs_xmax_alloc.span_view());
-    double const quadrature_integral_derivs_xmax = ddc::parallel_transform_reduce(
+    ddc::Real const quadrature_integral_derivs_xmax = ddc::parallel_transform_reduce(
             execution_space(),
             quadrature_coefficients_derivs_xmax.domain(),
-            0.0,
-            ddc::reducer::sum<double>(),
+            ddc::Real(0.0),
+            ddc::reducer::sum<ddc::Real>(),
             KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<DimX>> const ix) {
                 return quadrature_coefficients_derivs_xmax(ix) * derivs_rhs(ix);
             });
 #else
-    double const quadrature_integral_derivs_xmax = 0.;
+    ddc::Real const quadrature_integral_derivs_xmax = 0.;
 #endif
     quadrature_integral += quadrature_integral_derivs_xmin + quadrature_integral_derivs_xmax;
 
     // 8. Checking errors
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             execution_space(),
             interpolation_domain,
-            0.0,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.0),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) {
-                double const error = spline_eval(ix) - yvals(ix);
+                ddc::Real const error = spline_eval(ix) - yvals(ix);
                 return Kokkos::fabs(error);
             });
-    double const max_norm_error_diff = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             execution_space(),
             interpolation_domain,
-            0.0,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.0),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) {
                 CoordX const x = ddc::coordinate(ix);
-                double const error_deriv = spline_eval_deriv(ix) - evaluator.deriv(x, 1);
+                ddc::Real const error_deriv = spline_eval_deriv(ix) - evaluator.deriv(x, 1);
                 return Kokkos::fabs(error_deriv);
             });
 
     auto integral_host = ddc::create_mirror_view_and_copy(integral.span_view());
-    double const max_norm_error_integ = std::fabs(
+    ddc::Real const max_norm_error_integ = std::fabs(
             integral_host(ddc::DiscreteElement<>()) - evaluator.deriv(xN, -1)
             + evaluator.deriv(x0, -1));
-    double const max_norm_error_quadrature_integ
+    ddc::Real const max_norm_error_quadrature_integ
             = std::fabs(quadrature_integral - evaluator.deriv(xN, -1) + evaluator.deriv(x0, -1));
 
-    double const max_norm = evaluator.max_norm();
-    double const max_norm_diff = evaluator.max_norm(1);
-    double const max_norm_int = evaluator.max_norm(-1);
+    ddc::Real const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm_diff = evaluator.max_norm(1);
+    ddc::Real const max_norm_int = evaluator.max_norm(-1);
     if constexpr (std::is_same_v<evaluator_type, PolynomialEvaluator::Evaluator<DDimX, s_degree>>) {
         EXPECT_LE(max_norm_error / max_norm, 1.0e-14);
         EXPECT_LE(max_norm_error_diff / max_norm_diff, 1.0e-11);
@@ -301,19 +301,19 @@ void TestNonPeriodicSplineBuilderTestIdentity()
         EXPECT_LE(max_norm_error_quadrature_integ / max_norm_int, 1.0e-14);
     } else {
         SplineErrorBounds<evaluator_type> const error_bounds(evaluator);
-        double const h = (xN - x0) / ncells;
+        ddc::Real const h = (xN - x0) / ncells;
         EXPECT_LE(
                 max_norm_error,
-                std::max(error_bounds.error_bound(h, s_degree), 1.0e-14 * max_norm));
+                std::max(error_bounds.error_bound(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
         EXPECT_LE(
                 max_norm_error_diff,
-                std::max(error_bounds.error_bound_on_deriv(h, s_degree), 1e-12 * max_norm_diff));
+                std::max(error_bounds.error_bound_on_deriv(h, s_degree), static_cast<ddc::Real>(1e-12) * max_norm_diff));
         EXPECT_LE(
                 max_norm_error_integ,
-                std::max(error_bounds.error_bound_on_int(h, s_degree), 1.0e-14 * max_norm_int));
+                std::max(error_bounds.error_bound_on_int(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm_int));
         EXPECT_LE(
                 max_norm_error_quadrature_integ,
-                std::max(error_bounds.error_bound_on_int(h, s_degree), 1.0e-14 * max_norm_int));
+                std::max(error_bounds.error_bound_on_int(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm_int));
     }
 }
 

--- a/tests/splines/non_periodic_spline_builder.cpp
+++ b/tests/splines/non_periodic_spline_builder.cpp
@@ -232,7 +232,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
     ddc::Real const quadrature_integral_derivs_xmin = ddc::parallel_transform_reduce(
             execution_space(),
             quadrature_coefficients_derivs_xmin.domain(),
-            ddc::Real(0.0),
+            static_cast<ddc::Real>(0.0),
             ddc::reducer::sum<ddc::Real>(),
             KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<DimX>> const ix) {
                 return quadrature_coefficients_derivs_xmin(ix) * derivs_lhs(ix);
@@ -243,7 +243,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
     ddc::Real quadrature_integral = ddc::parallel_transform_reduce(
             execution_space(),
             quadrature_coefficients.domain(),
-            ddc::Real(0.0),
+            static_cast<ddc::Real>(0.0),
             ddc::reducer::sum<ddc::Real>(),
             KOKKOS_LAMBDA(ddc::DiscreteElement<DDimX> const ix) {
                 return quadrature_coefficients(ix) * yvals(ix);
@@ -254,7 +254,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
     ddc::Real const quadrature_integral_derivs_xmax = ddc::parallel_transform_reduce(
             execution_space(),
             quadrature_coefficients_derivs_xmax.domain(),
-            ddc::Real(0.0),
+            static_cast<ddc::Real>(0.0),
             ddc::reducer::sum<ddc::Real>(),
             KOKKOS_LAMBDA(ddc::DiscreteElement<ddc::Deriv<DimX>> const ix) {
                 return quadrature_coefficients_derivs_xmax(ix) * derivs_rhs(ix);
@@ -268,7 +268,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             execution_space(),
             interpolation_domain,
-            ddc::Real(0.0),
+            static_cast<ddc::Real>(0.0),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) {
                 ddc::Real const error = spline_eval(ix) - yvals(ix);
@@ -277,7 +277,7 @@ void TestNonPeriodicSplineBuilderTestIdentity()
     ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             execution_space(),
             interpolation_domain,
-            ddc::Real(0.0),
+            static_cast<ddc::Real>(0.0),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) {
                 CoordX const x = ddc::coordinate(ix);

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -70,7 +70,7 @@ void TestPeriodicSplineBuilderTestIdentity()
 #elif defined(BSPLINES_TYPE_NON_UNIFORM)
         DVectX const npoints(ncells + 1);
         std::vector<CoordX> breaks(npoints);
-        double const dx = (xN - x0) / ncells;
+        ddc::Real const dx = (xN - x0) / ncells;
         for (int i(0); i < npoints; ++i) {
             breaks[i] = CoordX(x0 + i * dx);
         }
@@ -82,7 +82,7 @@ void TestPeriodicSplineBuilderTestIdentity()
 
     // 2. Create a Spline represented by a chunk over BSplines
     // The chunk is filled with garbage data, we need to initialize it
-    ddc::Chunk coef(dom_bsplines_x, ddc::KokkosAllocator<double, memory_space>());
+    ddc::Chunk coef(dom_bsplines_x, ddc::KokkosAllocator<ddc::Real, memory_space>());
 
     // 3. Create the interpolation domain
     ddc::init_discrete_space<DDimX>(GrevillePoints::get_sampling<DDimX>());
@@ -99,7 +99,7 @@ void TestPeriodicSplineBuilderTestIdentity()
             ddc::SplineSolver::GINKGO> const spline_builder(interpolation_domain);
 
     // 5. Allocate and fill a chunk over the interpolation domain
-    ddc::Chunk yvals_alloc(interpolation_domain, ddc::KokkosAllocator<double, memory_space>());
+    ddc::Chunk yvals_alloc(interpolation_domain, ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const yvals(yvals_alloc.span_view());
     evaluator_type const evaluator(interpolation_domain);
     ddc::parallel_for_each(
@@ -130,13 +130,13 @@ void TestPeriodicSplineBuilderTestIdentity()
             KOKKOS_LAMBDA(DElemX const ix) { coords_eval(ix) = ddc::coordinate(ix); });
 
     ddc::Chunk
-            spline_eval_alloc(interpolation_domain, ddc::KokkosAllocator<double, memory_space>());
+            spline_eval_alloc(interpolation_domain, ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const spline_eval(spline_eval_alloc.span_view());
     spline_evaluator(spline_eval.span_view(), coords_eval.span_cview(), coef.span_cview());
 
     ddc::Chunk spline_eval_deriv_alloc(
             interpolation_domain,
-            ddc::KokkosAllocator<double, memory_space>());
+            ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const spline_eval_deriv(spline_eval_deriv_alloc.span_view());
     spline_evaluator
             .deriv(ddc::DiscreteElement<ddc::Deriv<DimX>>(1),
@@ -146,65 +146,65 @@ void TestPeriodicSplineBuilderTestIdentity()
 
     ddc::Chunk integral(
             spline_builder.batch_domain(interpolation_domain),
-            ddc::KokkosAllocator<double, memory_space>());
+            ddc::KokkosAllocator<ddc::Real, memory_space>());
     spline_evaluator.integrate(integral.span_view(), coef.span_cview());
 
-    ddc::Chunk<double, ddc::DiscreteDomain<DDimX>, ddc::KokkosAllocator<double, memory_space>>
+    ddc::Chunk<ddc::Real, ddc::DiscreteDomain<DDimX>, ddc::KokkosAllocator<ddc::Real, memory_space>>
             quadrature_coefficients_alloc;
     std::tie(std::ignore, quadrature_coefficients_alloc, std::ignore)
             = spline_builder.quadrature_coefficients();
     ddc::ChunkSpan const quadrature_coefficients = quadrature_coefficients_alloc.span_cview();
-    double const quadrature_integral = ddc::parallel_transform_reduce(
+    ddc::Real const quadrature_integral = ddc::parallel_transform_reduce(
             execution_space(),
             quadrature_coefficients.domain(),
-            0.0,
-            ddc::reducer::sum<double>(),
+            ddc::Real(0.0),
+            ddc::reducer::sum<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) { return quadrature_coefficients(ix) * yvals(ix); });
 
     // 8. Checking errors
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             execution_space(),
             interpolation_domain,
-            0.0,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.0),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) {
-                double const error = spline_eval(ix) - yvals(ix);
+                ddc::Real const error = spline_eval(ix) - yvals(ix);
                 return Kokkos::fabs(error);
             });
-    double const max_norm_error_diff = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             execution_space(),
             interpolation_domain,
-            0.0,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.0),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) {
                 CoordX const x = ddc::coordinate(ix);
-                double const error_deriv = spline_eval_deriv(ix) - evaluator.deriv(x, 1);
+                ddc::Real const error_deriv = spline_eval_deriv(ix) - evaluator.deriv(x, 1);
                 return Kokkos::fabs(error_deriv);
             });
 
     auto integral_host = ddc::create_mirror_view_and_copy(integral.span_view());
-    double const max_norm_error_integ = std::fabs(
+    ddc::Real const max_norm_error_integ = std::fabs(
             integral_host(ddc::DiscreteElement<>()) - evaluator.deriv(xN, -1)
             + evaluator.deriv(x0, -1));
-    double const max_norm_error_quadrature_integ
+    ddc::Real const max_norm_error_quadrature_integ
             = std::fabs(quadrature_integral - evaluator.deriv(xN, -1) + evaluator.deriv(x0, -1));
 
-    double const max_norm = evaluator.max_norm();
-    double const max_norm_diff = evaluator.max_norm(1);
-    double const max_norm_int = evaluator.max_norm(-1);
+    ddc::Real const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm_diff = evaluator.max_norm(1);
+    ddc::Real const max_norm_int = evaluator.max_norm(-1);
 
     SplineErrorBounds<evaluator_type> const error_bounds(evaluator);
-    double const h = (xN - x0) / ncells;
-    EXPECT_LE(max_norm_error, std::max(error_bounds.error_bound(h, s_degree), 1.0e-14 * max_norm));
+    ddc::Real const h = (xN - x0) / ncells;
+    EXPECT_LE(max_norm_error, std::max(error_bounds.error_bound(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff,
-            std::max(error_bounds.error_bound_on_deriv(h, s_degree), 1e-12 * max_norm_diff));
+            std::max(error_bounds.error_bound_on_deriv(h, s_degree), static_cast<ddc::Real>(1e-12) * max_norm_diff));
     EXPECT_LE(
             max_norm_error_integ,
-            std::max(error_bounds.error_bound_on_int(h, s_degree), 1.0e-14 * max_norm_int));
+            std::max(error_bounds.error_bound_on_int(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm_int));
     EXPECT_LE(
             max_norm_error_quadrature_integ,
-            std::max(error_bounds.error_bound_on_int(h, s_degree), 1.0e-14 * max_norm_int));
+            std::max(error_bounds.error_bound_on_int(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm_int));
 }
 
 TEST(PeriodicSplineBuilderTest, Identity)

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -157,7 +157,7 @@ void TestPeriodicSplineBuilderTestIdentity()
     ddc::Real const quadrature_integral = ddc::parallel_transform_reduce(
             execution_space(),
             quadrature_coefficients.domain(),
-            ddc::Real(0.0),
+            static_cast<ddc::Real>(0.0),
             ddc::reducer::sum<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) { return quadrature_coefficients(ix) * yvals(ix); });
 
@@ -165,7 +165,7 @@ void TestPeriodicSplineBuilderTestIdentity()
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             execution_space(),
             interpolation_domain,
-            ddc::Real(0.0),
+            static_cast<ddc::Real>(0.0),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) {
                 ddc::Real const error = spline_eval(ix) - yvals(ix);
@@ -174,7 +174,7 @@ void TestPeriodicSplineBuilderTestIdentity()
     ddc::Real const max_norm_error_diff = ddc::parallel_transform_reduce(
             execution_space(),
             interpolation_domain,
-            ddc::Real(0.0),
+            static_cast<ddc::Real>(0.0),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElemX const ix) {
                 CoordX const x = ddc::coordinate(ix);

--- a/tests/splines/periodic_spline_builder.cpp
+++ b/tests/splines/periodic_spline_builder.cpp
@@ -129,8 +129,9 @@ void TestPeriodicSplineBuilderTestIdentity()
             interpolation_domain,
             KOKKOS_LAMBDA(DElemX const ix) { coords_eval(ix) = ddc::coordinate(ix); });
 
-    ddc::Chunk
-            spline_eval_alloc(interpolation_domain, ddc::KokkosAllocator<ddc::Real, memory_space>());
+    ddc::Chunk spline_eval_alloc(
+            interpolation_domain,
+            ddc::KokkosAllocator<ddc::Real, memory_space>());
     ddc::ChunkSpan const spline_eval(spline_eval_alloc.span_view());
     spline_evaluator(spline_eval.span_view(), coords_eval.span_cview(), coef.span_cview());
 
@@ -195,16 +196,26 @@ void TestPeriodicSplineBuilderTestIdentity()
 
     SplineErrorBounds<evaluator_type> const error_bounds(evaluator);
     ddc::Real const h = (xN - x0) / ncells;
-    EXPECT_LE(max_norm_error, std::max(error_bounds.error_bound(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
+    EXPECT_LE(
+            max_norm_error,
+            std::
+                    max(error_bounds.error_bound(h, s_degree),
+                        static_cast<ddc::Real>(1.0e-14) * max_norm));
     EXPECT_LE(
             max_norm_error_diff,
-            std::max(error_bounds.error_bound_on_deriv(h, s_degree), static_cast<ddc::Real>(1e-12) * max_norm_diff));
+            std::
+                    max(error_bounds.error_bound_on_deriv(h, s_degree),
+                        static_cast<ddc::Real>(1e-12) * max_norm_diff));
     EXPECT_LE(
             max_norm_error_integ,
-            std::max(error_bounds.error_bound_on_int(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm_int));
+            std::
+                    max(error_bounds.error_bound_on_int(h, s_degree),
+                        static_cast<ddc::Real>(1.0e-14) * max_norm_int));
     EXPECT_LE(
             max_norm_error_quadrature_integ,
-            std::max(error_bounds.error_bound_on_int(h, s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm_int));
+            std::
+                    max(error_bounds.error_bound_on_int(h, s_degree),
+                        static_cast<ddc::Real>(1.0e-14) * max_norm_int));
 }
 
 TEST(PeriodicSplineBuilderTest, Identity)

--- a/tests/splines/periodic_spline_builder_ordered_points.cpp
+++ b/tests/splines/periodic_spline_builder_ordered_points.cpp
@@ -34,8 +34,8 @@ struct DDimX : GrevillePoints::interpolation_discrete_dimension_type
 
 using DElemX = ddc::DiscreteElement<DDimX>;
 using DVectX = ddc::DiscreteVector<DDimX>;
-using SplineX = ddc::Chunk<double, ddc::DiscreteDomain<BSplinesX>>;
-using FieldX = ddc::Chunk<double, ddc::DiscreteDomain<DDimX>>;
+using SplineX = ddc::Chunk<ddc::Real, ddc::DiscreteDomain<BSplinesX>>;
+using FieldX = ddc::Chunk<ddc::Real, ddc::DiscreteDomain<DDimX>>;
 using CoordX = ddc::Coordinate<DimX>;
 
 TEST(PeriodicSplineBuilderOrderTest, OrderedPoints)
@@ -44,7 +44,7 @@ TEST(PeriodicSplineBuilderOrderTest, OrderedPoints)
 
     // 1. Create BSplines
     int const npoints(ncells + 1);
-    std::vector<double> d_breaks({0, 0.01, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
+    std::vector<ddc::Real> d_breaks({0, 0.01, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0});
     std::vector<CoordX> breaks(npoints);
     for (std::size_t i(0); i < npoints; ++i) {
         breaks[i] = CoordX(d_breaks[i]);
@@ -55,8 +55,8 @@ TEST(PeriodicSplineBuilderOrderTest, OrderedPoints)
     ddc::init_discrete_space<DDimX>(GrevillePoints::get_sampling<DDimX>());
     ddc::DiscreteDomain<DDimX> const interpolation_domain(GrevillePoints::get_domain<DDimX>());
 
-    double last(ddc::coordinate(interpolation_domain.front()));
-    double current;
+    ddc::Real last(ddc::coordinate(interpolation_domain.front()));
+    ddc::Real current;
     for (DElemX const ix : interpolation_domain) {
         current = ddc::coordinate(ix);
         EXPECT_LE(current, ddc::discrete_space<BSplinesX>().rmax());

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -186,7 +186,7 @@ void TestPeriodicitySplineBuilder()
     ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            ddc::Real(0.),
+            static_cast<ddc::Real>(0.),
             ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDim<X>> const e) {
                 return Kokkos::abs(

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -81,7 +81,7 @@ Coord<X> xn()
 
 // Templated function giving step of the mesh in given dimension.
 template <typename X>
-double dx(std::size_t ncells)
+ddc::Real dx(std::size_t ncells)
 {
     return (xn<X>() - x0<X>()) / ncells;
 }
@@ -139,7 +139,7 @@ void TestPeriodicitySplineBuilder()
     ddc::DiscreteDomain<BSplines<X>> const dom_bsplines = spline_builder.spline_domain();
 
     // Allocate and fill a chunk containing values to be passed as input to spline_builder. Those are values of cosine along interest dimension duplicated along batch dimensions
-    ddc::Chunk vals_host_alloc(dom_vals, ddc::HostAllocator<double>());
+    ddc::Chunk vals_host_alloc(dom_vals, ddc::HostAllocator<ddc::Real>());
     ddc::ChunkSpan const vals_host = vals_host_alloc.span_view();
     evaluator_type<DDim<X>> const evaluator(dom_vals);
     evaluator(vals_host);
@@ -147,7 +147,7 @@ void TestPeriodicitySplineBuilder()
     ddc::ChunkSpan const vals = vals_alloc.span_view();
 
     // Instantiate chunk of spline coefs to receive output of spline_builder
-    ddc::Chunk coef_alloc(dom_bsplines, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk coef_alloc(dom_bsplines, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const coef = coef_alloc.span_view();
 
     // Finally compute the spline by filling `coef`
@@ -176,30 +176,30 @@ void TestPeriodicitySplineBuilder()
 
 
     // Instantiate chunks to receive outputs of spline_evaluator
-    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<double, MemorySpace>());
+    ddc::Chunk spline_eval_alloc(dom_vals, ddc::KokkosAllocator<ddc::Real, MemorySpace>());
     ddc::ChunkSpan const spline_eval = spline_eval_alloc.span_view();
 
     // Call spline_evaluator on the same mesh we started with
     spline_evaluator(spline_eval, coords_eval.span_cview(), coef.span_cview());
 
     // Checking errors (we recover the initial values)
-    double const max_norm_error = ddc::parallel_transform_reduce(
+    ddc::Real const max_norm_error = ddc::parallel_transform_reduce(
             exec_space,
             spline_eval.domain(),
-            0.,
-            ddc::reducer::max<double>(),
+            ddc::Real(0.),
+            ddc::reducer::max<ddc::Real>(),
             KOKKOS_LAMBDA(DElem<DDim<X>> const e) {
                 return Kokkos::abs(
                         spline_eval(e)
                         - (-vals(e))); // Because function is even, we get f_eval = -f
             });
 
-    double const max_norm = evaluator.max_norm();
+    ddc::Real const max_norm = evaluator.max_norm();
 
     SplineErrorBounds<evaluator_type<DDim<X>>> const error_bounds(evaluator);
     EXPECT_LE(
             max_norm_error,
-            std::max(error_bounds.error_bound(dx<X>(ncells), s_degree), 1.0e-14 * max_norm));
+            std::max(error_bounds.error_bound(dx<X>(ncells), s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
 }
 
 } // namespace anonymous_namespace_workaround_periodicity_spline_builder_cpp

--- a/tests/splines/periodicity_spline_builder.cpp
+++ b/tests/splines/periodicity_spline_builder.cpp
@@ -199,7 +199,9 @@ void TestPeriodicitySplineBuilder()
     SplineErrorBounds<evaluator_type<DDim<X>>> const error_bounds(evaluator);
     EXPECT_LE(
             max_norm_error,
-            std::max(error_bounds.error_bound(dx<X>(ncells), s_degree), static_cast<ddc::Real>(1.0e-14) * max_norm));
+            std::
+                    max(error_bounds.error_bound(dx<X>(ncells), s_degree),
+                        static_cast<ddc::Real>(1.0e-14) * max_norm));
 }
 
 } // namespace anonymous_namespace_workaround_periodicity_spline_builder_cpp

--- a/tests/splines/polynomial_evaluator.hpp
+++ b/tests/splines/polynomial_evaluator.hpp
@@ -22,9 +22,9 @@ struct PolynomialEvaluator
         using Dim = DDim;
 
     private:
-        std::array<double, Degree + 1> m_coeffs;
+        std::array<ddc::Real, Degree + 1> m_coeffs;
 
-        double m_xn;
+        ddc::Real m_xn;
 
     public:
         template <class Domain>
@@ -39,12 +39,12 @@ struct PolynomialEvaluator
             }
         }
 
-        KOKKOS_FUNCTION double operator()(double const x) const noexcept
+        KOKKOS_FUNCTION ddc::Real operator()(ddc::Real const x) const noexcept
         {
             return eval(x, 0);
         }
 
-        void operator()(ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>> chunk) const
+        void operator()(ddc::ChunkSpan<ddc::Real, ddc::DiscreteDomain<DDim>> chunk) const
         {
             ddc::DiscreteDomain<DDim> const domain = chunk.domain();
 
@@ -53,12 +53,12 @@ struct PolynomialEvaluator
             }
         }
 
-        KOKKOS_FUNCTION double deriv(double const x, int const derivative) const noexcept
+        KOKKOS_FUNCTION ddc::Real deriv(ddc::Real const x, int const derivative) const noexcept
         {
             return eval(x, derivative);
         }
 
-        void deriv(ddc::ChunkSpan<double, ddc::DiscreteDomain<DDim>> chunk, int const derivative)
+        void deriv(ddc::ChunkSpan<ddc::Real, ddc::DiscreteDomain<DDim>> chunk, int const derivative)
                 const
         {
             ddc::DiscreteDomain<DDim> const domain = chunk.domain();
@@ -68,27 +68,27 @@ struct PolynomialEvaluator
             }
         }
 
-        KOKKOS_FUNCTION double max_norm(int diff = 0) const
+        KOKKOS_FUNCTION ddc::Real max_norm(int diff = 0) const
         {
             return Kokkos::abs(deriv(m_xn, diff));
         }
 
     private:
-        KOKKOS_FUNCTION double eval(double const x, int const derivative) const
+        KOKKOS_FUNCTION ddc::Real eval(ddc::Real const x, int const derivative) const
         {
-            double result(0.0);
+            ddc::Real result(0.0);
             int const start = derivative < 0 ? 0 : derivative;
             for (int i(start); i < Degree + 1; ++i) {
-                double const v
-                        = double(falling_factorial(i, derivative)) * Kokkos::pow(x, i - derivative);
+                ddc::Real const v
+                        = ddc::Real(falling_factorial(i, derivative)) * Kokkos::pow(x, i - derivative);
                 result += m_coeffs[i] * v;
             }
             return result;
         }
 
-        KOKKOS_FUNCTION double falling_factorial(int i, int d) const
+        KOKKOS_FUNCTION ddc::Real falling_factorial(int i, int d) const
         {
-            double c = 1.0;
+            ddc::Real c = 1.0;
             if (d >= 0) {
                 for (int k(0); k < d; ++k) {
                     c *= (i - k);

--- a/tests/splines/polynomial_evaluator.hpp
+++ b/tests/splines/polynomial_evaluator.hpp
@@ -79,8 +79,8 @@ struct PolynomialEvaluator
             ddc::Real result(0.0);
             int const start = derivative < 0 ? 0 : derivative;
             for (int i(start); i < Degree + 1; ++i) {
-                ddc::Real const v = ddc::Real(falling_factorial(i, derivative))
-                                    * Kokkos::pow(x, i - derivative);
+                ddc::Real const v
+                        = falling_factorial(i, derivative) * Kokkos::pow(x, i - derivative);
                 result += m_coeffs[i] * v;
             }
             return result;

--- a/tests/splines/polynomial_evaluator.hpp
+++ b/tests/splines/polynomial_evaluator.hpp
@@ -79,8 +79,8 @@ struct PolynomialEvaluator
             ddc::Real result(0.0);
             int const start = derivative < 0 ? 0 : derivative;
             for (int i(start); i < Degree + 1; ++i) {
-                ddc::Real const v
-                        = ddc::Real(falling_factorial(i, derivative)) * Kokkos::pow(x, i - derivative);
+                ddc::Real const v = ddc::Real(falling_factorial(i, derivative))
+                                    * Kokkos::pow(x, i - derivative);
                 result += m_coeffs[i] * v;
             }
             return result;

--- a/tests/splines/spline_builder.cpp
+++ b/tests/splines/spline_builder.cpp
@@ -42,7 +42,7 @@ TEST(SplineBuilder, ShortInterpolationGrid)
     ddc::init_discrete_space<BSplinesX>(x0, xN, ncells);
 
     // One point missing
-    std::vector<double> const range {0.1, 0.3, 0.5, 0.7};
+    std::vector<ddc::Real> const range {0.1, 0.3, 0.5, 0.7};
 
     ddc::DiscreteDomain<DDimX> const interpolation_domain
             = ddc::init_discrete_space<DDimX>(DDimX::init<DDimX>(range));
@@ -68,7 +68,7 @@ TEST(SplineBuilder, LongInterpolationGrid)
     ddc::init_discrete_space<BSplinesX>(x0, xN, ncells);
 
     // One point too much
-    std::vector<double> const range {0.1, 0.3, 0.5, 0.7, 0.9, 0.95};
+    std::vector<ddc::Real> const range {0.1, 0.3, 0.5, 0.7, 0.9, 0.95};
 
     ddc::DiscreteDomain<DDimX> const interpolation_domain
             = ddc::init_discrete_space<DDimX>(DDimX::init<DDimX>(range));
@@ -94,7 +94,7 @@ TEST(SplineBuilder, BadShapeInterpolationGrid)
     ddc::init_discrete_space<BSplinesX>(x0, xN, ncells);
 
     // All points end up in the first cell ]0, 0.2[
-    std::vector<double> const range {0.1, 0.11, 0.12, 0.13, 0.14};
+    std::vector<ddc::Real> const range {0.1, 0.11, 0.12, 0.13, 0.14};
 
     ddc::DiscreteDomain<DDimX> const interpolation_domain
             = ddc::init_discrete_space<DDimX>(DDimX::init<DDimX>(range));
@@ -119,7 +119,7 @@ TEST(SplineBuilder, CorrectInterpolationGrid)
 
     ddc::init_discrete_space<BSplinesX>(x0, xN, ncells);
 
-    std::vector<double> const range {0.05, 0.15, 0.5, 0.85, 0.95};
+    std::vector<ddc::Real> const range {0.05, 0.15, 0.5, 0.85, 0.95};
 
     ddc::DiscreteDomain<DDimX> const interpolation_domain
             = ddc::init_discrete_space<DDimX>(DDimX::init<DDimX>(range));

--- a/tests/splines/spline_error_bounds.hpp
+++ b/tests/splines/spline_error_bounds.hpp
@@ -14,17 +14,18 @@ template <class Evaluator>
 class SplineErrorBounds
 {
 private:
-    static constexpr std::array<ddc::Real, 10> tikhomirov_error_bound_array = std::array<ddc::Real, 10>(
-            {static_cast<ddc::Real>(1.0 / 2.0),
-             static_cast<ddc::Real>(1.0 / 8.0),
-             static_cast<ddc::Real>(1.0 / 24.0),
-             static_cast<ddc::Real>(5.0 / 384.0),
-             static_cast<ddc::Real>(1.0 / 240.0),
-             static_cast<ddc::Real>(61.0 / 46080.0),
-             static_cast<ddc::Real>(17.0 / 40320.0),
-             static_cast<ddc::Real>(277.0 / 2064384.0),
-             static_cast<ddc::Real>(31.0 / 725760.0),
-             static_cast<ddc::Real>(50521.0 / 3715891200.0)});
+    static constexpr std::array<ddc::Real, 10> tikhomirov_error_bound_array
+            = std::array<ddc::Real, 10>(
+                    {static_cast<ddc::Real>(1.0 / 2.0),
+                     static_cast<ddc::Real>(1.0 / 8.0),
+                     static_cast<ddc::Real>(1.0 / 24.0),
+                     static_cast<ddc::Real>(5.0 / 384.0),
+                     static_cast<ddc::Real>(1.0 / 240.0),
+                     static_cast<ddc::Real>(61.0 / 46080.0),
+                     static_cast<ddc::Real>(17.0 / 40320.0),
+                     static_cast<ddc::Real>(277.0 / 2064384.0),
+                     static_cast<ddc::Real>(31.0 / 725760.0),
+                     static_cast<ddc::Real>(50521.0 / 3715891200.0)});
 
     Evaluator m_evaluator;
 
@@ -66,7 +67,8 @@ public:
         return tikhomirov_error_bound(cell_width, degree, m_evaluator.max_norm(degree + 1));
     }
 
-    ddc::Real error_bound(ddc::Real cell_width1, ddc::Real cell_width2, int degree1, int degree2) const
+    ddc::Real error_bound(ddc::Real cell_width1, ddc::Real cell_width2, int degree1, int degree2)
+            const
     {
         ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0);
         ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1);
@@ -95,8 +97,11 @@ public:
         return tikhomirov_error_bound(cell_width, degree - 1, m_evaluator.max_norm(degree + 1));
     }
 
-    ddc::Real error_bound_on_deriv_1(ddc::Real cell_width1, ddc::Real cell_width2, int degree1, int degree2)
-            const
+    ddc::Real error_bound_on_deriv_1(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            int degree1,
+            int degree2) const
     {
         ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0);
         ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1);
@@ -120,8 +125,11 @@ public:
                + tikhomirov_error_bound(cell_width3, degree3, norm3);
     }
 
-    ddc::Real error_bound_on_deriv_2(ddc::Real cell_width1, ddc::Real cell_width2, int degree1, int degree2)
-            const
+    ddc::Real error_bound_on_deriv_2(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            int degree1,
+            int degree2) const
     {
         ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0);
         ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1);
@@ -166,8 +174,11 @@ public:
      *       the correct asympthotic rate of convergence.
      *       The error constant may be overestimated.
      *******************************************************************************/
-    ddc::Real error_bound_on_deriv_12(ddc::Real cell_width1, ddc::Real cell_width2, int degree1, int degree2)
-            const
+    ddc::Real error_bound_on_deriv_12(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            int degree1,
+            int degree2) const
     {
         ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 1);
         ddc::Real const norm2 = m_evaluator.max_norm(1, degree2 + 1);

--- a/tests/splines/spline_error_bounds.hpp
+++ b/tests/splines/spline_error_bounds.hpp
@@ -14,17 +14,17 @@ template <class Evaluator>
 class SplineErrorBounds
 {
 private:
-    static constexpr std::array<double, 10> tikhomirov_error_bound_array = std::array<double, 10>(
-            {1.0 / 2.0,
-             1.0 / 8.0,
-             1.0 / 24.0,
-             5.0 / 384.0,
-             1.0 / 240.0,
-             61.0 / 46080.0,
-             17.0 / 40320.0,
-             277.0 / 2064384.0,
-             31.0 / 725760.0,
-             50521.0 / 3715891200.0});
+    static constexpr std::array<ddc::Real, 10> tikhomirov_error_bound_array = std::array<ddc::Real, 10>(
+            {static_cast<ddc::Real>(1.0 / 2.0),
+             static_cast<ddc::Real>(1.0 / 8.0),
+             static_cast<ddc::Real>(1.0 / 24.0),
+             static_cast<ddc::Real>(5.0 / 384.0),
+             static_cast<ddc::Real>(1.0 / 240.0),
+             static_cast<ddc::Real>(61.0 / 46080.0),
+             static_cast<ddc::Real>(17.0 / 40320.0),
+             static_cast<ddc::Real>(277.0 / 2064384.0),
+             static_cast<ddc::Real>(31.0 / 725760.0),
+             static_cast<ddc::Real>(50521.0 / 3715891200.0)});
 
     Evaluator m_evaluator;
 
@@ -40,7 +40,7 @@ private:
      * Also applicable to first derivative by passing deg-1 instead of deg
      * Volkov & Subbotin 2015, eq. 15
      *******************************************************************************/
-    static double tikhomirov_error_bound(double cell_width, int degree, double max_norm)
+    static ddc::Real tikhomirov_error_bound(ddc::Real cell_width, int degree, ddc::Real max_norm)
     {
         degree = std::min(degree, 9);
         return tikhomirov_error_bound_array[degree] * ddc::detail::ipow(cell_width, degree + 1)
@@ -49,7 +49,7 @@ private:
 
     /// @brief Computes the max norm on the ith component
     template <std::size_t N, std::size_t... Ints>
-    double max_norm(
+    ddc::Real max_norm(
             std::array<ddc::DiscreteElementType, N> const& orders,
             std::array<std::size_t, N> const& degrees,
             std::size_t i,
@@ -61,101 +61,101 @@ private:
 public:
     explicit SplineErrorBounds(Evaluator const& evaluator) : m_evaluator(evaluator) {}
 
-    double error_bound(double cell_width, int degree) const
+    ddc::Real error_bound(ddc::Real cell_width, int degree) const
     {
         return tikhomirov_error_bound(cell_width, degree, m_evaluator.max_norm(degree + 1));
     }
 
-    double error_bound(double cell_width1, double cell_width2, int degree1, int degree2) const
+    ddc::Real error_bound(ddc::Real cell_width1, ddc::Real cell_width2, int degree1, int degree2) const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 0);
-        double const norm2 = m_evaluator.max_norm(0, degree2 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0);
+        ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1);
         return tikhomirov_error_bound(cell_width1, degree1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2, norm2);
     }
 
-    double error_bound(
-            double cell_width1,
-            double cell_width2,
-            double cell_width3,
+    ddc::Real error_bound(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            ddc::Real cell_width3,
             int degree1,
             int degree2,
             int degree3) const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
-        double const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
-        double const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
+        ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
+        ddc::Real const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
         return tikhomirov_error_bound(cell_width1, degree1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2, norm2)
                + tikhomirov_error_bound(cell_width3, degree3, norm3);
     }
 
-    double error_bound_on_deriv(double cell_width, int degree) const
+    ddc::Real error_bound_on_deriv(ddc::Real cell_width, int degree) const
     {
         return tikhomirov_error_bound(cell_width, degree - 1, m_evaluator.max_norm(degree + 1));
     }
 
-    double error_bound_on_deriv_1(double cell_width1, double cell_width2, int degree1, int degree2)
+    ddc::Real error_bound_on_deriv_1(ddc::Real cell_width1, ddc::Real cell_width2, int degree1, int degree2)
             const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 0);
-        double const norm2 = m_evaluator.max_norm(0, degree2 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0);
+        ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1);
         return tikhomirov_error_bound(cell_width1, degree1 - 1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2, norm2);
     }
 
-    double error_bound_on_deriv_1(
-            double cell_width1,
-            double cell_width2,
-            double cell_width3,
+    ddc::Real error_bound_on_deriv_1(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            ddc::Real cell_width3,
             int degree1,
             int degree2,
             int degree3) const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
-        double const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
-        double const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
+        ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
+        ddc::Real const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
         return tikhomirov_error_bound(cell_width1, degree1 - 1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2, norm2)
                + tikhomirov_error_bound(cell_width3, degree3, norm3);
     }
 
-    double error_bound_on_deriv_2(double cell_width1, double cell_width2, int degree1, int degree2)
+    ddc::Real error_bound_on_deriv_2(ddc::Real cell_width1, ddc::Real cell_width2, int degree1, int degree2)
             const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 0);
-        double const norm2 = m_evaluator.max_norm(0, degree2 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0);
+        ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1);
         return tikhomirov_error_bound(cell_width1, degree1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2 - 1, norm2);
     }
 
-    double error_bound_on_deriv_2(
-            double cell_width1,
-            double cell_width2,
-            double cell_width3,
+    ddc::Real error_bound_on_deriv_2(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            ddc::Real cell_width3,
             int degree1,
             int degree2,
             int degree3) const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
-        double const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
-        double const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
+        ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
+        ddc::Real const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
         return tikhomirov_error_bound(cell_width1, degree1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2 - 1, norm2)
                + tikhomirov_error_bound(cell_width3, degree3, norm3);
     }
 
-    double error_bound_on_deriv_3(
-            double cell_width1,
-            double cell_width2,
-            double cell_width3,
+    ddc::Real error_bound_on_deriv_3(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            ddc::Real cell_width3,
             int degree1,
             int degree2,
             int degree3) const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
-        double const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
-        double const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
+        ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
+        ddc::Real const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
         return tikhomirov_error_bound(cell_width1, degree1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2, norm2)
                + tikhomirov_error_bound(cell_width3, degree3 - 1, norm3);
@@ -166,80 +166,80 @@ public:
      *       the correct asympthotic rate of convergence.
      *       The error constant may be overestimated.
      *******************************************************************************/
-    double error_bound_on_deriv_12(double cell_width1, double cell_width2, int degree1, int degree2)
+    ddc::Real error_bound_on_deriv_12(ddc::Real cell_width1, ddc::Real cell_width2, int degree1, int degree2)
             const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 1);
-        double const norm2 = m_evaluator.max_norm(1, degree2 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 1);
+        ddc::Real const norm2 = m_evaluator.max_norm(1, degree2 + 1);
         return tikhomirov_error_bound(cell_width1, degree1 - 1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2 - 1, norm2);
     }
 
-    double error_bound_on_deriv_12(
-            double cell_width1,
-            double cell_width2,
-            double cell_width3,
+    ddc::Real error_bound_on_deriv_12(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            ddc::Real cell_width3,
             int degree1,
             int degree2,
             int degree3) const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 1, 0);
-        double const norm2 = m_evaluator.max_norm(1, degree2 + 1, 0);
-        double const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 1, 0);
+        ddc::Real const norm2 = m_evaluator.max_norm(1, degree2 + 1, 0);
+        ddc::Real const norm3 = m_evaluator.max_norm(0, 0, degree3 + 1);
         return tikhomirov_error_bound(cell_width1, degree1 - 1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2 - 1, norm2)
                + tikhomirov_error_bound(cell_width3, degree3, norm3);
     }
 
-    double error_bound_on_deriv_23(
-            double cell_width1,
-            double cell_width2,
-            double cell_width3,
+    ddc::Real error_bound_on_deriv_23(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            ddc::Real cell_width3,
             int degree1,
             int degree2,
             int degree3) const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
-        double const norm2 = m_evaluator.max_norm(0, degree2 + 1, 1);
-        double const norm3 = m_evaluator.max_norm(0, 1, degree3 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 0);
+        ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1, 1);
+        ddc::Real const norm3 = m_evaluator.max_norm(0, 1, degree3 + 1);
         return tikhomirov_error_bound(cell_width1, degree1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2 - 1, norm2)
                + tikhomirov_error_bound(cell_width3, degree3 - 1, norm3);
     }
 
-    double error_bound_on_deriv_13(
-            double cell_width1,
-            double cell_width2,
-            double cell_width3,
+    ddc::Real error_bound_on_deriv_13(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            ddc::Real cell_width3,
             int degree1,
             int degree2,
             int degree3) const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 1);
-        double const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
-        double const norm3 = m_evaluator.max_norm(1, 0, degree3 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 0, 1);
+        ddc::Real const norm2 = m_evaluator.max_norm(0, degree2 + 1, 0);
+        ddc::Real const norm3 = m_evaluator.max_norm(1, 0, degree3 + 1);
         return tikhomirov_error_bound(cell_width1, degree1 - 1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2, norm2)
                + tikhomirov_error_bound(cell_width3, degree3 - 1, norm3);
     }
 
-    double error_bound_on_deriv_123(
-            double cell_width1,
-            double cell_width2,
-            double cell_width3,
+    ddc::Real error_bound_on_deriv_123(
+            ddc::Real cell_width1,
+            ddc::Real cell_width2,
+            ddc::Real cell_width3,
             int degree1,
             int degree2,
             int degree3) const
     {
-        double const norm1 = m_evaluator.max_norm(degree1 + 1, 1, 1);
-        double const norm2 = m_evaluator.max_norm(1, degree2 + 1, 1);
-        double const norm3 = m_evaluator.max_norm(1, 1, degree3 + 1);
+        ddc::Real const norm1 = m_evaluator.max_norm(degree1 + 1, 1, 1);
+        ddc::Real const norm2 = m_evaluator.max_norm(1, degree2 + 1, 1);
+        ddc::Real const norm3 = m_evaluator.max_norm(1, 1, degree3 + 1);
         return tikhomirov_error_bound(cell_width1, degree1 - 1, norm1)
                + tikhomirov_error_bound(cell_width2, degree2 - 1, norm2)
                + tikhomirov_error_bound(cell_width3, degree3 - 1, norm3);
     }
 
-    double error_bound_on_int(double cell_width, int degree) const
+    ddc::Real error_bound_on_int(ddc::Real cell_width, int degree) const
     {
         return tikhomirov_error_bound(cell_width, degree + 1, m_evaluator.max_norm(degree + 1));
     }
@@ -250,12 +250,12 @@ public:
      *******************************************************************************/
 
     template <std::size_t N>
-    double error_bound(
+    ddc::Real error_bound(
             std::array<ddc::DiscreteElementType, N> const& orders,
-            std::array<double, N> const& cell_width,
+            std::array<ddc::Real, N> const& cell_width,
             std::array<std::size_t, N> const& degrees) const
     {
-        double error = 0.;
+        ddc::Real error = 0.;
         for (std::size_t i = 0; i < N; i++) {
             error += tikhomirov_error_bound(
                     cell_width[i],

--- a/tests/splines/splines_linear_problem.cpp
+++ b/tests/splines/splines_linear_problem.cpp
@@ -51,16 +51,16 @@ void check_inverse(
                 matrix,
         ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS const& inv)
 {
-    double const TOL = 1e-10;
+    ddc::Real const TOL = 1e-10;
     std::size_t const N = matrix.extent(0);
 
     for (std::size_t i(0); i < N; ++i) {
         for (std::size_t j(0); j < N; ++j) {
-            double id_val = 0.0;
+            ddc::Real id_val = 0.0;
             for (std::size_t k(0); k < N; ++k) {
                 id_val += matrix(i, k) * inv(k, j);
             }
-            EXPECT_NEAR(id_val, static_cast<double>(i == j), TOL);
+            EXPECT_NEAR(id_val, static_cast<ddc::Real>(i == j), TOL);
         }
     }
 }
@@ -70,16 +70,16 @@ void check_inverse_transpose(
                 matrix,
         ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS const& inv)
 {
-    double const TOL = 1e-10;
+    ddc::Real const TOL = 1e-10;
     std::size_t const N = matrix.extent(0);
 
     for (std::size_t i(0); i < N; ++i) {
         for (std::size_t j(0); j < N; ++j) {
-            double id_val = 0.0;
+            ddc::Real id_val = 0.0;
             for (std::size_t k(0); k < N; ++k) {
                 id_val += matrix(i, k) * inv(j, k);
             }
-            EXPECT_NEAR(id_val, static_cast<double>(i == j), TOL);
+            EXPECT_NEAR(id_val, static_cast<ddc::Real>(i == j), TOL);
         }
     }
 }
@@ -89,7 +89,7 @@ void solve_and_validate(
 {
     std::size_t const N = splines_linear_problem.size();
 
-    std::vector<double> val_ptr(N * N);
+    std::vector<ddc::Real> val_ptr(N * N);
     ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS const
             val(val_ptr.data(), N, N);
 
@@ -97,7 +97,7 @@ void solve_and_validate(
 
     splines_linear_problem.setup_solver();
 
-    Kokkos::DualView<double*>
+    Kokkos::DualView<ddc::Real*>
             inv_ptr("inv_ptr", splines_linear_problem.required_number_of_rhs_rows() * N);
     ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS const
             inv(inv_ptr.view_host().data(),
@@ -115,7 +115,7 @@ void solve_and_validate(
     inv_ptr.modify_device();
     inv_ptr.sync_host();
 
-    Kokkos::DualView<double*>
+    Kokkos::DualView<ddc::Real*>
             inv_tr_ptr("inv_tr_ptr", splines_linear_problem.required_number_of_rhs_rows() * N);
     ddc::detail::SplinesLinearProblem<Kokkos::DefaultHostExecutionSpace>::MultiRHS const
             inv_tr(inv_tr_ptr.view_host().data(),

--- a/tests/splines/view.cpp
+++ b/tests/splines/view.cpp
@@ -10,18 +10,18 @@
 
 TEST(View1DTest, Constructor)
 {
-    std::array<double, 10> x = {0};
-    std::array<double const, 10> cx = {0};
-    std::array<double, 10> const ccx = {0};
-    std::array<double const, 10> const ccx2 = {0};
-    ddc::Span1D<double> const xv(x.data(), x.size());
-    [[maybe_unused]] ddc::Span1D<double> const xv_(xv);
-    [[maybe_unused]] ddc::Span1D<double const> const xcv(xv);
-    [[maybe_unused]] ddc::Span1D<double const> const xcv_(xcv);
-    ddc::Span1D<double const> const cxcv(cx.data(), cx.size());
-    [[maybe_unused]] ddc::Span1D<double const> const cxcv_(cxcv);
-    ddc::Span1D<double const> const ccxcv(ccx.data(), ccx.size());
-    [[maybe_unused]] ddc::Span1D<double const> const ccxcv_(cxcv);
-    ddc::Span1D<double const> const ccx2cv(ccx2.data(), ccx2.size());
-    [[maybe_unused]] ddc::Span1D<double const> const ccx2cv_(ccx2cv);
+    std::array<ddc::Real, 10> x = {0};
+    std::array<ddc::Real const, 10> cx = {0};
+    std::array<ddc::Real, 10> const ccx = {0};
+    std::array<ddc::Real const, 10> const ccx2 = {0};
+    ddc::Span1D<ddc::Real> const xv(x.data(), x.size());
+    [[maybe_unused]] ddc::Span1D<ddc::Real> const xv_(xv);
+    [[maybe_unused]] ddc::Span1D<ddc::Real const> const xcv(xv);
+    [[maybe_unused]] ddc::Span1D<ddc::Real const> const xcv_(xcv);
+    ddc::Span1D<ddc::Real const> const cxcv(cx.data(), cx.size());
+    [[maybe_unused]] ddc::Span1D<ddc::Real const> const cxcv_(cxcv);
+    ddc::Span1D<ddc::Real const> const ccxcv(ccx.data(), ccx.size());
+    [[maybe_unused]] ddc::Span1D<ddc::Real const> const ccxcv_(cxcv);
+    ddc::Span1D<ddc::Real const> const ccx2cv(ccx2.data(), ccx2.size());
+    [[maybe_unused]] ddc::Span1D<ddc::Real const> const ccx2cv_(ccx2cv);
 }


### PR DESCRIPTION
Allow different precisions for spline calculations splines. Fixes #999 

The tolerances used in the tests are chosen manually for double precision. They therefore do not pass currently when using single precision